### PR TITLE
[permissions]: remove collection-level grants

### DIFF
--- a/internal/clique/clique.go
+++ b/internal/clique/clique.go
@@ -29,6 +29,7 @@ type cliqueMember struct {
 type Store interface {
 	CreateClique(owner syntax.DID, members []syntax.DID) (habitat_syntax.Clique, error)
 	GetMembers(clique habitat_syntax.Clique) ([]syntax.DID, error)
+	GetCliquesForMember(member syntax.DID) ([]habitat_syntax.Clique, error)
 	AddMembers(clique habitat_syntax.Clique, members []syntax.DID) error
 	RemoveMembers(clique habitat_syntax.Clique, members []syntax.DID) error
 	IsMember(clique habitat_syntax.Clique, maybeMember syntax.DID) (bool, error)
@@ -126,6 +127,18 @@ func (s *store) AddMembers(clique habitat_syntax.Clique, members []syntax.DID) e
 		// If that passes, try creating the clique members (no-op if exists already)
 		return tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&cliqueMembers).Error
 	})
+}
+
+func (s *store) GetCliquesForMember(member syntax.DID) ([]habitat_syntax.Clique, error) {
+	var rows []cliqueMember
+	err := s.db.Model(cliqueMember{}).Where("member = ?", member).Distinct("owner", "key").Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return xslices.Map(rows, func(m cliqueMember) habitat_syntax.Clique {
+		return habitat_syntax.ConstructClique(syntax.DID(m.Owner), m.Key)
+	}), nil
 }
 
 // IsMember returns true if maybeMember is in the clique identified by (owner, key).

--- a/internal/clique/clique_test.go
+++ b/internal/clique/clique_test.go
@@ -125,3 +125,46 @@ func TestIsMember_False(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, isMember)
 }
+
+func TestGetCliquesForMember(t *testing.T) {
+	s := newTestStore(t)
+
+	clique1, err := s.CreateClique(owner, []syntax.DID{alice, bob})
+	require.NoError(t, err)
+
+	clique2, err := s.CreateClique(owner, []syntax.DID{alice})
+	require.NoError(t, err)
+
+	// bob is only in clique1
+	cliques, err := s.GetCliquesForMember(bob)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []habitat_syntax.Clique{clique1}, cliques)
+
+	// alice is in both cliques
+	cliques, err = s.GetCliquesForMember(alice)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []habitat_syntax.Clique{clique1, clique2}, cliques)
+}
+
+func TestGetCliquesForMemberEmtpy(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.CreateClique(owner, []syntax.DID{alice})
+	require.NoError(t, err)
+
+	cliques, err := s.GetCliquesForMember(bob)
+	require.NoError(t, err)
+	require.Empty(t, cliques)
+}
+
+func TestGetCliquesForMemberOwner(t *testing.T) {
+	s := newTestStore(t)
+
+	clique, err := s.CreateClique(owner, []syntax.DID{})
+	require.NoError(t, err)
+
+	// owner is always a member of their own cliques
+	cliques, err := s.GetCliquesForMember(owner)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []habitat_syntax.Clique{clique}, cliques)
+}

--- a/internal/pear/pear.go
+++ b/internal/pear/pear.go
@@ -373,19 +373,31 @@ func (p *pear) listRecordsLocal(
 		return nil, fmt.Errorf("only support filtering by a collection")
 	}
 
+	fmt.Println("listrecordslocal", collection, caller, subjects)
 	// Resolve grants for both the caller and the clique
 	perms, err := p.permissions.ListGranteePermissions(ctx, caller, collection, subjects)
 	if err != nil {
 		return nil, err
 	}
 
-	records, err := p.repo.ListRecords(ctx, perms)
+	// Exclude caller's own records from the permission-based query — those are fetched
+	// separately below, and a caller may have granted their own records to a clique they belong to.
+	otherPerms := xslices.Filter(perms, func(p permissions.Permission) bool {
+		return p.Owner != caller
+	})
+
+	permissioned, err := p.repo.ListRecordsFromPermissions(ctx, otherPerms)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list records: %w", err)
+		return nil, fmt.Errorf("failed to list permissioned records: %w", err)
+	}
+
+	owned, err := p.repo.ListRecords(ctx, caller.String(), collection.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list own records: %w", err)
 	}
 
 	// TODO: consider checking hasPermission here for each record to detect if we ever return inconsistent state
-	return records, nil
+	return append(permissioned, owned...), nil
 }
 
 /*

--- a/internal/pear/pear.go
+++ b/internal/pear/pear.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"slices"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -374,7 +373,8 @@ func (p *pear) listRecordsLocal(
 		return nil, fmt.Errorf("only support filtering by a collection")
 	}
 
-	perms, err := p.permissions.ResolvePermissionsForCollection(ctx, caller, collection, subjects)
+	// Resolve grants for both the caller and the clique
+	perms, err := p.permissions.ListGranteePermissions(ctx, caller, collection, subjects)
 	if err != nil {
 		return nil, err
 	}
@@ -450,9 +450,6 @@ func (p *pear) ListCollections(ctx context.Context, caller syntax.DID, subject s
 			return nil, err
 		}
 
-		perms = slices.DeleteFunc(perms, func(p permissions.Permission) bool {
-			return p.Effect == permissions.Deny
-		})
 		grantees := xslices.Map(perms, func(p permissions.Permission) permissions.Grantee {
 			return p.Grantee
 		})

--- a/internal/pear/pear.go
+++ b/internal/pear/pear.go
@@ -374,7 +374,6 @@ func (p *pear) listRecordsLocal(
 		return nil, fmt.Errorf("only support filtering by a collection")
 	}
 
-	fmt.Println("listrecordslocal", collection, caller, subjects)
 	// Resolve grants for both the caller and the clique
 	perms, err := p.permissions.ListGranteePermissions(ctx, caller, collection, subjects)
 	if err != nil {

--- a/internal/pear/pear.go
+++ b/internal/pear/pear.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -382,7 +383,7 @@ func (p *pear) listRecordsLocal(
 
 	// Exclude caller's own records from the permission-based query — those are fetched
 	// separately below, and a caller may have granted their own records to a clique they belong to.
-	otherPerms := xslices.Filter(perms, func(p permissions.Permission) bool {
+	otherPerms := slices.DeleteFunc(perms, func(p permissions.Permission) bool {
 		return p.Owner != caller
 	})
 

--- a/internal/pear/pear.go
+++ b/internal/pear/pear.go
@@ -383,7 +383,7 @@ func (p *pear) listRecordsLocal(
 	// Exclude caller's own records from the permission-based query — those are fetched
 	// separately below, and a caller may have granted their own records to a clique they belong to.
 	otherPerms := slices.DeleteFunc(perms, func(p permissions.Permission) bool {
-		return p.Owner != caller
+		return p.Owner == caller
 	})
 
 	permissioned, err := p.repo.ListRecordsFromPermissions(ctx, otherPerms)

--- a/internal/pear/pear_authz_test.go
+++ b/internal/pear/pear_authz_test.go
@@ -163,36 +163,6 @@ func TestRemovePermissions(t *testing.T) {
 		require.Nil(t, got)
 		require.ErrorIs(t, err, habitat_err.ErrUnauthorized)
 	})
-
-	t.Run("owner can remove collection-level permission, revoking access to all records in that collection", func(t *testing.T) {
-		coll2 := syntax.NSID("my.second.collection")
-		rkey2a := syntax.RecordKey("rkey2a")
-		rkey2b := syntax.RecordKey("rkey2b")
-		_, err := p.PutRecord(t.Context(), ownerDID, ownerDID, coll2, map[string]any{"k": "v"}, rkey2a, &validate, []permissions.Grantee{})
-		require.NoError(t, err)
-		_, err = p.PutRecord(t.Context(), ownerDID, ownerDID, coll2, map[string]any{"k": "v"}, rkey2b, &validate, []permissions.Grantee{})
-		require.NoError(t, err)
-
-		// Grant collection-level access (empty rkey)
-		require.NoError(t, p.AddPermissions(ownerDID, []permissions.Grantee{permissions.DIDGrantee(granteeDID)}, ownerDID, coll2, ""))
-
-		// Confirm access before revocation
-		got, err := p.GetRecord(t.Context(), coll2, rkey2a, ownerDID, granteeDID)
-		require.NoError(t, err)
-		require.NotNil(t, got)
-
-		// Remove collection-level permission
-		require.NoError(t, p.RemovePermissions(ownerDID, []permissions.Grantee{permissions.DIDGrantee(granteeDID)}, ownerDID, coll2, ""))
-
-		// Grantee no longer has access to any record in the collection
-		got, err = p.GetRecord(t.Context(), coll2, rkey2a, ownerDID, granteeDID)
-		require.Nil(t, got)
-		require.ErrorIs(t, err, habitat_err.ErrUnauthorized)
-
-		got, err = p.GetRecord(t.Context(), coll2, rkey2b, ownerDID, granteeDID)
-		require.Nil(t, got)
-		require.ErrorIs(t, err, habitat_err.ErrUnauthorized)
-	})
 }
 
 // TestListPermissionGrants tests the ListPermissionGrants pear method's authz logic.

--- a/internal/pear/pear_test.go
+++ b/internal/pear/pear_test.go
@@ -139,7 +139,7 @@ func TestControllerPrivateDataPutGet(t *testing.T) {
 	require.ErrorIs(t, habitat_err.ErrUnauthorized, err)
 
 	// Grant permission
-	require.NoError(t, p.permissions.AddPermissions([]permissions.Grantee{permissions.DIDGrantee("did:example:anotherid")}, syntax.DID("did:example:myid"), coll, ""))
+	require.NoError(t, p.permissions.AddPermissions([]permissions.Grantee{permissions.DIDGrantee("did:example:anotherid")}, syntax.DID("did:example:myid"), coll, rkey))
 
 	// Now non-owner can access
 	got, err = p.GetRecord(t.Context(), coll, rkey, syntax.DID("did:example:myid"), syntax.DID("did:example:anotherid"))
@@ -202,30 +202,6 @@ func TestListRecords(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Empty(t, records)
-	})
-
-	t.Run("returns records with full collection permission", func(t *testing.T) {
-		require.NoError(
-			t,
-			p.permissions.AddPermissions(
-				[]permissions.Grantee{permissions.DIDGrantee("did:example:readerid")},
-				syntax.DID("did:example:myid"),
-				coll1,
-				"",
-			),
-		)
-
-		records, err := p.ListRecords(
-			t.Context(),
-			syntax.DID("did:example:readerid"),
-			coll1,
-			nil,
-		)
-		require.NoError(t, err)
-		// did:example:readerid has permission to see all did:example:myid's records in coll1
-		require.Len(t, records, 2)
-		require.Equal(t, "did:example:myid", records[0].Did)
-		require.Equal(t, "did:example:myid", records[1].Did)
 	})
 
 	t.Run("returns only specific permitted record", func(t *testing.T) {
@@ -580,7 +556,6 @@ func TestListRecordsWithPermissions(t *testing.T) {
 	aliceDID := syntax.DID("did:plc:alice")
 	bobDID := syntax.DID("did:plc:bob")
 	carolDID := syntax.DID("did:plc:carol")
-	remoteDID := syntax.DID("did:plc:remote")
 
 	// Create a shared database for the test
 	db, err := gorm.Open(sqlite.Open(":memory:"))
@@ -623,7 +598,8 @@ func TestListRecordsWithPermissions(t *testing.T) {
 
 	t.Run("includes records from other users when user has permission", func(t *testing.T) {
 		// Grant Alice permission to read Bob's records
-		require.NoError(t, perms.AddPermissions([]permissions.Grantee{permissions.DIDGrantee(syntax.DID(aliceDID))}, syntax.DID(bobDID), coll, ""))
+		require.NoError(t, perms.AddPermissions([]permissions.Grantee{permissions.DIDGrantee(syntax.DID(aliceDID))}, syntax.DID(bobDID), coll, "bob-rkey1"))
+		require.NoError(t, perms.AddPermissions([]permissions.Grantee{permissions.DIDGrantee(syntax.DID(aliceDID))}, syntax.DID(bobDID), coll, "bob-rkey2"))
 
 		records, err := p.ListRecords(
 			t.Context(),
@@ -674,25 +650,11 @@ func TestListRecordsWithPermissions(t *testing.T) {
 		}
 	})
 
-	t.Run("includes records from different nodes if they exist in database", func(t *testing.T) {
-		// Grant Alice permission to read remote user's records
-		require.NoError(t, perms.AddPermissions([]permissions.Grantee{permissions.DIDGrantee(syntax.DID(aliceDID))}, syntax.DID(remoteDID), coll, ""))
-
-		records, err := p.ListRecords(
-			t.Context(),
-			syntax.DID(aliceDID),
-			coll,
-			nil,
-		)
-		require.NoError(t, err)
-		require.Len(t, records, 4)
-	})
-
 	t.Run("filters by collection", func(t *testing.T) {
 		otherColl := syntax.NSID("other.collection")
 		_, err := p.PutRecord(t.Context(), syntax.DID(bobDID), syntax.DID(bobDID), otherColl, val, "bob-other-rkey", &validate, []permissions.Grantee{})
 		require.NoError(t, err)
-		require.NoError(t, perms.AddPermissions([]permissions.Grantee{permissions.DIDGrantee(syntax.DID(aliceDID))}, syntax.DID(bobDID), otherColl, ""))
+		require.NoError(t, perms.AddPermissions([]permissions.Grantee{permissions.DIDGrantee(syntax.DID(aliceDID))}, syntax.DID(bobDID), otherColl, "bob-other-rkey"))
 
 		// Query for original collection
 		records, err := p.ListRecords(
@@ -716,42 +678,6 @@ func TestListRecordsWithPermissions(t *testing.T) {
 		require.Len(t, records, 1)
 		require.Equal(t, bobDID.String(), records[0].Did)
 		require.Equal(t, "bob-other-rkey", records[0].Rkey)
-	})
-
-	t.Run("returns only specific permitted records", func(t *testing.T) {
-		// Remove full collection permission first, then grant only specific permission
-		require.NoError(t, perms.RemovePermissions([]permissions.Grantee{permissions.DIDGrantee(syntax.DID(aliceDID))}, syntax.DID(bobDID), coll, ""))
-		require.NoError(
-			t,
-			perms.AddPermissions([]permissions.Grantee{permissions.DIDGrantee(syntax.DID(aliceDID))}, syntax.DID(bobDID), coll, "bob-rkey1"),
-		)
-
-		records, err := p.ListRecords(
-			t.Context(),
-			syntax.DID(aliceDID),
-			coll,
-			nil,
-		)
-		require.NoError(t, err)
-		// Should have at least 2 from Alice + 1 specific from Bob (may include remote if it exists)
-		require.GreaterOrEqual(t, len(records), 3)
-
-		// Verify we have the right records from Bob
-		bobRkey1Found := false
-		for _, record := range records {
-			if record.Did == bobDID.String() && record.Rkey == "bob-rkey1" {
-				bobRkey1Found = true
-			}
-			if record.Did == bobDID.String() {
-				require.Equal(
-					t,
-					"bob-rkey1",
-					record.Rkey,
-					"Should only have bob-rkey1, not bob-rkey2",
-				)
-			}
-		}
-		require.True(t, bobRkey1Found, "Should have found bob-rkey1")
 	})
 }
 

--- a/internal/permissions/store.go
+++ b/internal/permissions/store.go
@@ -110,8 +110,6 @@ func NewStore(db *gorm.DB, cliqueStore clique.Store) (*store, error) {
 	if db.Migrator().HasColumn(&permission{}, "effect") {
 		if err := db.Migrator().DropColumn(&permission{}, "effect"); err != nil {
 			return nil, fmt.Errorf("failed to drop effect column: %w", err)
-		} else {
-			fmt.Println("dropped effect column")
 		}
 	}
 
@@ -271,7 +269,7 @@ func (s *store) RemovePermissions(
 // Returns all permissions which have the given grantee for records part of collection and owned by owners
 func (s *store) ListGranteePermissions(ctx context.Context, grantee syntax.DID, collection syntax.NSID, owners []syntax.DID) ([]Permission, error) {
 	// Direct permission grants
-	direct, err := s.listPermissions([]Grantee{DIDGrantee(grantee)}, owners, collection, "*")
+	direct, err := s.listPermissions([]Grantee{DIDGrantee(grantee)}, owners, collection, "")
 	if err != nil {
 		return nil, err
 	}
@@ -286,12 +284,16 @@ func (s *store) ListGranteePermissions(ctx context.Context, grantee syntax.DID, 
 		return Grantee(c)
 	})
 
-	indirect, err := s.listPermissions(cliqueGrantees, owners, collection, "*")
-	if err != nil {
-		return nil, err
+	var indirect []Permission
+	if len(cliqueGrantees) > 0 {
+		indirect, err = s.listPermissions(cliqueGrantees, owners, collection, "")
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return append(direct, indirect...), nil
+	perms := append(direct, indirect...)
+	return perms, nil
 }
 
 // ListPermissionGrants implements Store.
@@ -338,8 +340,7 @@ func (s *store) listPermissions(
 		query = query.Where("collection = ?", collection)
 	}
 	if rkey != "" {
-		// permissions with empty rkeys grant the entire collection
-		query = query.Where("rkey = ? OR rkey = ''", rkey)
+		query = query.Where("rkey = ?", rkey)
 	}
 
 	if err := query.Find(&queried).Error; err != nil {

--- a/internal/permissions/store.go
+++ b/internal/permissions/store.go
@@ -116,12 +116,10 @@ func NewStore(db *gorm.DB, cliqueStore clique.Store) (*store, error) {
 	}
 
 	// Delete collection-level grants (rkey = "") — these are unsupported
-	/*
-		err = db.Where("rkey = ?", "").Delete(&permission{}).Error
-		if err != nil {
-			return nil, fmt.Errorf("failed to delete collection-level permissions: %w", err)
-		}
-	*/
+	err = db.Where("rkey = ?", "").Delete(&permission{}).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete collection-level permissions: %w", err)
+	}
 
 	return &store{db: db, cliqueStore: cliqueStore}, nil
 }

--- a/internal/permissions/store.go
+++ b/internal/permissions/store.go
@@ -2,12 +2,12 @@ package permissions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
-	"github.com/bradenaw/juniper/xmaps"
 	"github.com/bradenaw/juniper/xslices"
 	"github.com/habitat-network/habitat/internal/clique"
 	"gorm.io/gorm"
@@ -37,7 +37,7 @@ type Store interface {
 		collection syntax.NSID,
 		rkey syntax.RecordKey,
 	) error
-	ResolvePermissionsForCollection(
+	ListGranteePermissions(
 		ctx context.Context,
 		grantee syntax.DID,
 		collection syntax.NSID,
@@ -72,20 +72,12 @@ type store struct {
 
 var _ Store = (*store)(nil)
 
-type Effect string
-
-const (
-	Allow Effect = "allow"
-	Deny  Effect = "deny"
-)
-
 // Public — exported for use elsewhere, typed with Grantee interface
 type Permission struct {
 	Grantee    Grantee
 	Owner      syntax.DID
 	Collection syntax.NSID
 	Rkey       syntax.RecordKey
-	Effect     Effect
 }
 
 // Permission represents a permission entry in the database. this type defines the Gorm DB model of permissions, not what is exported to other packages.
@@ -94,10 +86,13 @@ type permission struct {
 	Owner      string `gorm:"primaryKey"`
 	Collection string `gorm:"primaryKey"`
 	Rkey       string `gorm:"primaryKey"`
-	Effect     string `gorm:"not null;check:effect IN ('allow', 'deny')"`
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }
+
+var (
+	ErrCollectionLevelNotSupported = errors.New("collection-level permissions are not supported")
+)
 
 // NewStore creates a new db-backed permission store.
 // The store manages permissions at different granularities:
@@ -110,6 +105,23 @@ func NewStore(db *gorm.DB, cliqueStore clique.Store) (*store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to migrate permissions table: %w", err)
 	}
+
+	// Drop the effect column if it still exists
+	if db.Migrator().HasColumn(&permission{}, "effect") {
+		if err := db.Migrator().DropColumn(&permission{}, "effect"); err != nil {
+			return nil, fmt.Errorf("failed to drop effect column: %w", err)
+		} else {
+			fmt.Println("dropped effect column")
+		}
+	}
+
+	// Delete collection-level grants (rkey = "") — these are unsupported
+	/*
+		err = db.Where("rkey = ?", "").Delete(&permission{}).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to delete collection-level permissions: %w", err)
+		}
+	*/
 
 	return &store{db: db, cliqueStore: cliqueStore}, nil
 }
@@ -127,13 +139,28 @@ func (s *store) HasPermission(
 		return true, nil
 	}
 
-	permissions, err := s.listPermissions(requester, []syntax.DID{owner}, collection, rkey)
+	if rkey == "" {
+		return false, ErrCollectionLevelNotSupported
+	}
+
+	// TODO: this query shouldn't use listPermissions
+	var permissions []permission
+	err := s.db.
+		Where("grantee = ? OR grantee LIKE ?", requester.String(), "clique:%"). // check for the habitat uri prefix for cliques
+		Where("owner = ?", owner).
+		Where("collection = ?", collection).
+		Where("rkey = ?", rkey).
+		Find(&permissions).Error
 	if err != nil {
 		return false, err
 	}
 
 	for _, permission := range permissions {
-		switch grantee := permission.Grantee.(type) {
+		parsed, err := ParseGranteeFromString(permission.Grantee)
+		if err != nil {
+			return false, fmt.Errorf("parsing grantee from db: %s: %w", parsed, err)
+		}
+		switch grantee := parsed.(type) {
 		case DIDGrantee:
 			// Direct grants to this DID can immediately resolve this request.
 			if grantee.String() != requester.String() {
@@ -141,12 +168,8 @@ func (s *store) HasPermission(
 				// We need to log / measure this
 				return false, fmt.Errorf("invalid permisssion returned from ListPermissions")
 			}
-			// Explicit allow or deny for this DID resolves the request
-			if permission.Effect == Allow {
-				return true, nil
-			} else {
-				return false, nil
-			}
+			// Found a match, return
+			return true, nil
 		case habitat_syntax.Clique:
 			ok, err := s.cliqueStore.IsMember(grantee, requester)
 			if err != nil {
@@ -166,10 +189,6 @@ func (s *store) HasPermission(
 }
 
 // AddPermissions grants read permission for an entire collection or specific record.
-// If rkey is empty, it grants read permission for the whole collection.
-// Will delete redundant permissions that are covered by the new grant.
-// Will not add redundant permssions that are less powerful than existing ones
-// Will not error in cases where no work is done
 func (s *store) AddPermissions(
 	granteesTyped []Grantee,
 	owner syntax.DID,
@@ -180,63 +199,47 @@ func (s *store) AddPermissions(
 		return fmt.Errorf("collection is required")
 	}
 
+	if rkey == "" {
+		return ErrCollectionLevelNotSupported
+	}
+
 	grantees := xslices.Map(granteesTyped, func(g Grantee) string {
 		return g.String()
 	})
 
-	var existingCollectionPermissions []permission
-	if rkey == "" { /* collection-level permission */
-		// delete redundant allow permissions that are less powerful
-		result := s.db.Where("grantee IN ?", grantees).
-			Where("owner = ?", owner).
-			Where("rkey != ''").
-			Where("effect = 'allow'").
-			Delete(&permission{})
-		if result.Error != nil {
-			return fmt.Errorf("failed to remove redundant allow permissions: %w", result.Error)
-		}
-	} else { /* record-level permission */
-		// check if there are existing grantess with collection-level permissions.
-		// if so, we shouldn't add new ones for those grantees
-		if err := s.db.Where("grantee IN ?", grantees).
-			Where("owner = ?", owner).
-			Where("collection = ?", collection).
-			Where("rkey = ''").Find(&existingCollectionPermissions).Error; err != nil {
-			return fmt.Errorf("failed to query existing collection permissions: %w", err)
-		}
-	}
-	if len(existingCollectionPermissions) == len(grantees) {
-		// all grantess already have collection-level permissions so don't do anything
-		return nil
-	}
-
-	existingCollectionGrantees := xmaps.Set[string]{}
-	for _, perm := range existingCollectionPermissions {
-		existingCollectionGrantees.Add(perm.Grantee)
-	}
-	// only add permissions for those that don't already have access
-	granteesSet := xmaps.Difference(xmaps.SetFromSlice(grantees), existingCollectionGrantees)
-	permissions := []permission{}
-	for grantee := range granteesSet {
-		permissions = append(permissions, permission{
-			Grantee:    grantee,
-			Owner:      owner.String(),
-			Effect:     string(Allow),
-			Collection: collection.String(),
-			Rkey:       rkey.String(),
-		})
-	}
-
 	// Delete any existing permission for this record before inserting the deny.
 	// This is jank and its because SQLITE/postgres differ in the ON CONFLICT specs. We should fix this.
 	return s.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("grantee IN ?", grantees).
+		var existing []string
+		err := tx.Model(&permission{}).
+			Where("grantee IN ?", grantees).
 			Where("owner = ?", owner).
 			Where("collection = ?", collection).
 			Where("rkey = ?", rkey).
-			Delete(&permission{}).Error; err != nil {
-			return fmt.Errorf("failed to clear existing permissions before deny insert: %w", err)
+			Pluck("grantee", &existing).Error
+		if err != nil {
+			return fmt.Errorf("error querying existing grantees: %w", err)
 		}
+
+		newGrantees := slices.DeleteFunc(grantees, func(g string) bool {
+			return slices.Contains(existing, g)
+		})
+
+		if len(newGrantees) == 0 {
+			// Nothing to do
+			return nil
+		}
+
+		permissions := make([]permission, len(newGrantees))
+		for i, grantee := range newGrantees {
+			permissions[i] = permission{
+				Grantee:    grantee,
+				Owner:      owner.String(),
+				Collection: collection.String(),
+				Rkey:       rkey.String(),
+			}
+		}
+
 		if err := tx.Create(&permissions).Error; err != nil {
 			return fmt.Errorf("failed to add lexicon permission: %w", err)
 		}
@@ -244,11 +247,7 @@ func (s *store) AddPermissions(
 	})
 }
 
-// RemovePermissions removes read permission for an entire collection or specific record.
-// If rkey is empty, it revokes read permission for the whole collection.
-// If the user already has access to the collection, it will add a deny permission for rkey.
-// Otherwise will delete the specific permission if it exists.
-// Will not error if there are no permissions to remove.
+// RemovePermissions removes read permission for a specific record and the given grantees.
 func (s *store) RemovePermissions(
 	granteesTyped []Grantee,
 	owner syntax.DID,
@@ -258,114 +257,48 @@ func (s *store) RemovePermissions(
 	grantees := xslices.Map(granteesTyped, func(g Grantee) string {
 		return g.String()
 	})
-	// If the removal is on an entire collection, delete all allow permissions for records in the collection or the entire collection.
+
 	if rkey == "" {
-		// delete all permissions for this collection
-		result := s.db.Where("grantee IN ?", grantees).
-			Where("owner = ?", owner).
-			Where("collection = ?", collection).
-			Delete(&permission{})
-		if result.Error != nil {
-			return fmt.Errorf("failed to remove collection permission: %w", result.Error)
-		}
-		return nil
+		return ErrCollectionLevelNotSupported
 	}
 
-	// Otherwise, the removal is on a specific record key.
-	return s.db.Transaction(func(tx *gorm.DB) error {
-
-		// Delete any existing allows on this record.
-		err := tx.Where("grantee IN ?", grantees).
-			Where("owner = ?", owner).
-			Where("collection = ?", collection).
-			Where("rkey = ?", rkey).
-			Where("effect = ?", Allow).
-			Delete(&permission{}).Error
-		if err != nil {
-			return fmt.Errorf("failed to remove allow permission: %w", err)
-		}
-
-		// For any grantees that have permissions to the whole collection, add a deny
-		var denyGrantees []string
-		err = tx.Model(&permission{}).
-			Where("grantee IN ?", grantees).
-			Where("owner = ?", owner).
-			Where("collection = ?", collection).
-			Where("rkey = ''").
-			Where("effect = ?", Allow).
-			Pluck("grantee", &denyGrantees).
-			Error
-		if err != nil {
-			return fmt.Errorf("failed to identify collection-level permissions: %w", err)
-		}
-
-		if len(denyGrantees) == 0 {
-			return nil
-		}
-
-		// Only need to add a deny row for people with collection-level permissions
-		recordPerms := make([]*permission, len(grantees))
-		for i, grantee := range denyGrantees {
-			recordPerms[i] = &permission{
-				Grantee:    grantee,
-				Owner:      owner.String(),
-				Collection: collection.String(),
-				Rkey:       rkey.String(),
-				Effect:     string(Deny),
-			}
-		}
-
-		// Delete any existing permission for this record before inserting the deny.
-		// This is jank and its because SQLITE/postgres differ in the ON CONFLICT specs. We should fix this.
-		if err := tx.Where("grantee IN ?", denyGrantees).
-			Where("owner = ?", owner).
-			Where("collection = ?", collection).
-			Where("rkey = ?", rkey).
-			Delete(&permission{}).Error; err != nil {
-			return fmt.Errorf("failed to clear existing permissions before deny insert: %w", err)
-		}
-		if err := tx.Create(recordPerms).Error; err != nil {
-			return fmt.Errorf("failed to add deny permissions: %w", err)
-		}
-		return nil
-	})
+	// Delete any existing allows on this record.
+	return s.db.Where("grantee IN ?", grantees).
+		Where("owner = ?", owner).
+		Where("collection = ?", collection).
+		Where("rkey = ?", rkey).
+		Delete(&permission{}).Error
 }
 
-func (s *store) ResolvePermissionsForCollection(ctx context.Context, grantee syntax.DID, collection syntax.NSID, owners []syntax.DID) ([]Permission, error) {
-	allPermissions, err := s.listPermissions(grantee, owners, collection, "")
+// Returns all permissions which have the given grantee for records part of collection and owned by owners
+func (s *store) ListGranteePermissions(ctx context.Context, grantee syntax.DID, collection syntax.NSID, owners []syntax.DID) ([]Permission, error) {
+	// Direct permission grants
+	direct, err := s.listPermissions([]Grantee{DIDGrantee(grantee)}, owners, collection, "*")
 	if err != nil {
 		return nil, err
 	}
 
-	relevant := []Permission{}
-	for _, permission := range allPermissions {
-		clique, ok := permission.Grantee.(habitat_syntax.Clique)
-		if !ok {
-			// Directly return specific grants for this DID
-			relevant = append(relevant, permission)
-			continue
-		}
-
-		// Otherwise, it's a clique grantee, so we need to resolve it
-		// TODO: we could potentially be more efficient with the DB query than resolving each independently.
-		ok, err := s.cliqueStore.IsMember(clique, grantee)
-		if err != nil {
-			return nil, err
-		}
-
-		if ok {
-			// Keep all other fields of the permission the same
-			permission.Grantee = DIDGrantee(grantee)
-			relevant = append(relevant, permission)
-		}
-		// If this did is not a member of the clique, ignore this permission
+	// Indirect permission grants through clique
+	cliques, err := s.cliqueStore.GetCliquesForMember(grantee)
+	if err != nil {
+		return nil, err
 	}
-	return relevant, nil
+
+	cliqueGrantees := xslices.Map(cliques, func(c habitat_syntax.Clique) Grantee {
+		return Grantee(c)
+	})
+
+	indirect, err := s.listPermissions(cliqueGrantees, owners, collection, "*")
+	if err != nil {
+		return nil, err
+	}
+
+	return append(direct, indirect...), nil
 }
 
 // ListPermissionGrants implements Store.
 func (s *store) ListPermissionGrants(ctx context.Context, granter syntax.DID, collection syntax.NSID) ([]Permission, error) {
-	return s.listPermissions("", []syntax.DID{granter}, collection, "")
+	return s.listPermissions([]Grantee{ /* match any */ }, []syntax.DID{granter}, collection, "")
 }
 
 // ListPermissionsForRecord implements Store.
@@ -374,32 +307,21 @@ func (s *store) ListAllowedGranteesForRecord(ctx context.Context, owner syntax.D
 		return nil, fmt.Errorf("this function expects to be called on a particular collection + record key; got collection %s, record %s", collection, rkey)
 	}
 
-	permissions, err := s.listPermissions("", []syntax.DID{owner}, collection, rkey)
+	permissions, err := s.listPermissions([]Grantee{ /* match any */ }, []syntax.DID{owner}, collection, rkey)
 	if err != nil {
 		return nil, err
 	}
 
-	denied := make(xmaps.Set[Grantee])
-	for _, p := range permissions {
-		if p.Effect == Deny {
-			denied.Add(p.Grantee)
-		}
-	}
-
-	var allowed []Grantee
-	for _, p := range permissions {
-		if p.Effect == Allow && !denied.Contains(p.Grantee) {
-			allowed = append(allowed, p.Grantee)
-		}
-	}
-
-	return allowed, nil
+	grantees := xslices.Map(permissions, func(p Permission) Grantee {
+		return p.Grantee
+	})
+	return grantees, nil
 }
 
 // ListPermissions returns the permissions available to this particular combination of inputs.
 // Any "" inputs are not filtered by.
 func (s *store) listPermissions(
-	grantee syntax.DID,
+	grantees []Grantee,
 	owners []syntax.DID,
 	collection syntax.NSID,
 	rkey syntax.RecordKey,
@@ -410,9 +332,9 @@ func (s *store) listPermissions(
 	if len(owners) > 0 {
 		query = query.Where("owner IN ?", owners)
 	}
-	if grantee.String() != "" {
+	if len(grantees) > 0 {
 		// The grantee field could also be a clique that includes this direct DID. so ifnore it
-		query = query.Where("grantee = ? OR grantee LIKE ?", grantee.String(), "clique:%") // check for the habitat uri prefix for cliques
+		query = query.Where("grantee IN ?", grantees) // check for the habitat uri prefix for cliques
 	}
 	if collection != "" {
 		query = query.Where("collection = ?", collection)
@@ -421,8 +343,6 @@ func (s *store) listPermissions(
 		// permissions with empty rkeys grant the entire collection
 		query = query.Where("rkey = ? OR rkey = ''", rkey)
 	}
-	// prioritize more specific permission and denies
-	query = query.Order("LENGTH(rkey) DESC, effect DESC")
 
 	if err := query.Find(&queried).Error; err != nil {
 		return nil, fmt.Errorf("failed to query permissions: %w", err)
@@ -430,21 +350,24 @@ func (s *store) listPermissions(
 
 	permissions := make([]Permission, len(queried))
 	for i, p := range queried {
-		grantee, err := ParseGranteeFromString(p.Grantee)
+		var err error
+		permissions[i], err = toPermission(p)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing found grantee in db: %s: %w", grantee, err)
+			return nil, fmt.Errorf("error parsing row: %w", err)
 		}
-		permissions[i] = Permission{
-			Owner:      syntax.DID(p.Owner),
-			Grantee:    grantee,
-			Collection: syntax.NSID(p.Collection),
-			Rkey:       syntax.RecordKey(p.Rkey),
-			Effect:     Effect(p.Effect),
-		}
-	}
-	if collection != "" && (slices.Contains(owners, grantee) || len(owners) == 0) {
-		// If the request is for a general collection (un-ownered), by default the grantee has permission to their own collections.
-		permissions = append(permissions, Permission{Grantee: DIDGrantee(grantee), Owner: grantee, Collection: collection, Effect: Allow})
 	}
 	return permissions, nil
+}
+
+func toPermission(p permission) (Permission, error) {
+	grantee, err := ParseGranteeFromString(p.Grantee)
+	if err != nil {
+		return Permission{}, fmt.Errorf("error parsing grantee: %s", grantee)
+	}
+	return Permission{
+		Owner:      syntax.DID(p.Owner),
+		Grantee:    grantee,
+		Collection: syntax.NSID(p.Collection),
+		Rkey:       syntax.RecordKey(p.Rkey),
+	}, nil
 }

--- a/internal/permissions/store.go
+++ b/internal/permissions/store.go
@@ -106,19 +106,6 @@ func NewStore(db *gorm.DB, cliqueStore clique.Store) (*store, error) {
 		return nil, fmt.Errorf("failed to migrate permissions table: %w", err)
 	}
 
-	// Drop the effect column if it still exists
-	if db.Migrator().HasColumn(&permission{}, "effect") {
-		if err := db.Migrator().DropColumn(&permission{}, "effect"); err != nil {
-			return nil, fmt.Errorf("failed to drop effect column: %w", err)
-		}
-	}
-
-	// Delete collection-level grants (rkey = "") — these are unsupported
-	err = db.Where("rkey = ?", "").Delete(&permission{}).Error
-	if err != nil {
-		return nil, fmt.Errorf("failed to delete collection-level permissions: %w", err)
-	}
-
 	return &store{db: db, cliqueStore: cliqueStore}, nil
 }
 
@@ -139,7 +126,6 @@ func (s *store) HasPermission(
 		return false, ErrCollectionLevelNotSupported
 	}
 
-	// TODO: this query shouldn't use listPermissions
 	var permissions []permission
 	err := s.db.
 		Where("grantee = ? OR grantee LIKE ?", requester.String(), "clique:%"). // check for the habitat uri prefix for cliques

--- a/internal/permissions/store_test.go
+++ b/internal/permissions/store_test.go
@@ -3,7 +3,6 @@ package permissions
 import (
 	"context"
 	"net/http"
-	"slices"
 	"testing"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -51,45 +50,30 @@ func TestStoreBasicPermissions(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, HasPermission, "non-owner without permission should be denied")
 
-	// Test: Grant lexicon-level permission
-	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
+	// Test: Grant record-level permission
+	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 
-	// Test: Bob should now have permission to all posts
+	// Test: Bob should now have permission to record1
 	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 	require.True(t, HasPermission, "bob should have permission after grant")
 
+	// Test: Bob should not have permission to other records
 	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record2")
 	require.NoError(t, err)
-	require.True(t, HasPermission, "bob should have permission to all records in the lexicon")
+	require.False(t, HasPermission, "bob should not have permission to other records")
 
-	// Test: Bob should not have permission to other lexicons
+	// Test: Bob should not have permission to other collections
 	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.likes", "record1")
 	require.NoError(t, err)
-	require.False(t, HasPermission, "bob should not have permission to other lexicons")
+	require.False(t, HasPermission, "bob should not have permission to other collections")
 
-	// Test: Remove permission for single record
+	// Test: Remove record-level permission
 	err = store.RemovePermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 
 	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
-	require.NoError(t, err)
-	require.False(t, HasPermission, "bob should not have permission to record1 after removal")
-
-	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record2")
-	require.NoError(t, err)
-	require.True(t, HasPermission, "bob should have permission to record2")
-
-	// Test: Remove permission for whole collection
-	err = store.RemovePermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
-	require.NoError(t, err)
-
-	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
-	require.NoError(t, err)
-	require.False(t, HasPermission, "bob should not have permission after removal")
-
-	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record2")
 	require.NoError(t, err)
 	require.False(t, HasPermission, "bob should not have permission after removal")
 }
@@ -97,15 +81,15 @@ func TestStoreBasicPermissions(t *testing.T) {
 func TestStoreMultipleGrantees(t *testing.T) {
 	store := newTestStore(t)
 
-	// Grant permissions to multiple users
-	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob"), DIDGrantee("did:example:charlie")}, "did:example:alice", "network.habitat.posts", "")
+	// Grant permissions to multiple users for different records
+	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob"), DIDGrantee("did:example:charlie")}, "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 
-	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.likes", "")
+	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.likes", "record1")
 	require.NoError(t, err)
 
-	// List permissions by lexicon
-	permissions, err := store.listPermissions("", []syntax.DID{"did:example:alice"}, "", "")
+	// List permissions by owner
+	permissions, err := store.listPermissions([]Grantee{}, []syntax.DID{"did:example:alice"}, "", "")
 	require.NoError(t, err)
 	// Alice gave three permission grants
 	require.Len(t, permissions, 3)
@@ -114,64 +98,51 @@ func TestStoreMultipleGrantees(t *testing.T) {
 func TestStoreListByGrantee(t *testing.T) {
 	store := newTestStore(t)
 
-	// Grant bob access to network.habitat.posts
-	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
+	// Grant bob access to a specific record in network.habitat.posts
+	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 
 	// List bob's permissions for network.habitat.posts
-	permissions, err := store.listPermissions("did:example:bob", nil, "network.habitat.posts", "")
-	slices.SortFunc(permissions, func(a, b Permission) int {
-		if a.Owner < b.Owner {
-			return -1
-		} else if a.Owner == b.Owner {
-			return 0
-		}
-		return 1
-	})
-	require.NoError(t, err)
-	require.Len(t, permissions, 2)
-	require.Equal(t, permissions[0].Owner.String(), "did:example:alice")
-	require.Equal(t, permissions[0].Grantee.String(), "did:example:bob")
-	require.Equal(t, permissions[0].Effect, Allow)
-	require.Equal(t, permissions[1].Owner.String(), "did:example:bob")
-	require.Equal(t, permissions[1].Grantee.String(), "did:example:bob")
-	require.Equal(t, permissions[1].Collection.String(), "network.habitat.posts")
-	require.Equal(t, permissions[1].Effect, Allow)
-
-	// Charlie has no permissions
-	permissions, err = store.listPermissions("did:example:charlie", nil, "network.habitat.posts", "")
+	permissions, err := store.listPermissions([]Grantee{DIDGrantee("did:example:bob")}, nil, "network.habitat.posts", "")
 	require.NoError(t, err)
 	require.Len(t, permissions, 1)
-	require.Equal(t, permissions[0].Owner.String(), "did:example:charlie")
-	require.Equal(t, permissions[0].Grantee.String(), "did:example:charlie")
-	require.Equal(t, permissions[0].Effect, Allow)
+	require.Equal(t, "did:example:alice", permissions[0].Owner.String())
+	require.Equal(t, "did:example:bob", permissions[0].Grantee.String())
+
+	// Charlie has no permissions
+	permissions, err = store.listPermissions([]Grantee{DIDGrantee("did:example:charlie")}, nil, "network.habitat.posts", "")
+	require.NoError(t, err)
+	require.Empty(t, permissions)
 }
 
-func TestStoreEmptyRecordKey(t *testing.T) {
+func TestStoreCollectionLevelNotSupported(t *testing.T) {
 	store := newTestStore(t)
 
-	// Grant permission
+	// AddPermissions with empty rkey should return ErrCollectionLevelNotSupported
 	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrCollectionLevelNotSupported)
 
-	// Check permission with empty record key (should check NSID-level permission)
-	HasPermission, err := store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "")
-	require.NoError(t, err)
-	require.True(t, HasPermission, "should have permission to NSID when record key is empty")
+	// RemovePermissions with empty rkey should return ErrCollectionLevelNotSupported
+	err = store.RemovePermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
+	require.ErrorIs(t, err, ErrCollectionLevelNotSupported)
+
+	// HasPermission with empty rkey should return ErrCollectionLevelNotSupported
+	_, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "")
+	require.ErrorIs(t, err, ErrCollectionLevelNotSupported)
 }
 
 func TestStoreMultipleOwners(t *testing.T) {
 	store := newTestStore(t)
 
-	// Grant bob access to alice's posts
-	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
+	// Grant bob access to alice's post
+	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 
-	// Grant bob access to charlie's likes
-	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:charlie", "network.habitat.likes", "")
+	// Grant bob access to charlie's like
+	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:charlie", "network.habitat.likes", "record1")
 	require.NoError(t, err)
 
-	// Bob should have access to alice's posts
+	// Bob should have access to alice's post
 	HasPermission, err := store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 	require.True(t, HasPermission)
@@ -181,183 +152,44 @@ func TestStoreMultipleOwners(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, HasPermission)
 
-	// Bob should have access to charlie's likes
+	// Bob should have access to charlie's like
 	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:charlie", "network.habitat.likes", "record1")
 	require.NoError(t, err)
 	require.True(t, HasPermission)
 
 	// List alice's permissions
-	permissions, err := store.listPermissions("", []syntax.DID{"did:example:alice"}, "", "")
+	permissions, err := store.listPermissions([]Grantee{}, []syntax.DID{"did:example:alice"}, "", "")
 	require.NoError(t, err)
 	require.Len(t, permissions, 1)
-	require.Equal(t, Permission{Grantee: DIDGrantee("did:example:bob"), Owner: "did:example:alice", Collection: "network.habitat.posts", Rkey: "", Effect: Allow}, permissions[0])
+	require.Equal(t, Permission{Grantee: DIDGrantee("did:example:bob"), Owner: "did:example:alice", Collection: "network.habitat.posts", Rkey: "record1"}, permissions[0])
 
 	// List charlie's permissions
-	permissions, err = store.listPermissions("", []syntax.DID{"did:example:charlie"}, "", "")
+	permissions, err = store.listPermissions([]Grantee{}, []syntax.DID{"did:example:charlie"}, "", "")
 	require.NoError(t, err)
 	require.Len(t, permissions, 1)
-	require.Equal(t, Permission{Grantee: DIDGrantee("did:example:bob"), Owner: "did:example:charlie", Collection: "network.habitat.likes", Rkey: "", Effect: Allow}, permissions[0])
+	require.Equal(t, Permission{Grantee: DIDGrantee("did:example:bob"), Owner: "did:example:charlie", Collection: "network.habitat.likes", Rkey: "record1"}, permissions[0])
 }
 
-func TestStoreDenyOverridesAllow(t *testing.T) {
+func TestStoreRemovePermission(t *testing.T) {
 	store := newTestStore(t)
 
-	// Grant bob broad access to network.habitat
-	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
+	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
+
+	HasPermission, err := store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
+	require.NoError(t, err)
+	require.True(t, HasPermission)
 
 	err = store.RemovePermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 
-	// Bob should not have access to the denied post
-	HasPermission, err := store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
+	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
 	require.NoError(t, err)
 	require.False(t, HasPermission)
-
-	// Bob should have access to other posts
-	HasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record2")
-	require.NoError(t, err)
-	require.True(t, HasPermission)
 }
-
-/*
-func TestHasPermissionViaClique(t *testing.T) {
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
-	require.NoError(t, err)
-
-	// The node serves did:example:alice, making her clique a local clique.
-	n := &mockNode{servedDIDs: map[string]bool{"did:example:alice": true}}
-	store, err := NewStore(db)
-	require.NoError(t, err)
-
-	clique := CliqueGrantee("habitat://did:example:alice/network.habitat.clique/my-clique")
-
-	// Alice grants her clique access to her posts.
-	err = store.AddPermissions([]Grantee{clique}, "did:example:alice", "network.habitat.posts", "")
-	require.NoError(t, err)
-
-	// Bob is a member of Alice's clique.
-	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.clique", "my-clique")
-	require.NoError(t, err)
-
-	// Bob should have permission to Alice's posts via the clique.
-	hasPermission, err := store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
-	require.NoError(t, err)
-	require.True(t, hasPermission, "bob should have permission via clique membership")
-
-	// Charlie is not a member of the clique and should not have permission.
-	hasPermission, err = store.HasPermission(t.Context(), "did:example:charlie", "did:example:alice", "network.habitat.posts", "record1")
-	require.NoError(t, err)
-	require.False(t, hasPermission, "charlie should not have permission without clique membership")
-}
-
-
-func TestResolvePermissionsForCollection(t *testing.T) {
-	t.Run("direct permission", func(t *testing.T) {
-		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
-		require.NoError(t, err)
-
-		store, err := NewStore(db)
-		require.NoError(t, err)
-
-		err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
-		require.NoError(t, err)
-
-		perms, err := store.ResolvePermissionsForCollection(t.Context(), "did:example:bob", "network.habitat.posts", nil)
-		require.NoError(t, err)
-		// Should include alice's direct grant and bob's own self-permission
-		require.Len(t, perms, 2)
-		var alicePerm *Permission
-		for i := range perms {
-			if perms[i].Owner == "did:example:alice" {
-				alicePerm = &perms[i]
-			}
-		}
-		require.NotNil(t, alicePerm)
-		require.Equal(t, DIDGrantee("did:example:bob"), alicePerm.Grantee)
-		require.Equal(t, Allow, alicePerm.Effect)
-	})
-
-	t.Run("no external permissions returns only self", func(t *testing.T) {
-		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
-		require.NoError(t, err)
-
-		store, err := NewStore(db)
-		require.NoError(t, err)
-
-		perms, err := store.ResolvePermissionsForCollection(t.Context(), "did:example:charlie", "network.habitat.posts", nil)
-		require.NoError(t, err)
-		require.Len(t, perms, 1)
-		require.Equal(t, DIDGrantee("did:example:charlie"), perms[0].Grantee)
-		require.Equal(t, syntax.DID("did:example:charlie"), perms[0].Owner)
-		require.Equal(t, Allow, perms[0].Effect)
-	})
-
-	t.Run("clique permission resolved for member", func(t *testing.T) {
-		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
-		require.NoError(t, err)
-
-		// Node serves alice, so her clique is resolved locally
-		n := &mockNode{servedDIDs: map[string]bool{"did:example:alice": true}}
-		store, err := NewStore(db, n)
-		require.NoError(t, err)
-
-		clique := CliqueGrantee("habitat://did:example:alice/network.habitat.clique/friends")
-
-		// Alice grants her clique access to her posts
-		err = store.AddPermissions([]Grantee{clique}, "did:example:alice", "network.habitat.posts", "")
-		require.NoError(t, err)
-
-		// Bob is a member of Alice's clique
-		err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.clique", "friends")
-		require.NoError(t, err)
-
-		perms, err := store.ResolvePermissionsForCollection(t.Context(), "did:example:bob", "network.habitat.posts", nil)
-		require.NoError(t, err)
-		// Should include: clique grant resolved to bob + bob's own self-permission
-		require.Len(t, perms, 2)
-		var alicePerm *Permission
-		for i := range perms {
-			if perms[i].Owner == "did:example:alice" {
-				alicePerm = &perms[i]
-			}
-		}
-		require.NotNil(t, alicePerm, "should include permission from alice resolved via clique")
-		require.Equal(t, DIDGrantee("did:example:bob"), alicePerm.Grantee, "clique grantee should be resolved to bob's DID")
-		require.Equal(t, Allow, alicePerm.Effect)
-	})
-
-	t.Run("clique permission excluded for non-member", func(t *testing.T) {
-		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
-		require.NoError(t, err)
-
-		// Node serves alice, so her clique is resolved locally
-		n := &mockNode{servedDIDs: map[string]bool{"did:example:alice": true}}
-		store, err := NewStore(db, n)
-		require.NoError(t, err)
-
-		clique := CliqueGrantee("habitat://did:example:alice/network.habitat.clique/friends")
-
-		// Alice grants her clique access to her posts
-		err = store.AddPermissions([]Grantee{clique}, "did:example:alice", "network.habitat.posts", "")
-		require.NoError(t, err)
-
-		// Bob is a member but charlie is not
-		err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.clique", "friends")
-		require.NoError(t, err)
-
-		// Charlie is not in the clique and should only see her own self-permission
-		perms, err := store.ResolvePermissionsForCollection(t.Context(), "did:example:charlie", "network.habitat.posts", nil)
-		require.NoError(t, err)
-		require.Len(t, perms, 1)
-		require.Equal(t, DIDGrantee("did:example:charlie"), perms[0].Grantee)
-		require.Equal(t, syntax.DID("did:example:charlie"), perms[0].Owner)
-	})
-}
-*/
 
 func TestListAllowedGranteesForRecord(t *testing.T) {
-	t.Run("basic: grantee with allow permission is returned", func(t *testing.T) {
+	t.Run("basic: grantee with permission is returned", func(t *testing.T) {
 		store := newTestStore(t)
 		err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 		require.NoError(t, err)
@@ -376,14 +208,12 @@ func TestListAllowedGranteesForRecord(t *testing.T) {
 		require.Empty(t, perms)
 	})
 
-	t.Run("deny permission is filtered out", func(t *testing.T) {
+	t.Run("removed permission is not returned", func(t *testing.T) {
 		store := newTestStore(t)
 
-		// Grant bob access at the collection level
-		err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
+		err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 		require.NoError(t, err)
 
-		// Add a deny directly on the record without any allow
 		err = store.RemovePermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
 		require.NoError(t, err)
 
@@ -392,27 +222,15 @@ func TestListAllowedGranteesForRecord(t *testing.T) {
 		require.Empty(t, perms)
 	})
 
-	t.Run("collection-level allow is included for specific record with no record-level deny", func(t *testing.T) {
+	t.Run("permission on different record does not appear", func(t *testing.T) {
 		store := newTestStore(t)
 
-		// Grant bob access at the collection level
-		err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
+		err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record2")
 		require.NoError(t, err)
 
-		// Add a deny on a different record to confirm it doesn't pollute results for record1
-		err = store.RemovePermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record2")
-		require.NoError(t, err)
-
-		// record1 has no record-level deny, so the collection-level allow should appear
 		grants, err := store.ListAllowedGranteesForRecord(t.Context(), "did:example:alice", "network.habitat.posts", "record1")
 		require.NoError(t, err)
-		require.Len(t, grants, 1)
-		require.Equal(t, DIDGrantee("did:example:bob"), grants[0])
-
-		// record2 has a deny, which should be filtered; the collection-level allow still appears
-		grants, err = store.ListAllowedGranteesForRecord(t.Context(), "did:example:alice", "network.habitat.posts", "record2")
-		require.NoError(t, err)
-		require.Len(t, grants, 0)
+		require.Empty(t, grants)
 	})
 }
 
@@ -428,37 +246,6 @@ func TestHasPermissionNoMatchingCollectionAndRkeyHasRandomClique(t *testing.T) {
 	require.False(t, hasPermission, "should return false when no permissions match the collection+rkey")
 }
 
-func TestAddCollectionPermissionClearsPriorRecordDeny(t *testing.T) {
-	store := newTestStore(t)
-
-	// Step 1: Grant bob record-level access to record1
-	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
-	require.NoError(t, err)
-
-	// Step 2: Remove that record-level permission (creates a Deny entry for record1)
-	err = store.RemovePermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record1")
-	require.NoError(t, err)
-
-	// Confirm bob cannot access record1 at this point
-	hasPermission, err := store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
-	require.NoError(t, err)
-	require.False(t, hasPermission, "bob should not have access after record-level permission was removed")
-
-	// Step 3: Grant bob collection-level access to all of alice's posts
-	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
-	require.NoError(t, err)
-
-	// The collection-level grant should supersede the prior record-level deny.
-	// Bob should now have access to all records, including the originally denied record1.
-	hasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record1")
-	require.NoError(t, err)
-	require.True(t, hasPermission, "bob should have access to record1 after collection-level permission was granted")
-
-	hasPermission, err = store.HasPermission(t.Context(), "did:example:bob", "did:example:alice", "network.habitat.posts", "record2")
-	require.NoError(t, err)
-	require.True(t, hasPermission, "bob should have access to other records in the collection")
-}
-
 func TestAddReadPermission_EmptyCollection(t *testing.T) {
 	store := newTestStore(t)
 
@@ -472,23 +259,15 @@ func TestListReadPermissionsByGrantee_NoRedundant(t *testing.T) {
 	err := store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record-1")
 	require.NoError(t, err)
 
-	// Should not return multiple permissions for the same record
+	// Adding the same permission again should not create a duplicate
 	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "record-1")
 	require.NoError(t, err)
 
-	perms, err := store.listPermissions("did:example:bob", nil, "", "")
+	perms, err := store.listPermissions([]Grantee{DIDGrantee("did:example:bob")}, nil, "", "")
 	require.NoError(t, err)
-	require.Len(t, perms, 1 /* has direct permission on record */)
+	require.Len(t, perms, 1)
 
-	// Should only return the most powerful permission
-	err = store.AddPermissions([]Grantee{DIDGrantee("did:example:bob")}, "did:example:alice", "network.habitat.posts", "")
-	require.NoError(t, err)
-
-	perms, err = store.listPermissions("did:example:bob", nil, "", "")
-	require.NoError(t, err)
-	require.Len(t, perms, 1 /* no collection specified so only returns direct permissions */)
-
-	// should not add unnecessary permissions
+	// Adding another grantee for the same record should not affect bob's count
 	err = store.AddPermissions(
 		[]Grantee{DIDGrantee("did:example:bob"), DIDGrantee("did:example:charlie")},
 		"did:example:alice",
@@ -497,7 +276,7 @@ func TestListReadPermissionsByGrantee_NoRedundant(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	perms, err = store.listPermissions("did:example:bob", nil, "", "")
+	perms, err = store.listPermissions([]Grantee{DIDGrantee("did:example:bob")}, nil, "", "")
 	require.NoError(t, err)
-	require.Len(t, perms, 1 /* has direct permission on record */)
+	require.Len(t, perms, 1)
 }

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -28,7 +28,8 @@ type Repo interface {
 	UploadBlob(ctx context.Context, did string, data []byte, mimeType string) (*BlobRef, error)
 	GetBlob(ctx context.Context, did string, cid string) (string /* mimetype */, []byte /* raw blob */, error)
 	GetBlobLinks(ctx context.Context, cid syntax.CID, did syntax.DID) ([]habitat_syntax.HabitatURI, error)
-	ListRecords(ctx context.Context, perms []permissions.Permission) ([]Record, error)
+	ListRecordsFromPermissions(ctx context.Context, perms []permissions.Permission) ([]Record, error)
+	ListRecords(ctx context.Context, did string, collection string) ([]Record, error)
 	ListCollections(ctx context.Context, did syntax.DID) ([]CollectionMetadata, error)
 }
 
@@ -271,15 +272,38 @@ func (r *repo) GetBlobLinks(ctx context.Context, cid syntax.CID, did syntax.DID)
 	}), nil
 }
 
+func rowsToRecords(rows []record) ([]Record, error) {
+	records := make([]Record, len(rows))
+	for i, row := range rows {
+
+		var value map[string]any
+		err := json.Unmarshal(row.Value, &value)
+		if err != nil {
+			return nil, err
+		}
+
+		r := Record{
+			Did:        row.Did,
+			Collection: row.Collection,
+			Rkey:       row.Rkey,
+			Value:      value,
+		}
+
+		records[i] = r
+	}
+	return records, nil
+}
+
 // listRecords implements repo.
 // perms should not include redundant permissions ie
 // if grantee has permission to the collection, perms should not include permissions to specific records in that collection
-func (r *repo) ListRecords(ctx context.Context, perms []permissions.Permission) ([]Record, error) {
+func (r *repo) ListRecordsFromPermissions(ctx context.Context, perms []permissions.Permission) ([]Record, error) {
 	if len(perms) == 0 {
 		return []Record{}, nil
 	}
 
 	// Start with base query filtering by did and collection
+	// TODO: simplify this to make it readable
 	query := r.db
 
 	allowQuery := query
@@ -311,26 +335,17 @@ func (r *repo) ListRecords(ctx context.Context, perms []permissions.Permission) 
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
 
-	records := make([]Record, len(rows))
-	for i, row := range rows {
+	return rowsToRecords(rows)
+}
 
-		var value map[string]any
-		err := json.Unmarshal(row.Value, &value)
-		if err != nil {
-			return nil, err
-		}
-
-		r := Record{
-			Did:        row.Did,
-			Collection: row.Collection,
-			Rkey:       row.Rkey,
-			Value:      value,
-		}
-
-		records[i] = r
+func (r *repo) ListRecords(ctx context.Context, did string, collection string) ([]Record, error) {
+	// Execute query
+	var rows []record
+	if err := r.db.Where("did = ?", did).Where("collection = ?", collection).Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
 	}
 
-	return records, nil
+	return rowsToRecords(rows)
 }
 
 // Ugly: hack to support SQLITE and Postgres

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -285,23 +285,16 @@ func (r *repo) ListRecords(ctx context.Context, perms []permissions.Permission) 
 	allowQuery := query
 	allows := 0
 	for _, perm := range perms {
-		if perm.Effect == permissions.Allow {
-			grantQuery := r.db.Where("did = ?", perm.Owner)
-			if perm.Collection != "" {
-				grantQuery = grantQuery.Where("collection = ?", perm.Collection)
-			}
-			if perm.Rkey != "" {
-				// if rkey is not empty
-				grantQuery = grantQuery.Where("rkey = ?", perm.Rkey)
-			}
-			allowQuery = allowQuery.Or(grantQuery)
-			allows++
-		} else {
-			// build up deny `NOT`s
-			query = query.Not(
-				r.db.Where("collection = ?", perm.Collection).Where("rkey = ?", perm.Rkey),
-			)
+		grantQuery := r.db.Where("did = ?", perm.Owner)
+		if perm.Collection != "" {
+			grantQuery = grantQuery.Where("collection = ?", perm.Collection)
 		}
+		if perm.Rkey != "" {
+			// if rkey is not empty
+			grantQuery = grantQuery.Where("rkey = ?", perm.Rkey)
+		}
+		// build up allow `OR`s
+		allowQuery = allowQuery.Or(grantQuery)
 	}
 	if allows > 0 {
 		query = query.Where(allowQuery)

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -307,7 +307,6 @@ func (r *repo) ListRecordsFromPermissions(ctx context.Context, perms []permissio
 	query := r.db
 
 	allowQuery := query
-	allows := 0
 	for _, perm := range perms {
 		grantQuery := r.db.Where("did = ?", perm.Owner)
 		if perm.Collection != "" {
@@ -320,11 +319,7 @@ func (r *repo) ListRecordsFromPermissions(ctx context.Context, perms []permissio
 		// build up allow `OR`s
 		allowQuery = allowQuery.Or(grantQuery)
 	}
-	if allows > 0 {
-		query = query.Where(allowQuery)
-	} else {
-		return []Record{}, nil
-	}
+	query = query.Where(allowQuery)
 
 	// Order by rkey for consistent pagination
 	query = query.Order("rkey ASC")

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -84,11 +84,11 @@ func TestRepoListRecords(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	records, err := repo.ListRecords(ctx, nil)
+	records, err := repo.ListRecordsFromPermissions(ctx, nil)
 	require.NoError(t, err)
 	require.Len(t, records, 0)
 
-	records, err = repo.ListRecords(
+	records, err = repo.ListRecordsFromPermissions(
 		ctx,
 		[]permissions.Permission{
 			{

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -216,6 +216,53 @@ func TestRepoUploadAndGetBlob(t *testing.T) {
 	require.ErrorIs(t, err, ErrRecordNotFound)
 }
 
+func TestListRecords(t *testing.T) {
+	ctx := t.Context()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	repo, err := NewRepo(db)
+	require.NoError(t, err)
+
+	did := "did:plc:testuser"
+	coll1 := "network.habitat.alpha"
+	coll2 := "network.habitat.beta"
+
+	for _, rec := range []Record{
+		{Did: did, Collection: coll1, Rkey: "key-1", Value: map[string]any{"x": "1"}},
+		{Did: did, Collection: coll1, Rkey: "key-2", Value: map[string]any{"x": "2"}},
+		{Did: did, Collection: coll2, Rkey: "key-1", Value: map[string]any{"x": "3"}},
+	} {
+		_, err = repo.PutRecord(ctx, rec, nil)
+		require.NoError(t, err)
+	}
+
+	// Returns only records in the specified collection
+	records, err := repo.ListRecords(ctx, did, coll1)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	for _, r := range records {
+		require.Equal(t, did, r.Did)
+		require.Equal(t, coll1, r.Collection)
+	}
+
+	// Returns records for the other collection
+	records, err = repo.ListRecords(ctx, did, coll2)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, "key-1", records[0].Rkey)
+
+	// Returns empty for a non-existent collection
+	records, err = repo.ListRecords(ctx, did, "network.habitat.nonexistent")
+	require.NoError(t, err)
+	require.Empty(t, records)
+
+	// Returns empty for a different DID
+	records, err = repo.ListRecords(ctx, "did:plc:other", coll1)
+	require.NoError(t, err)
+	require.Empty(t, records)
+}
+
 func TestDeleteRecord(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -95,50 +95,16 @@ func TestRepoListRecords(t *testing.T) {
 				Owner:      "my-did",
 				Collection: "network.habitat.collection-1",
 				Rkey:       "key-1",
-				Effect:     "allow",
 			},
 			{
 				Owner:      "my-did",
 				Collection: "network.habitat.collection-1",
 				Rkey:       "key-2",
-				Effect:     "allow",
 			},
 		},
 	)
 	require.NoError(t, err)
 	require.Len(t, records, 2)
-
-	records, err = repo.ListRecords(
-		ctx,
-		[]permissions.Permission{
-			{
-				Owner:      "my-did",
-				Collection: "network.habitat.collection-1",
-				Effect:     "allow",
-			},
-		},
-	)
-	require.NoError(t, err)
-	require.Len(t, records, 2)
-
-	records, err = repo.ListRecords(
-		ctx,
-		[]permissions.Permission{
-			{
-				Owner:      "my-did",
-				Collection: "network.habitat.collection-1",
-				Effect:     "allow",
-			},
-			{
-				Owner:      "my-did",
-				Collection: "network.habitat.collection-1",
-				Rkey:       "key-1",
-				Effect:     "deny",
-			},
-		},
-	)
-	require.NoError(t, err)
-	require.Len(t, records, 1)
 }
 
 func TestRepoListCollections(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -470,12 +470,8 @@ func (s *Server) ListPermissions(w http.ResponseWriter, r *http.Request) {
 	output.Permissions = []habitat.NetworkHabitatPermissionsListPermissionsPermission{}
 	for _, p := range perms {
 		// Only display allows
-		if p.Effect == permissions.Deny {
-			continue
-		}
 		output.Permissions = append(output.Permissions, habitat.NetworkHabitatPermissionsListPermissionsPermission{
 			Collection: p.Collection.String(),
-			Effect:     string(p.Effect),
 			Grantee:    p.Grantee.String(),
 			Rkey:       p.Rkey.String(),
 		})


### PR DESCRIPTION
Found a bug in docs where if you have a collection-level grant but are not a member of the clique for that doc, its unclear what should happen.

Generally, this is going to be confusing with cliques, and seems like we likely don't need it. Let's delete it and we can add it back later if we need to.