### PR TITLE
[server]: refactor auth

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,4 +1,4 @@
-go = "1.25.7"
+go = "1.26"
 golangci-lint = "2.7.2"
 moon = "2.0.0-rc.0"
 node = "24.4.1"

--- a/.prototools
+++ b/.prototools
@@ -1,4 +1,4 @@
-go = "1.26"
+go = "1.25.7"
 golangci-lint = "2.7.2"
 moon = "2.0.0-rc.0"
 node = "24.4.1"

--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -151,7 +151,8 @@ func run(_ context.Context, cmd *cli.Command) error {
 	if err != nil {
 		log.Fatal().Err(err).Msg("unable to setup pear servers")
 	}
-	pearServer := server.NewServer(dir, pear, oauthServer, authn.NewServiceAuthMethod(dir))
+	serviceAuth := authn.NewServiceAuthMethod(dir)
+	pearServer := server.NewServer(dir, pear, oauthServer, serviceAuth)
 
 	p2pServer, err := p2p.NewServer(authn.NewServiceAuthMethod(dir), pear, meter)
 	if err != nil {
@@ -181,6 +182,9 @@ func run(_ context.Context, cmd *cli.Command) error {
 		log.Err(err).Msgf("unable to set up waitlist service")
 	}
 
+	// serve did:web DID doc for this server
+	mux.HandleFunc("/.well-known/did.json", serveDid(domain))
+
 	// auth routes
 	mux.HandleFunc("/oauth-callback", oauthServer.HandleCallback)
 	mux.HandleFunc("/client-metadata.json", oauthServer.HandleClientMetadata)
@@ -189,30 +193,33 @@ func run(_ context.Context, cmd *cli.Command) error {
 	mux.HandleFunc("/xrpc/network.habitat.listConnectedApps", oauthServer.ListConnectedApps)
 
 	// pear routes
-	// repo
-	mux.HandleFunc("/xrpc/network.habitat.putRecord", pearServer.PutRecord)
-	mux.HandleFunc("/xrpc/network.habitat.getRecord", pearServer.GetRecord)
-	mux.HandleFunc("/xrpc/network.habitat.listRecords", pearServer.ListRecords)
-	mux.HandleFunc("/xrpc/network.habitat.repo.listCollections", pearServer.ListCollections)
-	mux.HandleFunc("/xrpc/network.habitat.repo.deleteRecord", pearServer.DeleteRecord)
+	// Use both oauth and serviceauth methods for all routes on pear (for now)
+	authnMiddleware := authn.Middleware(oauthServer, serviceAuth)
+	pearRouter := mux.NewRoute().Subrouter()
+	pearRouter.Use(authnMiddleware)
 
-	// blobs
-	mux.HandleFunc("/xrpc/network.habitat.uploadBlob", pearServer.UploadBlob)
-	mux.HandleFunc("/xrpc/network.habitat.getBlob", pearServer.GetBlob)
+	// pear repo
+	pearRouter.HandleFunc("/xrpc/network.habitat.putRecord", pearServer.PutRecord)
+	pearRouter.HandleFunc("/xrpc/network.habitat.getRecord", pearServer.GetRecord)
+	pearRouter.HandleFunc("/xrpc/network.habitat.listRecords", pearServer.ListRecords)
+	pearRouter.HandleFunc("/xrpc/network.habitat.repo.listCollections", pearServer.ListCollections)
+	pearRouter.HandleFunc("/xrpc/network.habitat.repo.deleteRecord", pearServer.DeleteRecord)
 
-	// permissions
-	mux.HandleFunc("/xrpc/network.habitat.listPermissions", pearServer.ListPermissions)
-	mux.HandleFunc("/xrpc/network.habitat.addPermission", pearServer.AddPermission)
-	mux.HandleFunc("/xrpc/network.habitat.removePermission", pearServer.RemovePermission)
+	// pear blobs
+	pearRouter.HandleFunc("/xrpc/network.habitat.uploadBlob", pearServer.UploadBlob)
+	pearRouter.HandleFunc("/xrpc/network.habitat.getBlob", pearServer.GetBlob)
 
-	// cliques
-	mux.HandleFunc("/xrpc/network.habitat.clique.createClique", pearServer.CreateClique)
-	mux.HandleFunc("/xrpc/network.habitat.clique.addMembers", pearServer.AddCliqueMembers)
-	mux.HandleFunc("/xrpc/network.habitat.clique.removeMembers", pearServer.RemoveCliqueMembers)
-	mux.HandleFunc("/xrpc/network.habitat.clique.getMembers", pearServer.GetCliqueMembers)
-	mux.HandleFunc("/xrpc/network.habitat.clique.isMember", pearServer.IsCliqueMember)
+	// pear permissions
+	pearRouter.HandleFunc("/xrpc/network.habitat.listPermissions", pearServer.ListPermissions)
+	pearRouter.HandleFunc("/xrpc/network.habitat.addPermission", pearServer.AddPermission)
+	pearRouter.HandleFunc("/xrpc/network.habitat.removePermission", pearServer.RemovePermission)
 
-	mux.HandleFunc("/.well-known/did.json", serveDid(domain))
+	// pear cliques
+	pearRouter.HandleFunc("/xrpc/network.habitat.clique.createClique", pearServer.CreateClique)
+	pearRouter.HandleFunc("/xrpc/network.habitat.clique.addMembers", pearServer.AddCliqueMembers)
+	pearRouter.HandleFunc("/xrpc/network.habitat.clique.removeMembers", pearServer.RemoveCliqueMembers)
+	pearRouter.HandleFunc("/xrpc/network.habitat.clique.getMembers", pearServer.GetCliqueMembers)
+	pearRouter.HandleFunc("/xrpc/network.habitat.clique.isMember", pearServer.IsCliqueMember)
 
 	pdsForwarding := newPDSForwarding(pdsCredStore, oauthServer, pdsClientFactory)
 	mux.PathPrefix("/xrpc/").Handler(pdsForwarding)
@@ -396,22 +403,4 @@ func setupOAuthServer(
 		log.Fatal().Err(err).Msgf("unable to setup oauth server")
 	}
 	return oauthServer
-}
-
-func corsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().
-			Set("Access-Control-Allow-Headers", "Content-Type, Authorization, habitat-auth-method, User-Agent, atproto-accept-labelers, at-proxy")
-		w.Header().Set("Access-Control-Max-Age", "86400") // Cache preflight for 24 hours
-
-		// Handle preflight OPTIONS request
-		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
 }

--- a/cmd/pear/middleware.go
+++ b/cmd/pear/middleware.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+)
+
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.Header().
+			Set("Access-Control-Allow-Headers", "Content-Type, Authorization, habitat-auth-method, User-Agent, atproto-accept-labelers, at-proxy")
+		w.Header().Set("Access-Control-Max-Age", "86400") // Cache preflight for 24 hours
+
+		// Handle preflight OPTIONS request
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/habitat-network/habitat
 
-go 1.26
+go 1.25.7
 
 require (
 	github.com/bluesky-social/indigo v0.0.0-20260318212431-cbaa83aee9dd

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/habitat-network/habitat
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/bluesky-social/indigo v0.0.0-20260318212431-cbaa83aee9dd
@@ -171,6 +171,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/securecookie v1.1.2
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
 github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=

--- a/internal/authn/authn_context.go
+++ b/internal/authn/authn_context.go
@@ -1,0 +1,12 @@
+package authn
+
+import (
+	"context"
+
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+func FromContext(ctx context.Context) (syntax.DID, bool) {
+	did, ok := ctx.Value(callerKey).(syntax.DID)
+	return did, ok
+}

--- a/internal/authn/authn_middleware.go
+++ b/internal/authn/authn_middleware.go
@@ -1,0 +1,28 @@
+package authn
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// Make sure the key used for setting the callerDID in the context is unique;
+// an unexported type means no collisions with other packages.
+type callerCtxKey struct{}
+
+var callerKey = callerCtxKey{}
+
+func Middleware(authMethods ...Method) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callerDID, ok := Validate(w, r, authMethods...)
+			if !ok {
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), callerKey, callerDID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/internal/authn/authn_middleware_test.go
+++ b/internal/authn/authn_middleware_test.go
@@ -1,0 +1,92 @@
+package authn
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware(t *testing.T) {
+	validMethod := &testAuthMethod{expectedHeader: "valid-token"}
+
+	reached := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := Middleware(validMethod)(next)
+
+	t.Run("authenticated request sets callerDID in context and calls next", func(t *testing.T) {
+		reached = false
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set("Authorization", "valid-token")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+
+		require.True(t, reached)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+		did, ok := FromContext(r.Context())
+		require.False(t, ok, "original request context is unmodified; DID lives on the context passed to next")
+		_ = did
+	})
+
+	t.Run("unauthenticated request returns 401 and does not call next", func(t *testing.T) {
+		reached = false
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set("Authorization", "wrong-token")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+
+		require.False(t, reached)
+		require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
+	})
+}
+
+func TestMiddlewareFromContext(t *testing.T) {
+	const testDID = syntax.DID("did:web:test")
+	validMethod := &testAuthMethod{expectedHeader: "valid-token"}
+
+	var callerFromCtx syntax.DID
+	var okFromCtx bool
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callerFromCtx, okFromCtx = FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := Middleware(validMethod)(next)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "valid-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	require.True(t, okFromCtx)
+	require.Equal(t, testDID, callerFromCtx)
+}
+
+func TestFromContext(t *testing.T) {
+	t.Run("returns DID when set", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		// same package — callerKey is accessible directly
+		ctx := context.WithValue(r.Context(), callerKey, syntax.DID("did:web:test"))
+
+		did, ok := FromContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, syntax.DID("did:web:test"), did)
+	})
+
+	t.Run("returns false when not set", func(t *testing.T) {
+		_, ok := FromContext(httptest.NewRequest("GET", "/", nil).Context())
+		require.False(t, ok)
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,7 +63,7 @@ func NewServer(
 
 // PutRecord puts a potentially encrypted record (see s.inner.putRecord)
 func (s *Server) PutRecord(w http.ResponseWriter, r *http.Request) {
-	callerDID, ok := authn.Validate(w, r, s.authMethods.oauth)
+	callerDID, ok := authn.FromContext(r.Context())
 	if !ok {
 		return
 	}
@@ -206,7 +206,7 @@ func (s *Server) GetRecord(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) UploadBlob(w http.ResponseWriter, r *http.Request) {
-	callerDID, ok := authn.Validate(w, r, s.authMethods.oauth)
+	callerDID, ok := authn.FromContext(r.Context())
 	if !ok {
 		return
 	}
@@ -255,7 +255,7 @@ func (s *Server) UploadBlob(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) DeleteRecord(w http.ResponseWriter, r *http.Request) {
-	callerDID, ok := authn.Validate(w, r, s.authMethods.oauth)
+	callerDID, ok := authn.FromContext(r.Context())
 	if !ok {
 		return
 	}
@@ -419,7 +419,7 @@ func (s *Server) ListRecords(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) ListCollections(w http.ResponseWriter, r *http.Request) {
-	callerDID, ok := authn.Validate(w, r, s.authMethods.oauth)
+	callerDID, ok := authn.FromContext(r.Context())
 	if !ok {
 		return
 	}
@@ -456,7 +456,7 @@ func (s *Server) ListCollections(w http.ResponseWriter, r *http.Request) {
 // However, this is currently only used in the UI to show all the permissions a particular user has granted to other people, as a way of
 // inspecting and easily adding / removing permission grants on your data. We should rename this and/or also make it generic.
 func (s *Server) ListPermissions(w http.ResponseWriter, r *http.Request) {
-	callerDID, ok := authn.Validate(w, r, s.authMethods.oauth)
+	callerDID, ok := authn.FromContext(r.Context())
 	if !ok {
 		return
 	}
@@ -486,7 +486,7 @@ func (s *Server) ListPermissions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) AddPermission(w http.ResponseWriter, r *http.Request) {
-	callerDID, ok := authn.Validate(w, r, s.authMethods.oauth)
+	callerDID, ok := authn.FromContext(r.Context())
 	if !ok {
 		return
 	}
@@ -516,7 +516,7 @@ func (s *Server) AddPermission(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) RemovePermission(w http.ResponseWriter, r *http.Request) {
-	callerDID, ok := authn.Validate(w, r, s.authMethods.oauth)
+	callerDID, ok := authn.FromContext(r.Context())
 	if !ok {
 		return
 	}
@@ -572,7 +572,7 @@ func (s *Server) NotifyOfUpdate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) CreateClique(w http.ResponseWriter, r *http.Request) {
 	// You can only call this method on your own node.
-	callerDID, ok := authn.Validate(w, r, s.authMethods.oauth)
+	callerDID, ok := authn.FromContext(r.Context())
 	if !ok {
 		return
 	}


### PR DESCRIPTION
This is a refactor that makes it easier to make my upcoming changes for orgs.

In an upcoming PR, I want to add an orgMiddleware, which if this pear is for an org, rejects all requests by DIDs not in the org. However, adding that middleware meant duplicated authentication work, since both the middleware and the server did authentication.

Instead, do authentication in a middleware, and then we can do the org check after this middleware, with a simple lookup to the org_members database. It seems that this is also the convention for doing authentication on go http servers, and putting the authenticated user in the context.

I had already bumped my local go version which messed some stuff up, so I bumped it for the repo as well.

Follow up PRs:
1. Add the org admin APIs to pear, ensure that after deployment everything works as is (fallback to no org is valid)
2. Separate repo, org provisioning service.
3. Test end-to-end flow with create org endpoint