### PR TITLE
[API] Fix typescript/api:generate

### DIFF
--- a/typescript/api/moon.yml
+++ b/typescript/api/moon.yml
@@ -1,4 +1,10 @@
 language: typescript
+
+fileGroups:
+  lexicons:
+    - /lexicons/**/*.json
+
+
 workspace:
   inheritedTasks:
     exclude:
@@ -7,11 +13,12 @@ workspace:
     - dev
 tasks:
   generate:
-    command: pnpx @atproto/lex-cli
+    command: pnpx 
     args:
+    - "@atproto/lex-cli"
     - gen-api
-    - .
-    - $workspaceRoot/lexicons/**/*.json
+    - $projectRoot
+    - "@files(lexicons)"
     outputs:
     - types/
     options:


### PR DESCRIPTION
broke after upgrading moon. Looks like moon passes the file glob with quotes which the lex-cli can't handle. Fixed by letting moon to enumerate the files and pass all of them to `lex-cli`