### PR TITLE
[oauth server]: remove habitat service stuff

### DIFF
--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -301,11 +301,7 @@ func setupOAuthServer(
 		log.Fatal().Err(err).Msgf("unable to setup oauth client")
 	}
 
-	serviceName := cmd.String(fServiceName)
-	serviceEndpoint := "https://" + domain
 	oauthServer, err := oauthserver.NewOAuthServer(
-		serviceName,
-		serviceEndpoint,
 		cmd.String(fOauthServerSecret),
 		oauthClient,
 		sessions.NewCookieStore([]byte("my super secret signing password")),

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -47,10 +47,6 @@ type authRequestFlash struct {
 // It handles OAuth authorization flows, token issuance, and integrates with DPoP
 // for proof-of-possession token binding.
 type OAuthServer struct {
-	// The habitat service name to look up in DID docs.
-	serviceName     string
-	serviceEndpoint string
-
 	provider     fosite.OAuth2Provider
 	credStore    pdscred.PDSCredentialStore // Database storage for OAuth sessions
 	sessionStore sessions.Store             // Session storage for authorization flow state
@@ -77,8 +73,6 @@ type OAuthServer struct {
 //
 // Returns a configured OAuthServer ready to handle authorization requests.
 func NewOAuthServer(
-	serviceName string,
-	serviceEndpoint string,
 	secret string,
 	oauthClient pdsclient.PdsOAuthClient,
 	sessionStore sessions.Store,
@@ -107,8 +101,6 @@ func NewOAuthServer(
 	gob.Register(&authRequestFlash{})
 	gob.Register(pdsclient.AuthorizeState{})
 	return &OAuthServer{
-		serviceName:     serviceName,
-		serviceEndpoint: serviceEndpoint,
 		provider: compose.Compose(
 			config,
 			storage,
@@ -283,25 +275,28 @@ func (o *OAuthServer) HandleCallback(
 		return
 	}
 
-	// Ensure that habitat serves this user
-	// Use context.Background() to avoid cached context cancelled errors: https://github.com/bluesky-social/indigo/pull/1345
-	id, err := o.directory.LookupDID(context.Background(), arf.Did)
-	if err != nil {
-		utils.LogAndHTTPError(w, err, "[oauth server: handle callback] failed to lookup did", http.StatusInternalServerError)
-		return
-	}
-
-	if endpoint, ok := id.Services[o.serviceName]; !ok || endpoint.URL != o.serviceEndpoint {
+	// TODO: we don't require people to be onboarded to the habitat service yet
+	/*
+		// Ensure that habitat serves this user
+		// Use context.Background() to avoid cached context cancelled errors: https://github.com/bluesky-social/indigo/pull/1345
+		id, err := o.directory.LookupDID(context.Background(), arf.Did)
 		if err != nil {
-			utils.LogAndHTTPError(
-				w,
-				err,
-				"user's habitat service in DID doc does not match expected service",
-				http.StatusInternalServerError,
-			)
+			utils.LogAndHTTPError(w, err, "[oauth server: handle callback] failed to lookup did", http.StatusInternalServerError)
 			return
 		}
-	}
+
+		if endpoint, ok := id.Services[o.serviceName]; !ok || endpoint.URL != o.serviceEndpoint {
+			if err != nil {
+				utils.LogAndHTTPError(
+					w,
+					err,
+					"user's habitat service in DID doc does not match expected service",
+					http.StatusInternalServerError,
+				)
+				return
+			}
+		}
+	*/
 
 	resp, err := o.provider.NewAuthorizeResponse(
 		ctx,

--- a/internal/oauthserver/oauth_server_test.go
+++ b/internal/oauthserver/oauth_server_test.go
@@ -27,7 +27,7 @@ import (
 func TestOAuthServerErrorPaths(t *testing.T) {
 	t.Run("NewOAuthServer rejects invalid secret", func(t *testing.T) {
 		_, err := NewOAuthServer(
-			"name", "endpoint", "not-valid-base64!!!",
+			"not-valid-base64!!!",
 			nil, nil, nil, nil, nil,
 		)
 		require.Error(t, err)
@@ -44,8 +44,6 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 	secret, err := encrypt.GenerateKey()
 	require.NoError(t, err)
 	oauthSrv, err := NewOAuthServer(
-		"testServiceName",
-		"testServiceEndpoint",
 		secret,
 		oauthClient,
 		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
@@ -182,7 +180,7 @@ func TestHandleCallbackDIDDocError(t *testing.T) {
 	require.NoError(t, err)
 
 	oauthSrv, err := NewOAuthServer(
-		"testServiceName", "testServiceEndpoint", secret,
+		secret,
 		oauthClient,
 		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 		&errLookupDIDDirectory{pdsclient.NewDummyDirectory("http://pds.url")},
@@ -252,8 +250,7 @@ func TestOAuthServerE2E(t *testing.T) {
 	require.NoError(t, err, "failed to generate secret")
 
 	oauthServer, err := NewOAuthServer(
-		"testServiceName",
-		"testServiceEndpoint",
+
 		secret,
 		oauthClient,
 		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),


### PR DESCRIPTION
Commenting this out for now because we don't require people to be onboarded.
Drive by change as I was going to add metrics.