### PR TITLE
[API] Fix grantees schema

### DIFF
--- a/api/habitat/repo_listRecords.go
+++ b/api/habitat/repo_listRecords.go
@@ -20,6 +20,7 @@ type NetworkHabitatRepoListRecordsOutput struct {
 
 // NetworkHabitatRepoListRecordsRecord represents a record object
 type NetworkHabitatRepoListRecordsRecord struct {
+	Cid         string        `json:"cid"`
 	Permissions []interface{} `json:"permissions,omitempty"`
 	Uri         string        `json:"uri"`
 	Value       interface{}   `json:"value"`

--- a/lexicons/network/habitat/repo/listRecords.json
+++ b/lexicons/network/habitat/repo/listRecords.json
@@ -69,6 +69,7 @@
       "type": "object",
       "required": [
         "uri",
+        "cid",
         "value"
       ],
       "properties": {
@@ -76,6 +77,10 @@
           "type": "string",
           "format": "uri",
           "description": "URI reference to the record, formatted as a habitat-uri."
+        },
+        "cid": {
+          "type": "string",
+          "format": "cid"
         },
         "value": {
           "type": "unknown"

--- a/typescript/api/lexicons.ts
+++ b/typescript/api/lexicons.ts
@@ -1188,13 +1188,17 @@ export const schemaDict = {
       },
       record: {
         type: 'object',
-        required: ['uri', 'value'],
+        required: ['uri', 'cid', 'value'],
         properties: {
           uri: {
             type: 'string',
             format: 'uri',
             description:
               'URI reference to the record, formatted as a habitat-uri.',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
           },
           value: {
             type: 'unknown',

--- a/typescript/api/types/network/habitat/repo/listRecords.ts
+++ b/typescript/api/types/network/habitat/repo/listRecords.ts
@@ -55,6 +55,7 @@ export interface Record {
   $type?: 'network.habitat.repo.listRecords#record'
   /** URI reference to the record, formatted as a habitat-uri. */
   uri: string
+  cid: string
   value: { [_ in string]: unknown }
   permissions?: (
     | $Typed<NetworkHabitatGrantee.DidGrantee>


### PR DESCRIPTION
According to https://atproto.com/specs/lexicon

> The schema definitions pointed to by a union must have type object or record. All the variants must be represented by a CBOR map (or JSON Object) and must include a $type field indicating the variant type. A union can not point to types query, procedure, subscription, unknown, blob, cid-link, array, params, token, ref, union, or any other currently defined types.

We were already treating them like this in the code. the generated typescript types were wrong though