### PR TITLE
[go]: fix version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,6 @@ jobs:
             .prototools
 
       - run: moon ci --color
+
+      - name: Build pear Docker image
+        run: docker build -f cmd/pear/Dockerfile .

--- a/cmd/pear/Dockerfile
+++ b/cmd/pear/Dockerfile
@@ -1,7 +1,7 @@
 #### BUILD STAGE
 #### Builds the Go binary.
 
-FROM golang:1.25.4-alpine AS build
+FROM golang:1.25.7-alpine AS build
 WORKDIR /app
 
 # Copy go module files first for better layer caching


### PR DESCRIPTION
Our cloud builds are failing bc go.mod and Dockerfile go versions are mismatched.
We need a way to keep these in sync; I'm adding a build step for the Dockerfile in CI to catch these, but I think we need them to derive from a single place?