### PR TITLE
[GHPages] Restore hash routing

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           DOMAIN: ${{ vars.DOMAIN }}
           HABITAT_DOMAIN: ${{ vars.HABITAT_DOMAIN }}
+          HASH_ROUTING: true
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/frontend/moon.yml
+++ b/frontend/moon.yml
@@ -21,8 +21,6 @@ tasks:
     options:
       internal: false
   gh-pages:
-    env:
-      HASH_ROUTING: 'true'
     deps:
       - target: ~:build
       - target: calendar:build


### PR DESCRIPTION
thought the env would be inherited by all deps but moon doesn't do that. restore setting it in the github action config so it applies to all tasks (frontend + calendar builds)