### PR TITLE
[routing]: fix

### DIFF
--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -207,7 +207,7 @@ func run(_ context.Context, cmd *cli.Command) error {
 
 	// hive is the identity minting service for orgs
 	// It is incomplete and needs authz, currently anyone can mint an identity.
-	orgHive, err := hive.NewHive("members."+domain, domain, db)
+	orgHive, err := hive.NewHive(domain, domain, db)
 	if err != nil {
 		log.Fatal().Err(err).Msg("unable to setup hive (identity service for org)")
 	}


### PR DESCRIPTION
This really should be an env var or something. I set up the org service to receive at `test-org.habitat.network` and `*.test-org.habitat.network` and this is serving at domain which is the correct path, but the lookup is happening for `*.members.test-org.habitat.network`. I need to fix this more thoroughly but for now merge this so i can see if it is working in prod.