### PR TITLE
[bugfix]: never cancel the context passed into identity cache, except on shutdown.

### DIFF
--- a/internal/authn/service_auth.go
+++ b/internal/authn/service_auth.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -50,7 +51,8 @@ func (p *pdsServiceAuthMethod) Validate(
 		utils.WriteHTTPError(w, err, http.StatusUnauthorized)
 		return "", false
 	}
-	id, err := p.directory.LookupDID(r.Context(), issuerDid)
+	// Use context.Background() to avoid cached context cancelled errors: https://github.com/bluesky-social/indigo/pull/1345
+	id, err := p.directory.LookupDID(context.Background(), issuerDid)
 	if err != nil {
 		utils.WriteHTTPError(w, err, http.StatusUnauthorized)
 		return "", false

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -47,7 +47,8 @@ var (
 
 // ServesDID implements Node.
 func (n *node) ServesDID(ctx context.Context, did syntax.DID) (bool, error) {
-	id, err := n.dir.LookupDID(ctx, did)
+	// Use context.Background() to avoid cached context cancelled errors: https://github.com/bluesky-social/indigo/pull/1345
+	id, err := n.dir.LookupDID(context.Background(), did)
 	if errors.Is(err, identity.ErrDIDNotFound) {
 		return false, nil
 	} else if err != nil {

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -3,6 +3,7 @@
 package oauthserver
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -283,7 +284,8 @@ func (o *OAuthServer) HandleCallback(
 	}
 
 	// Ensure that habitat serves this user
-	id, err := o.directory.LookupDID(ctx, arf.Did)
+	// Use context.Background() to avoid cached context cancelled errors: https://github.com/bluesky-social/indigo/pull/1345
+	id, err := o.directory.LookupDID(context.Background(), arf.Did)
 	if err != nil {
 		utils.LogAndHTTPError(w, err, "[oauth server: handle callback] failed to lookup did", http.StatusInternalServerError)
 		return

--- a/internal/pdsclient/client_factory.go
+++ b/internal/pdsclient/client_factory.go
@@ -41,7 +41,8 @@ func (f *clientFactoryImpl) NewClient(
 	ctx context.Context,
 	did syntax.DID,
 ) (HttpClient, error) {
-	id, err := f.dir.LookupDID(ctx, did)
+	// Use context.Background() to avoid cached context cancelled errors: https://github.com/bluesky-social/indigo/pull/1345
+	id, err := f.dir.LookupDID(context.Background(), did)
 	if err != nil {
 		return nil, fmt.Errorf("[pds client factory]: failed to lookup did: error is %w", err)
 	}

--- a/internal/xrpcchannel/xrpc_channel.go
+++ b/internal/xrpcchannel/xrpc_channel.go
@@ -45,7 +45,8 @@ func (m *serviceProxyXrpcChannel) SendXRPC(
 	receiver syntax.DID,
 	req *http.Request,
 ) (*http.Response, error) {
-	atid, err := m.directory.LookupDID(ctx, receiver)
+	// Use context.Background() to avoid cached context cancelled errors: https://github.com/bluesky-social/indigo/pull/1345
+	atid, err := m.directory.LookupDID(context.Background(), receiver)
 	if err != nil {
 		return nil, fmt.Errorf("[xrpc channel]: failed to lookup identity: %w", err)
 	}


### PR DESCRIPTION
Context errors are cached. We see this specifically during an OAuth flow, where the browser re-directs a number of times, and then on the redirect back to habitat, on page load, we fail to load because a context cancelled error is cached. This type of error should not be cached. I opened a PR in my fork of indigo to demonstrate the issue: https://github.com/bluesky-social/indigo/pull/1345.

Seems like these should never be cached, but I'm also wondering if we're doing something wrong in our flow that is causing this. This is a temporary workaround (I see this like 30 times a day, on each login, which I'm doing frequently for testing reasons); either we should stop this from happening or merge the fix in the upstream repo (maybe both?)