### PR TITLE
[Integration] Run docker-build before

### DIFF
--- a/.moon/tasks.yml
+++ b/.moon/tasks.yml
@@ -7,3 +7,4 @@ tasks:
     options:
       internal: true
       runFromWorkspaceRoot: true
+      persistent: false


### PR DESCRIPTION
`local: true` sets `persistent: true` but that makes it run in parallel with `integration:test`. We need docker-build to run before `integration:test`


context: https://github.com/habitat-network/habitat/actions/runs/20511868500