### PR TITLE
[pear]: build for multiple architectures

### DIFF
--- a/.github/workflows/publish-pear.yml
+++ b/.github/workflows/publish-pear.yml
@@ -34,11 +34,18 @@ jobs:
             type=raw,value={{branch}},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=ref,event=tag
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: build/debian/pear/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-pear.yml
+++ b/.github/workflows/publish-pear.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -34,9 +34,6 @@ jobs:
             type=raw,value={{branch}},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=ref,event=tag
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -46,6 +43,6 @@ jobs:
           context: .
           file: build/debian/pear/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/build/debian/pear/Dockerfile
+++ b/build/debian/pear/Dockerfile
@@ -1,7 +1,7 @@
 #### BUILD STAGE
 #### Builds the Go binaries. Uses Debian-based Go image for CGO support (required by SQLite).
 
-FROM golang:1.25.7-bookworm AS build
+FROM golang:1.26-bookworm AS build
 WORKDIR /app
 
 # Copy go module files first for better layer caching


### PR DESCRIPTION
I was testing self-hosting by manually building on my own machine and then pushing those to github container repo. but my machine is the same arch (arm64) as debian / linux but the github workflow gets built with amd64 so it failed when i pulled from master. this builds it for both architectures.


https://docs.docker.com/build/ci/github-actions/multi-platform/