### PR TITLE
[oauth server]: refactor

### DIFF
--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -35,6 +36,7 @@ import (
 	"github.com/habitat-network/habitat/internal/forwarding"
 	"github.com/habitat-network/habitat/internal/hive"
 	"github.com/habitat-network/habitat/internal/inbox"
+	"github.com/habitat-network/habitat/internal/login"
 	"github.com/habitat-network/habitat/internal/node"
 	"github.com/habitat-network/habitat/internal/oauthserver"
 	"github.com/habitat-network/habitat/internal/org"
@@ -243,7 +245,7 @@ func run(_ context.Context, cmd *cli.Command) error {
 
 	// always public routes
 	mux.HandleFunc("/.well-known/did.json", serveDid(domain))
-	mux.HandleFunc("/client-metadata.json", oauthServer.HandleClientMetadata)
+	mux.HandleFunc("/client-metadata.json", serveClientMetadata(oauthClient))
 
 	// auth routes
 	// TODO: who is allowed to call the oauth handlers in an org?
@@ -361,6 +363,16 @@ func serveDid(domain string) http.HandlerFunc {
 	}
 }
 
+func serveClientMetadata(oauthClient pdsclient.PdsOAuthClient) http.HandlerFunc {
+	metadata := oauthClient.ClientMetadata()
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(metadata); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
 func setupDB(cmd *cli.Command) *gorm.DB {
 	var db *gorm.DB
 	var err error
@@ -443,9 +455,13 @@ func setupOAuthServer(
 	meter metric.Meter,
 	org org.Org,
 ) *oauthserver.OAuthServer {
+	loginRouter := login.NewRouter(
+		login.NewPDSProvider(oauthClient, credStore),
+		login.NewHabitatProvider(),
+	)
 	oauthServer, err := oauthserver.NewOAuthServer(
 		cmd.String(fOauthServerSecret),
-		oauthClient,
+		loginRouter,
 		sessions.NewCookieStore([]byte("my super secret signing password")),
 		node,
 		identity.DefaultDirectory(),

--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/gorilla/mux"
-	"github.com/gorilla/sessions"
 	"github.com/habitat-network/habitat/internal/authn"
 	"github.com/habitat-network/habitat/internal/clique"
 	"github.com/habitat-network/habitat/internal/encrypt"
@@ -462,7 +461,6 @@ func setupOAuthServer(
 	oauthServer, err := oauthserver.NewOAuthServer(
 		cmd.String(fOauthServerSecret),
 		loginRouter,
-		sessions.NewCookieStore([]byte("my super secret signing password")),
 		node,
 		identity.DefaultDirectory(),
 		credStore,

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as DevtoolsRouteImport } from './routes/devtools'
 import { Route as RequireAuthRouteImport } from './routes/_requireAuth'
 import { Route as RequireAuthIndexRouteImport } from './routes/_requireAuth/index'
 import { Route as OrgJoinRouteImport } from './routes/org/join'
+import { Route as LoginHabitatRouteImport } from './routes/login/habitat'
 import { Route as RequireAuthPermissionsRouteImport } from './routes/_requireAuth/permissions'
 import { Route as RequireAuthDataRouteImport } from './routes/_requireAuth/data'
 import { Route as RequireAuthForwardingTestRouteImport } from './routes/_requireAuth/_forwarding-test'
@@ -64,6 +65,11 @@ const RequireAuthIndexRoute = RequireAuthIndexRouteImport.update({
 const OrgJoinRoute = OrgJoinRouteImport.update({
   id: '/org/join',
   path: '/org/join',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginHabitatRoute = LoginHabitatRouteImport.update({
+  id: '/login/habitat',
+  path: '/login/habitat',
   getParentRoute: () => rootRouteImport,
 } as any)
 const RequireAuthPermissionsRoute = RequireAuthPermissionsRouteImport.update({
@@ -159,6 +165,7 @@ export interface FileRoutesByFullPath {
   '/onboard': typeof OnboardRoute
   '/data': typeof RequireAuthDataRoute
   '/permissions': typeof RequireAuthPermissionsRouteWithChildren
+  '/login/habitat': typeof LoginHabitatRoute
   '/org/join': typeof OrgJoinRoute
   '/': typeof RequireAuthIndexRoute
   '/collections/$collection': typeof RequireAuthCollectionsCollectionRoute
@@ -180,6 +187,7 @@ export interface FileRoutesByTo {
   '/oauth-login': typeof OauthLoginRoute
   '/onboard': typeof OnboardRoute
   '/data': typeof RequireAuthDataRoute
+  '/login/habitat': typeof LoginHabitatRoute
   '/org/join': typeof OrgJoinRoute
   '/': typeof RequireAuthIndexRoute
   '/collections/$collection': typeof RequireAuthCollectionsCollectionRoute
@@ -204,6 +212,7 @@ export interface FileRoutesById {
   '/_requireAuth/_forwarding-test': typeof RequireAuthForwardingTestRoute
   '/_requireAuth/data': typeof RequireAuthDataRoute
   '/_requireAuth/permissions': typeof RequireAuthPermissionsRouteWithChildren
+  '/login/habitat': typeof LoginHabitatRoute
   '/org/join': typeof OrgJoinRoute
   '/_requireAuth/': typeof RequireAuthIndexRoute
   '/_requireAuth/collections/$collection': typeof RequireAuthCollectionsCollectionRoute
@@ -228,6 +237,7 @@ export interface FileRouteTypes {
     | '/onboard'
     | '/data'
     | '/permissions'
+    | '/login/habitat'
     | '/org/join'
     | '/'
     | '/collections/$collection'
@@ -249,6 +259,7 @@ export interface FileRouteTypes {
     | '/oauth-login'
     | '/onboard'
     | '/data'
+    | '/login/habitat'
     | '/org/join'
     | '/'
     | '/collections/$collection'
@@ -272,6 +283,7 @@ export interface FileRouteTypes {
     | '/_requireAuth/_forwarding-test'
     | '/_requireAuth/data'
     | '/_requireAuth/permissions'
+    | '/login/habitat'
     | '/org/join'
     | '/_requireAuth/'
     | '/_requireAuth/collections/$collection'
@@ -294,6 +306,7 @@ export interface RootRouteChildren {
   ExploreRoute: typeof ExploreRoute
   OauthLoginRoute: typeof OauthLoginRoute
   OnboardRoute: typeof OnboardRoute
+  LoginHabitatRoute: typeof LoginHabitatRoute
   OrgJoinRoute: typeof OrgJoinRoute
 }
 
@@ -346,6 +359,13 @@ declare module '@tanstack/react-router' {
       path: '/org/join'
       fullPath: '/org/join'
       preLoaderRoute: typeof OrgJoinRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login/habitat': {
+      id: '/login/habitat'
+      path: '/login/habitat'
+      fullPath: '/login/habitat'
+      preLoaderRoute: typeof LoginHabitatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_requireAuth/permissions': {
@@ -544,6 +564,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExploreRoute: ExploreRoute,
   OauthLoginRoute: OauthLoginRoute,
   OnboardRoute: OnboardRoute,
+  LoginHabitatRoute: LoginHabitatRoute,
   OrgJoinRoute: OrgJoinRoute,
 }
 export const routeTree = rootRouteImport

--- a/frontend/src/routes/login/habitat.tsx
+++ b/frontend/src/routes/login/habitat.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export const Route = createFileRoute("/login/habitat")({
+  component() {
+    useEffect(() => {
+      window.location.replace(`https://${__HABITAT_DOMAIN__}/oauth-callback`);
+    }, []);
+    return <p>Logging in...</p>;
+  },
+});

--- a/internal/login/habitat.go
+++ b/internal/login/habitat.go
@@ -20,10 +20,10 @@ func (h *habitatProvider) CanHandle(id *identity.Identity) bool {
 }
 
 // Allow all logins to work for now, this is a work-in-progress
-func (h *habitatProvider) BeginLogin(_ context.Context, _ *identity.Identity) (string, []byte, error) {
-	return "", []byte("placeholder"), nil
+func (h *habitatProvider) Authorize(_ context.Context, _ *identity.Identity) (string, []byte, error) {
+	return "https://habitat.network/login/habitat", []byte("placeholder"), nil // TODO: to work in dev this should really be https://[frontend_domain]/login/habitat
 }
 
-func (h *habitatProvider) CompleteLogin(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
+func (h *habitatProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
 	return nil
 }

--- a/internal/login/habitat.go
+++ b/internal/login/habitat.go
@@ -2,7 +2,6 @@ package login
 
 import (
 	"context"
-	"errors"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -20,10 +19,11 @@ func (h *habitatProvider) CanHandle(id *identity.Identity) bool {
 	return hasHabitat && !hasPDS
 }
 
+// Allow all logins to work for now, this is a work-in-progress
 func (h *habitatProvider) BeginLogin(_ context.Context, _ *identity.Identity) (string, []byte, error) {
-	return "", nil, errors.New("habitat-native auth not yet implemented")
+	return "", []byte("placeholder"), nil
 }
 
 func (h *habitatProvider) CompleteLogin(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
-	return errors.New("habitat-native auth not yet implemented")
+	return nil
 }

--- a/internal/login/habitat.go
+++ b/internal/login/habitat.go
@@ -1,0 +1,29 @@
+package login
+
+import (
+	"context"
+	"errors"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+type habitatProvider struct{}
+
+func NewHabitatProvider() Provider { return &habitatProvider{} }
+
+func (h *habitatProvider) Type() ProviderType { return ProviderTypeHabitat }
+
+func (h *habitatProvider) CanHandle(id *identity.Identity) bool {
+	_, hasHabitat := id.Services["habitat"]
+	_, hasPDS := id.Services["atproto_pds"]
+	return hasHabitat && !hasPDS
+}
+
+func (h *habitatProvider) BeginLogin(_ context.Context, _ *identity.Identity) (string, []byte, error) {
+	return "", nil, errors.New("habitat-native auth not yet implemented")
+}
+
+func (h *habitatProvider) CompleteLogin(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
+	return errors.New("habitat-native auth not yet implemented")
+}

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -117,32 +117,32 @@ func TestPDSProvider_CanHandle(t *testing.T) {
 	require.False(t, p.CanHandle(idWithNoServices()), "identity with no services should not be handled")
 }
 
-func TestPDSProvider_BeginLogin(t *testing.T) {
+func TestPDSProvider_Authorize(t *testing.T) {
 	client := &stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}
 	p := NewPDSProvider(client, newStubCredStore())
 
-	redirect, state, err := p.BeginLogin(context.Background(), idWithPDSOnly())
+	redirect, state, err := p.Authorize(context.Background(), idWithPDSOnly())
 	require.NoError(t, err)
 	require.Equal(t, "https://pds.example.com/authorize", redirect)
 	require.NotEmpty(t, state)
 
-	// state must round-trip through CompleteLogin — verify it's valid JSON with expected fields
+	// state must round-trip through Exchange — verify it's valid JSON with expected fields
 	var s pdsProviderState
 	require.NoError(t, unmarshalProviderState(state, &s))
 	require.NotEmpty(t, s.DpopKey)
 	require.Equal(t, "verifier", s.AuthorizeState.Verifier)
 }
 
-func TestPDSProvider_CompleteLogin(t *testing.T) {
+func TestPDSProvider_Exchange(t *testing.T) {
 	credStore := newStubCredStore()
 	p := NewPDSProvider(&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}, credStore)
 	did := syntax.DID("did:web:pds.example.com")
 
-	// Obtain valid state from BeginLogin.
-	_, state, err := p.BeginLogin(context.Background(), idWithPDSOnly())
+	// Obtain valid state from Authorize.
+	_, state, err := p.Authorize(context.Background(), idWithPDSOnly())
 	require.NoError(t, err)
 
-	err = p.CompleteLogin(context.Background(), did, "code", "https://pds.example.com", state)
+	err = p.Exchange(context.Background(), did, "code", "https://pds.example.com", state)
 	require.NoError(t, err)
 
 	creds, stored := credStore.upserted[did]
@@ -163,15 +163,15 @@ func TestHabitatProvider_CanHandle(t *testing.T) {
 	require.False(t, p.CanHandle(idWithNoServices()), "identity with no services should not be handled")
 }
 
-func TestHabitatProvider_BeginLogin_AlwaysSucceeds(t *testing.T) {
+func TestHabitatProvider_Authorize_AlwaysSucceeds(t *testing.T) {
 	p := NewHabitatProvider()
-	_, _, err := p.BeginLogin(context.Background(), idWithHabitatOnly())
+	_, _, err := p.Authorize(context.Background(), idWithHabitatOnly())
 	require.NoError(t, err)
 }
 
-func TestHabitatProvider_CompleteLogin_AlwaysSucceeds(t *testing.T) {
+func TestHabitatProvider_Exchange_AlwaysSucceeds(t *testing.T) {
 	p := NewHabitatProvider()
-	err := p.CompleteLogin(context.Background(), "did:web:test", "code", "issuer", nil)
+	err := p.Exchange(context.Background(), "did:web:test", "code", "issuer", nil)
 	require.NoError(t, err)
 }
 

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1,0 +1,223 @@
+package login
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/pdsclient"
+	"github.com/habitat-network/habitat/internal/pdscred"
+	"github.com/stretchr/testify/require"
+)
+
+// stubOAuthClient is a minimal PdsOAuthClient for testing.
+type stubOAuthClient struct {
+	authorizeErr    error
+	exchangeCodeErr error
+	redirectURL     string
+}
+
+func (s *stubOAuthClient) ClientMetadata() *pdsclient.ClientMetadata { return nil }
+
+func (s *stubOAuthClient) Authorize(_ *pdsclient.DpopHttpClient, _ *identity.Identity) (string, *pdsclient.AuthorizeState, error) {
+	if s.authorizeErr != nil {
+		return "", nil, s.authorizeErr
+	}
+	return s.redirectURL, &pdsclient.AuthorizeState{
+		Verifier:      "verifier",
+		State:         "state",
+		TokenEndpoint: "https://pds.example.com/token",
+	}, nil
+}
+
+func (s *stubOAuthClient) ExchangeCode(_ *pdsclient.DpopHttpClient, _, _ string, _ *pdsclient.AuthorizeState) (*pdsclient.TokenResponse, error) {
+	if s.exchangeCodeErr != nil {
+		return nil, s.exchangeCodeErr
+	}
+	return &pdsclient.TokenResponse{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}, nil
+}
+
+func (s *stubOAuthClient) RefreshToken(_ *pdsclient.DpopHttpClient, _ *identity.Identity, _ string, _ string) (*pdsclient.TokenResponse, error) {
+	return nil, errors.New("not used in these tests")
+}
+
+// stubCredStore tracks UpsertCredentials calls.
+type stubCredStore struct {
+	upserted  map[syntax.DID]*pdscred.Credentials
+	upsertErr error
+}
+
+func newStubCredStore() *stubCredStore {
+	return &stubCredStore{upserted: make(map[syntax.DID]*pdscred.Credentials)}
+}
+
+func (s *stubCredStore) UpsertCredentials(did syntax.DID, creds *pdscred.Credentials) error {
+	if s.upsertErr != nil {
+		return s.upsertErr
+	}
+	s.upserted[did] = creds
+	return nil
+}
+
+func (s *stubCredStore) GetCredentials(did syntax.DID) (*pdscred.Credentials, error) {
+	return nil, errors.New("not used in these tests")
+}
+
+// helpers to build identities with specific service combinations
+
+func idWithPDSOnly() *identity.Identity {
+	return &identity.Identity{
+		DID: "did:web:pds.example.com",
+		Services: map[string]identity.ServiceEndpoint{
+			"atproto_pds": {URL: "https://pds.example.com"},
+		},
+	}
+}
+
+func idWithHabitatOnly() *identity.Identity {
+	return &identity.Identity{
+		DID: "did:web:habitat.example.com",
+		Services: map[string]identity.ServiceEndpoint{
+			"habitat": {URL: "https://habitat.example.com"},
+		},
+	}
+}
+
+func idWithBothServices() *identity.Identity {
+	return &identity.Identity{
+		DID: "did:web:both.example.com",
+		Services: map[string]identity.ServiceEndpoint{
+			"atproto_pds": {URL: "https://pds.example.com"},
+			"habitat":     {URL: "https://habitat.example.com"},
+		},
+	}
+}
+
+func idWithNoServices() *identity.Identity {
+	return &identity.Identity{
+		DID:      "did:web:nobody.example.com",
+		Services: map[string]identity.ServiceEndpoint{},
+	}
+}
+
+// --- pdsProvider ---
+
+func TestPDSProvider_CanHandle(t *testing.T) {
+	p := NewPDSProvider(&stubOAuthClient{}, newStubCredStore())
+
+	require.True(t, p.CanHandle(idWithPDSOnly()), "pds-only identity should be handled")
+	require.False(t, p.CanHandle(idWithHabitatOnly()), "habitat-only identity should not be handled")
+	require.False(t, p.CanHandle(idWithBothServices()), "identity with both services should not be handled")
+	require.False(t, p.CanHandle(idWithNoServices()), "identity with no services should not be handled")
+}
+
+func TestPDSProvider_BeginLogin(t *testing.T) {
+	client := &stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}
+	p := NewPDSProvider(client, newStubCredStore())
+
+	redirect, state, err := p.BeginLogin(context.Background(), idWithPDSOnly())
+	require.NoError(t, err)
+	require.Equal(t, "https://pds.example.com/authorize", redirect)
+	require.NotEmpty(t, state)
+
+	// state must round-trip through CompleteLogin — verify it's valid JSON with expected fields
+	var s pdsProviderState
+	require.NoError(t, unmarshalProviderState(state, &s))
+	require.NotEmpty(t, s.DpopKey)
+	require.Equal(t, "verifier", s.AuthorizeState.Verifier)
+}
+
+func TestPDSProvider_CompleteLogin(t *testing.T) {
+	credStore := newStubCredStore()
+	p := NewPDSProvider(&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}, credStore)
+	did := syntax.DID("did:web:pds.example.com")
+
+	// Obtain valid state from BeginLogin.
+	_, state, err := p.BeginLogin(context.Background(), idWithPDSOnly())
+	require.NoError(t, err)
+
+	err = p.CompleteLogin(context.Background(), did, "code", "https://pds.example.com", state)
+	require.NoError(t, err)
+
+	creds, stored := credStore.upserted[did]
+	require.True(t, stored, "credentials should have been upserted")
+	require.Equal(t, "access", creds.AccessToken)
+	require.Equal(t, "refresh", creds.RefreshToken)
+	require.NotNil(t, creds.DpopKey)
+}
+
+// --- habitatProvider ---
+
+func TestHabitatProvider_CanHandle(t *testing.T) {
+	p := NewHabitatProvider()
+
+	require.True(t, p.CanHandle(idWithHabitatOnly()), "habitat-only identity should be handled")
+	require.False(t, p.CanHandle(idWithPDSOnly()), "pds-only identity should not be handled")
+	require.False(t, p.CanHandle(idWithBothServices()), "identity with both services should not be handled")
+	require.False(t, p.CanHandle(idWithNoServices()), "identity with no services should not be handled")
+}
+
+func TestHabitatProvider_BeginLogin_AlwaysSucceeds(t *testing.T) {
+	p := NewHabitatProvider()
+	_, _, err := p.BeginLogin(context.Background(), idWithHabitatOnly())
+	require.NoError(t, err)
+}
+
+func TestHabitatProvider_CompleteLogin_AlwaysSucceeds(t *testing.T) {
+	p := NewHabitatProvider()
+	err := p.CompleteLogin(context.Background(), "did:web:test", "code", "issuer", nil)
+	require.NoError(t, err)
+}
+
+// --- Router ---
+
+func newTestRouter() *Router {
+	return NewRouter(
+		NewPDSProvider(&stubOAuthClient{}, newStubCredStore()),
+		NewHabitatProvider(),
+	)
+}
+
+func TestRouter_For(t *testing.T) {
+	r := newTestRouter()
+
+	p, err := r.For(idWithPDSOnly())
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypePDS, p.Type())
+
+	p, err = r.For(idWithHabitatOnly())
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypeHabitat, p.Type())
+
+	_, err = r.For(idWithBothServices())
+	require.Error(t, err, "identity with both services should have no provider")
+
+	_, err = r.For(idWithNoServices())
+	require.Error(t, err, "identity with no services should have no provider")
+}
+
+func TestRouter_ByType(t *testing.T) {
+	r := newTestRouter()
+
+	p, err := r.ByType(ProviderTypePDS)
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypePDS, p.Type())
+
+	p, err = r.ByType(ProviderTypeHabitat)
+	require.NoError(t, err)
+	require.Equal(t, ProviderTypeHabitat, p.Type())
+
+	_, err = r.ByType("unknown")
+	require.Error(t, err)
+}
+
+// unmarshalProviderState is a test helper to inspect the opaque pds state bytes.
+func unmarshalProviderState(b []byte, s *pdsProviderState) error {
+	return json.Unmarshal(b, s)
+}

--- a/internal/login/pds.go
+++ b/internal/login/pds.go
@@ -38,7 +38,7 @@ func (p *pdsProvider) CanHandle(id *identity.Identity) bool {
 	return hasPDS && !hasHabitat
 }
 
-func (p *pdsProvider) BeginLogin(_ context.Context, id *identity.Identity) (string, []byte, error) {
+func (p *pdsProvider) Authorize(_ context.Context, id *identity.Identity) (string, []byte, error) {
 	dpopKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return "", nil, fmt.Errorf("generate dpop key: %w", err)
@@ -59,7 +59,7 @@ func (p *pdsProvider) BeginLogin(_ context.Context, id *identity.Identity) (stri
 	return redirect, stateBytes, nil
 }
 
-func (p *pdsProvider) CompleteLogin(_ context.Context, did syntax.DID, code string, issuer string, stateBytes []byte) error {
+func (p *pdsProvider) Exchange(_ context.Context, did syntax.DID, code string, issuer string, stateBytes []byte) error {
 	var s pdsProviderState
 	if err := json.Unmarshal(stateBytes, &s); err != nil {
 		return fmt.Errorf("unmarshal pds provider state: %w", err)

--- a/internal/login/pds.go
+++ b/internal/login/pds.go
@@ -1,0 +1,85 @@
+package login
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/pdsclient"
+	"github.com/habitat-network/habitat/internal/pdscred"
+	"github.com/rs/zerolog/log"
+)
+
+type pdsProvider struct {
+	oauthClient pdsclient.PdsOAuthClient
+	credStore   pdscred.PDSCredentialStore
+}
+
+// pdsProviderState is the opaque flash state for the PDS login flow.
+type pdsProviderState struct {
+	DpopKey        []byte                   `json:"dpop_key"`
+	AuthorizeState pdsclient.AuthorizeState `json:"authorize_state"`
+}
+
+func NewPDSProvider(oauthClient pdsclient.PdsOAuthClient, credStore pdscred.PDSCredentialStore) Provider {
+	return &pdsProvider{oauthClient: oauthClient, credStore: credStore}
+}
+
+func (p *pdsProvider) Type() ProviderType { return ProviderTypePDS }
+
+func (p *pdsProvider) CanHandle(id *identity.Identity) bool {
+	_, hasPDS := id.Services["atproto_pds"]
+	_, hasHabitat := id.Services["habitat"]
+	return hasPDS && !hasHabitat
+}
+
+func (p *pdsProvider) BeginLogin(_ context.Context, id *identity.Identity) (string, []byte, error) {
+	dpopKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", nil, fmt.Errorf("generate dpop key: %w", err)
+	}
+	dpopClient := pdsclient.NewDpopHttpClient(dpopKey, &pdsclient.MemoryNonceProvider{})
+	redirect, state, err := p.oauthClient.Authorize(dpopClient, id)
+	if err != nil {
+		return "", nil, err
+	}
+	dpopKeyBytes, err := dpopKey.Bytes()
+	if err != nil {
+		return "", nil, fmt.Errorf("serialize dpop key: %w", err)
+	}
+	stateBytes, err := json.Marshal(pdsProviderState{DpopKey: dpopKeyBytes, AuthorizeState: *state})
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal pds provider state: %w", err)
+	}
+	return redirect, stateBytes, nil
+}
+
+func (p *pdsProvider) CompleteLogin(_ context.Context, did syntax.DID, code string, issuer string, stateBytes []byte) error {
+	var s pdsProviderState
+	if err := json.Unmarshal(stateBytes, &s); err != nil {
+		return fmt.Errorf("unmarshal pds provider state: %w", err)
+	}
+	dpopKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), s.DpopKey)
+	if err != nil {
+		return fmt.Errorf("parse dpop key: %w", err)
+	}
+	dpopClient := pdsclient.NewDpopHttpClient(dpopKey, &pdsclient.MemoryNonceProvider{})
+	tokenInfo, err := p.oauthClient.ExchangeCode(dpopClient, code, issuer, &s.AuthorizeState)
+	if err != nil {
+		return fmt.Errorf("exchange code: %w", err)
+	}
+	if err := p.credStore.UpsertCredentials(did, &pdscred.Credentials{
+		AccessToken:  tokenInfo.AccessToken,
+		RefreshToken: tokenInfo.RefreshToken,
+		DpopKey:      dpopKey,
+	}); err != nil {
+		// Log and move on since an error upserting doesn't mean the login failed
+		log.Err(err).Msgf("error upserting PDS credentials")
+	}
+	return nil
+}

--- a/internal/login/provider.go
+++ b/internal/login/provider.go
@@ -1,0 +1,66 @@
+package login
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+type ProviderType string
+
+const (
+	ProviderTypePDS     ProviderType = "pds"
+	ProviderTypeHabitat ProviderType = "habitat"
+)
+
+// Provider abstracts a login backend. Each implementation handles a specific
+// login type (ex: PDS, habitat-org-password, Identity provider / SSO) and is responsible for its own credential storage.
+type Provider interface {
+	// Type returns a stable identifier stored in the session flash so
+	// HandleCallback can route to the correct provider without re-resolving the DID.
+	Type() ProviderType
+
+	// CanHandle returns true if this provider handles the given identity.
+	CanHandle(id *identity.Identity) bool
+
+	// BeginLogin starts the auth flow and returns the redirect URL plus opaque
+	// provider-specific state to be stored in the session flash.
+	BeginLogin(ctx context.Context, id *identity.Identity) (redirectUri string, state []byte, err error)
+
+	// CompleteLogin exchanges the callback code for credentials and should persist
+	// whatever credentials the provider acquires.
+	CompleteLogin(ctx context.Context, did syntax.DID, code string, issuer string, state []byte) error
+}
+
+// Router selects the correct Provider for a given identity.
+type Router struct {
+	providers []Provider
+}
+
+func NewRouter(providers ...Provider) *Router {
+	return &Router{providers: providers}
+}
+
+// For returns the first provider whose CanHandle returns true.
+// It is assumed that only one provider matches the given identity (for now)
+func (r *Router) For(id *identity.Identity) (Provider, error) {
+	for _, p := range r.providers {
+		fmt.Println("checking id, provider", id, p.Type())
+		if p.CanHandle(id) {
+			return p, nil
+		}
+	}
+	return nil, fmt.Errorf("no login provider for identity %s", id.DID)
+}
+
+// ByType returns the provider registered for the given ProviderType.
+func (r *Router) ByType(t ProviderType) (Provider, error) {
+	for _, p := range r.providers {
+		if p.Type() == t {
+			return p, nil
+		}
+	}
+	return nil, fmt.Errorf("no login provider of type %q", t)
+}

--- a/internal/login/provider.go
+++ b/internal/login/provider.go
@@ -25,13 +25,13 @@ type Provider interface {
 	// CanHandle returns true if this provider handles the given identity.
 	CanHandle(id *identity.Identity) bool
 
-	// BeginLogin starts the auth flow and returns the redirect URL plus opaque
+	// Authorize starts the auth flow and returns the redirect URL plus opaque
 	// provider-specific state to be stored in the session flash.
-	BeginLogin(ctx context.Context, id *identity.Identity) (redirectUri string, state []byte, err error)
+	Authorize(ctx context.Context, id *identity.Identity) (redirectUri string, state []byte, err error)
 
-	// CompleteLogin exchanges the callback code for credentials and should persist
+	// Exchange exchanges the callback code for credentials and should persist
 	// whatever credentials the provider acquires.
-	CompleteLogin(ctx context.Context, did syntax.DID, code string, issuer string, state []byte) error
+	Exchange(ctx context.Context, did syntax.DID, code string, issuer string, state []byte) error
 }
 
 // Router selects the correct Provider for a given identity.
@@ -47,7 +47,6 @@ func NewRouter(providers ...Provider) *Router {
 // It is assumed that only one provider matches the given identity (for now)
 func (r *Router) For(id *identity.Identity) (Provider, error) {
 	for _, p := range r.providers {
-		fmt.Println("checking id, provider", id, p.Type())
 		if p.CanHandle(id) {
 			return p, nil
 		}

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -157,6 +157,7 @@ type OAuthServer struct {
 	directory   identity.Directory         // AT Protocol identity directory for handle resolution
 	storage     *store
 
+	// Store a map of opaque cookie id --> flash between Authorize and Callback since session cookies have a size limit
 	flashMu    sync.Mutex
 	flashStore map[string]*authRequestFlash
 
@@ -300,6 +301,8 @@ func (o *OAuthServer) HandleAuthorize(
 		utils.LogAndHTTPError(w, err, "failed to initiate authorization", http.StatusInternalServerError)
 		return
 	}
+
+	// Generate opaque flash id to store in cookie
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		o.metrics.authorizeErr(err, "gen_flash_id")
@@ -307,6 +310,7 @@ func (o *OAuthServer) HandleAuthorize(
 		return
 	}
 	flashID := hex.EncodeToString(b)
+
 	o.flashMu.Lock()
 	o.flashStore[flashID] = &authRequestFlash{
 		Form:          requester.GetRequestForm(),
@@ -315,6 +319,7 @@ func (o *OAuthServer) HandleAuthorize(
 		Did:           id.DID,
 	}
 	o.flashMu.Unlock()
+
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionName,
 		Value:    flashID,
@@ -354,10 +359,13 @@ func (o *OAuthServer) HandleCallback(
 		utils.LogAndHTTPError(w, err, "failed to get session cookie", http.StatusBadRequest)
 		return
 	}
+
+	// Lookup cookie --> flash
 	o.flashMu.Lock()
 	arf, ok := o.flashStore[cookie.Value]
 	delete(o.flashStore, cookie.Value)
 	o.flashMu.Unlock()
+
 	if !ok {
 		o.metrics.callbackErr(nil, "no_flash")
 		utils.LogAndHTTPError(w, nil, "no state found for session", http.StatusBadRequest)

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -468,7 +468,6 @@ func (o *OAuthServer) HandleToken(w http.ResponseWriter, r *http.Request) {
 	o.provider.WriteAccessResponse(ctx, w, req, resp)
 }
 
-
 var _ authn.Method = (*OAuthServer)(nil)
 
 func (o *OAuthServer) CanHandle(r *http.Request) bool {

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -4,17 +4,18 @@ package oauthserver
 
 import (
 	"context"
-	"encoding/gob"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
-	"github.com/gorilla/sessions"
 	"github.com/habitat-network/habitat/api/habitat"
 	"github.com/habitat-network/habitat/internal/authn"
 	"github.com/habitat-network/habitat/internal/encrypt"
@@ -150,12 +151,14 @@ type OAuthServer struct {
 	// The habitat service name to look up in DID docs.
 	node node.Node
 
-	provider     fosite.OAuth2Provider
-	credStore    pdscred.PDSCredentialStore // Database storage for OAuth sessions
-	sessionStore sessions.Store             // Session storage for authorization flow state
-	loginRouter  *login.Router              // Routes login flows by DID service endpoint
-	directory    identity.Directory         // AT Protocol identity directory for handle resolution
-	storage      *store
+	provider    fosite.OAuth2Provider
+	credStore   pdscred.PDSCredentialStore // Database storage for OAuth sessions
+	loginRouter *login.Router              // Routes login flows by DID service endpoint
+	directory   identity.Directory         // AT Protocol identity directory for handle resolution
+	storage     *store
+
+	flashMu    sync.Mutex
+	flashStore map[string]*authRequestFlash
 
 	// Org this server belongs to
 	org org.Org
@@ -171,18 +174,15 @@ type OAuthServer struct {
 //   - Database storage for OAuth sessions and PDS tokens
 //
 // Parameters:
-//   - oauthClient: Client for AT Protocol OAuth operations
-//   - sessionStore: Store for managing user sessions during authorization flow
+//   - loginRouter: Routes login flows by DID service endpoint
 //   - directory: AT Protocol identity directory for resolving handles to DIDs
 //   - db: GORM database connection for storing OAuth sessions
 //   - credStore: Store for PDS credentials
-//   - userStore: Store for managing users (can be nil if not needed)
 //
 // Returns a configured OAuthServer ready to handle authorization requests.
 func NewOAuthServer(
 	secret string,
 	loginRouter *login.Router,
-	sessionStore sessions.Store,
 	node node.Node,
 	directory identity.Directory,
 	credStore pdscred.PDSCredentialStore,
@@ -208,8 +208,6 @@ func NewOAuthServer(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage: %w", err)
 	}
-	// Register types for session serialization
-	gob.Register(&authRequestFlash{})
 
 	oauthMetrics, err := newMetrics(meter)
 	if err != nil {
@@ -227,13 +225,13 @@ func NewOAuthServer(
 			compose.OAuth2PKCEFactory,
 			compose.OAuth2StatelessJWTIntrospectionFactory, // Use stateless JWT introspection
 		),
-		credStore:    credStore,
-		loginRouter:  loginRouter,
-		sessionStore: sessionStore,
-		directory:    directory,
-		node:         node,
-		storage:      storage,
-		org:          org,
+		credStore:   credStore,
+		loginRouter: loginRouter,
+		flashStore:  make(map[string]*authRequestFlash),
+		directory:   directory,
+		node:        node,
+		storage:     storage,
+		org:         org,
 	}, nil
 }
 
@@ -296,28 +294,38 @@ func (o *OAuthServer) HandleAuthorize(
 		utils.LogAndHTTPError(w, err, "no login provider for identity", http.StatusBadRequest)
 		return
 	}
-	redirect, providerState, err := provider.BeginLogin(ctx, id)
+	redirect, providerState, err := provider.Authorize(ctx, id)
 	if err != nil {
 		o.metrics.authorizeErr(err, "begin_login")
 		utils.LogAndHTTPError(w, err, "failed to initiate authorization", http.StatusInternalServerError)
 		return
 	}
-	authorizeSession, _ := o.sessionStore.New(r, sessionName)
-	authorizeSession.AddFlash(&authRequestFlash{
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		o.metrics.authorizeErr(err, "gen_flash_id")
+		utils.LogAndHTTPError(w, err, "failed to generate session id", http.StatusInternalServerError)
+		return
+	}
+	flashID := hex.EncodeToString(b)
+	o.flashMu.Lock()
+	o.flashStore[flashID] = &authRequestFlash{
 		Form:          requester.GetRequestForm(),
 		ProviderType:  provider.Type(),
 		ProviderState: providerState,
 		Did:           id.DID,
-	})
-	if err := authorizeSession.Save(r, w); err != nil {
-		o.metrics.authorizeErr(err, "save_flash")
-		utils.LogAndHTTPError(w, err, "failed to save session", http.StatusInternalServerError)
-		return
 	}
+	o.flashMu.Unlock()
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionName,
+		Value:    flashID,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
+		Path:     "/oauth-callback",
+	})
 
 	http.Redirect(w, r, redirect, http.StatusSeeOther)
 	o.metrics.authorizeSuccess()
-
 }
 
 // HandleCallback processes the OAuth callback from the user's PDS.
@@ -340,23 +348,19 @@ func (o *OAuthServer) HandleCallback(
 	r *http.Request,
 ) {
 	ctx := r.Context()
-	authorizeSession, err := o.sessionStore.Get(r, sessionName)
+	cookie, err := r.Cookie(sessionName)
 	if err != nil {
 		o.metrics.callbackErr(err, "get_session")
-		utils.LogAndHTTPError(w, err, "failed to get session", http.StatusInternalServerError)
+		utils.LogAndHTTPError(w, err, "failed to get session cookie", http.StatusBadRequest)
 		return
 	}
-	flashes := authorizeSession.Flashes()
-	_ = authorizeSession.Save(r, w)
-	if len(flashes) == 0 {
-		o.metrics.callbackErr(err, "save_flash")
-		utils.LogAndHTTPError(w, err, "failed to get auth request flash", http.StatusBadRequest)
-		return
-	}
-	arf, ok := flashes[0].(*authRequestFlash)
+	o.flashMu.Lock()
+	arf, ok := o.flashStore[cookie.Value]
+	delete(o.flashStore, cookie.Value)
+	o.flashMu.Unlock()
 	if !ok {
-		o.metrics.callbackErr(err, "flash_type")
-		utils.LogAndHTTPError(w, err, "failed to parse auth request flash", http.StatusBadRequest)
+		o.metrics.callbackErr(nil, "no_flash")
+		utils.LogAndHTTPError(w, nil, "no state found for session", http.StatusBadRequest)
 		return
 	}
 
@@ -393,7 +397,7 @@ func (o *OAuthServer) HandleCallback(
 		utils.LogAndHTTPError(w, err, "no login provider for session", http.StatusBadRequest)
 		return
 	}
-	if err := provider.CompleteLogin(
+	if err := provider.Exchange(
 		ctx,
 		arf.Did,
 		r.URL.Query().Get("code"),

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -4,9 +4,6 @@ package oauthserver
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"encoding/gob"
 	"encoding/json"
 	"errors"
@@ -21,9 +18,9 @@ import (
 	"github.com/habitat-network/habitat/api/habitat"
 	"github.com/habitat-network/habitat/internal/authn"
 	"github.com/habitat-network/habitat/internal/encrypt"
+	"github.com/habitat-network/habitat/internal/login"
 	"github.com/habitat-network/habitat/internal/node"
 	"github.com/habitat-network/habitat/internal/org"
-	"github.com/habitat-network/habitat/internal/pdsclient"
 	"github.com/habitat-network/habitat/internal/pdscred"
 	"github.com/habitat-network/habitat/internal/utils"
 	"github.com/ory/fosite"
@@ -45,10 +42,10 @@ const (
 // This data is temporarily stored during the OAuth authorization flow to preserve
 // request context across redirects.
 type authRequestFlash struct {
-	Form           url.Values // Original authorization request form data
-	DpopKey        []byte
-	AuthorizeState *pdsclient.AuthorizeState // AT Protocol authorization state
-	Did            syntax.DID                // DID of the user
+	Form          url.Values         // Original authorization request form data
+	ProviderType  login.ProviderType // Which login provider initiated this flow
+	ProviderState []byte             // Opaque provider-specific state
+	Did           syntax.DID         // DID of the user
 }
 
 type metrics struct {
@@ -156,7 +153,7 @@ type OAuthServer struct {
 	provider     fosite.OAuth2Provider
 	credStore    pdscred.PDSCredentialStore // Database storage for OAuth sessions
 	sessionStore sessions.Store             // Session storage for authorization flow state
-	oauthClient  pdsclient.PdsOAuthClient   // Client for communicating with AT Protocol services
+	loginRouter  *login.Router              // Routes login flows by DID service endpoint
 	directory    identity.Directory         // AT Protocol identity directory for handle resolution
 	storage      *store
 
@@ -184,7 +181,7 @@ type OAuthServer struct {
 // Returns a configured OAuthServer ready to handle authorization requests.
 func NewOAuthServer(
 	secret string,
-	oauthClient pdsclient.PdsOAuthClient,
+	loginRouter *login.Router,
 	sessionStore sessions.Store,
 	node node.Node,
 	directory identity.Directory,
@@ -213,7 +210,6 @@ func NewOAuthServer(
 	}
 	// Register types for session serialization
 	gob.Register(&authRequestFlash{})
-	gob.Register(pdsclient.AuthorizeState{})
 
 	oauthMetrics, err := newMetrics(meter)
 	if err != nil {
@@ -232,7 +228,7 @@ func NewOAuthServer(
 			compose.OAuth2StatelessJWTIntrospectionFactory, // Use stateless JWT introspection
 		),
 		credStore:    credStore,
-		oauthClient:  oauthClient,
+		loginRouter:  loginRouter,
 		sessionStore: sessionStore,
 		directory:    directory,
 		node:         node,
@@ -293,36 +289,25 @@ func (o *OAuthServer) HandleAuthorize(
 		utils.LogAndHTTPError(w, err, "failed to lookup identity", http.StatusInternalServerError)
 		return
 	}
-	dpopKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	provider, err := o.loginRouter.For(id)
 	if err != nil {
-		o.metrics.authorizeErr(err, "gen_dpop_key")
-		utils.LogAndHTTPError(w, err, "failed to generate key", http.StatusInternalServerError)
+		o.metrics.authorizeErr(err, "no_provider")
+		utils.LogAndHTTPError(w, err, "no login provider for identity", http.StatusBadRequest)
 		return
 	}
-	dpopClient := pdsclient.NewDpopHttpClient(dpopKey, &pdsclient.MemoryNonceProvider{})
-	redirect, state, err := o.oauthClient.Authorize(dpopClient, id)
+	redirect, providerState, err := provider.BeginLogin(ctx, id)
 	if err != nil {
-		o.metrics.authorizeErr(err, fositeErrReason(err))
-		utils.LogAndHTTPError(
-			w,
-			err,
-			"failed to initiate authorization",
-			http.StatusInternalServerError,
-		)
-		return
-	}
-	dpopKeyBytes, err := dpopKey.Bytes()
-	if err != nil {
-		o.metrics.authorizeErr(err, "serialize_dpop")
-		utils.LogAndHTTPError(w, err, "failed to serialize key", http.StatusInternalServerError)
+		o.metrics.authorizeErr(err, "begin_login")
+		utils.LogAndHTTPError(w, err, "failed to initiate authorization", http.StatusInternalServerError)
 		return
 	}
 	authorizeSession, _ := o.sessionStore.New(r, sessionName)
 	authorizeSession.AddFlash(&authRequestFlash{
-		Form:           requester.GetRequestForm(),
-		AuthorizeState: state,
-		DpopKey:        dpopKeyBytes,
-		Did:            id.DID,
+		Form:          requester.GetRequestForm(),
+		ProviderType:  provider.Type(),
+		ProviderState: providerState,
+		Did:           id.DID,
 	})
 	if err := authorizeSession.Save(r, w); err != nil {
 		o.metrics.authorizeErr(err, "save_flash")
@@ -402,42 +387,21 @@ func (o *OAuthServer) HandleCallback(
 			fosite.ErrAccessDenied.WithDescription("You are not a member of this habitat organization.").WithHint(""))
 		return
 	}
-	dpopKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), arf.DpopKey)
+	provider, err := o.loginRouter.ByType(arf.ProviderType)
 	if err != nil {
-		o.metrics.callbackErr(err, "parse_dpop")
-		utils.LogAndHTTPError(w, err, "failed to parse dpop key", http.StatusBadRequest)
+		o.metrics.callbackErr(err, "no_provider")
+		utils.LogAndHTTPError(w, err, "no login provider for session", http.StatusBadRequest)
 		return
 	}
-	dpopClient := pdsclient.NewDpopHttpClient(dpopKey, &pdsclient.MemoryNonceProvider{})
-	tokenInfo, err := o.oauthClient.ExchangeCode(
-		dpopClient,
+	if err := provider.CompleteLogin(
+		ctx,
+		arf.Did,
 		r.URL.Query().Get("code"),
 		r.URL.Query().Get("iss"),
-		arf.AuthorizeState,
-	)
-	if err != nil {
-		o.metrics.callbackErr(err, fositeErrReason(err))
-		utils.LogAndHTTPError(w, err, "failed to exchange code", http.StatusInternalServerError)
-		return
-	}
-
-	// Store/update user credentials in the database with the PDS tokens
-	err = o.credStore.UpsertCredentials(
-		arf.Did,
-		&pdscred.Credentials{
-			AccessToken:  tokenInfo.AccessToken,
-			RefreshToken: tokenInfo.RefreshToken,
-			DpopKey:      dpopKey,
-		},
-	)
-	if err != nil {
-		o.metrics.callbackErr(err, "upsert_creds")
-		utils.LogAndHTTPError(
-			w,
-			err,
-			"failed to save user credentials",
-			http.StatusInternalServerError,
-		)
+		arf.ProviderState,
+	); err != nil {
+		o.metrics.callbackErr(err, "complete_login")
+		utils.LogAndHTTPError(w, err, "failed to complete login", http.StatusInternalServerError)
 		return
 	}
 
@@ -504,19 +468,6 @@ func (o *OAuthServer) HandleToken(w http.ResponseWriter, r *http.Request) {
 	o.provider.WriteAccessResponse(ctx, w, req, resp)
 }
 
-func (o *OAuthServer) HandleClientMetadata(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "application/json")
-	err := json.NewEncoder(w).Encode(o.oauthClient.ClientMetadata())
-	if err != nil {
-		utils.LogAndHTTPError(
-			w,
-			err,
-			"failed to encode client metadata",
-			http.StatusInternalServerError,
-		)
-		return
-	}
-}
 
 var _ authn.Method = (*OAuthServer)(nil)
 

--- a/internal/oauthserver/oauth_server_test.go
+++ b/internal/oauthserver/oauth_server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"github.com/habitat-network/habitat/internal/encrypt"
+	"github.com/habitat-network/habitat/internal/login"
 	"github.com/habitat-network/habitat/internal/node"
 	"github.com/habitat-network/habitat/internal/org"
 	"github.com/habitat-network/habitat/internal/pdsclient"
@@ -48,7 +49,7 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 	require.NoError(t, err)
 	oauthSrv, err := NewOAuthServer(
 		secret,
-		oauthClient,
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
 		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
@@ -67,8 +68,6 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 			oauthSrv.HandleCallback(w, r)
 		case "/token":
 			oauthSrv.HandleToken(w, r)
-		case "/client-metadata":
-			oauthSrv.HandleClientMetadata(w, r)
 		case "/resource":
 			oauthSrv.Validate(w, r)
 		default:
@@ -86,14 +85,6 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 	t.Run("CanHandle returns false without oauth header", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		require.False(t, oauthSrv.CanHandle(r))
-	})
-
-	t.Run("HandleClientMetadata returns metadata as JSON", func(t *testing.T) {
-		resp, err := server.Client().Get(server.URL + "/client-metadata")
-		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	})
 
 	t.Run("HandleAuthorize rejects request missing OAuth params", func(t *testing.T) {
@@ -154,7 +145,7 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 
 	oauthServer, err := NewOAuthServer(
 		secret,
-		oauthClient,
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
 		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
@@ -268,7 +259,7 @@ func TestOAuthServerE2E(t *testing.T) {
 
 	oauthServer, err := NewOAuthServer(
 		secret,
-		oauthClient,
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
 		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
@@ -501,7 +492,7 @@ func TestValidate(t *testing.T) {
 	newSrv := func(o org.Org) *OAuthServer {
 		s, srvErr := NewOAuthServer(
 			secret,
-			oauthClient,
+			login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
 			sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 			node.NewDummy(),
 			pdsclient.NewDummyDirectory("http://pds.url"),

--- a/internal/oauthserver/oauth_server_test.go
+++ b/internal/oauthserver/oauth_server_test.go
@@ -13,8 +13,6 @@ import (
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
-	"github.com/gorilla/securecookie"
-	"github.com/gorilla/sessions"
 	"github.com/habitat-network/habitat/internal/encrypt"
 	"github.com/habitat-network/habitat/internal/login"
 	"github.com/habitat-network/habitat/internal/node"
@@ -32,7 +30,7 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 	t.Run("NewOAuthServer rejects invalid secret", func(t *testing.T) {
 		_, err := NewOAuthServer(
 			"not-valid-base64!!!",
-			nil, nil, nil, nil, nil, nil, noop.Meter{}, org.NewEveryoneOrg(),
+			nil, nil, nil, nil, nil, noop.Meter{}, org.NewEveryoneOrg(),
 		)
 		require.Error(t, err)
 	})
@@ -50,7 +48,6 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 	oauthSrv, err := NewOAuthServer(
 		secret,
 		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
-		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -64,7 +61,7 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 		switch r.URL.Path {
 		case "/authorize":
 			oauthSrv.HandleAuthorize(w, r)
-		case "/callback":
+		case "/oauth-callback":
 			oauthSrv.HandleCallback(w, r)
 		case "/token":
 			oauthSrv.HandleToken(w, r)
@@ -97,7 +94,7 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 
 	t.Run("HandleCallback rejects request with no session flash", func(t *testing.T) {
 		// No prior /authorize call, so the session contains no flash data.
-		resp, err := server.Client().Get(server.URL + "/callback")
+		resp, err := server.Client().Get(server.URL + "/oauth-callback")
 		require.NoError(t, err)
 		defer func() { _ = resp.Body.Close() }()
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
@@ -146,7 +143,6 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 	oauthServer, err := NewOAuthServer(
 		secret,
 		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
-		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -160,7 +156,7 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 		switch r.URL.Path {
 		case "/authorize":
 			oauthServer.HandleAuthorize(w, r)
-		case "/callback":
+		case "/oauth-callback":
 			oauthServer.HandleCallback(w, r)
 		case "/token":
 			oauthServer.HandleToken(w, r)
@@ -173,7 +169,7 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 	server.Client().Jar = jar
-	clientMetadata.RedirectUris = []string{server.URL + "/callback"}
+	clientMetadata.RedirectUris = []string{server.URL + "/oauth-callback"}
 
 	verifier := oauth2.GenerateVerifier()
 	config := &oauth2.Config{
@@ -190,7 +186,7 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 				w.Header().Set("Content-Type", "application/json")
 				require.NoError(t, json.NewEncoder(w).Encode(&pdsclient.ClientMetadata{
 					ClientId:      "http://" + r.Host + "/client-metadata.json",
-					RedirectUris:  []string{"http://" + r.Host + "/callback"},
+					RedirectUris:  []string{"http://" + r.Host + "/oauth-callback"},
 					ResponseTypes: []string{"code"},
 					GrantTypes:    []string{"authorization_code", "refresh_token"},
 				}))
@@ -202,7 +198,7 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 	defer clientApp.Close()
 
 	config.ClientID = clientApp.URL + "/client-metadata.json"
-	config.RedirectURL = clientApp.URL + "/callback"
+	config.RedirectURL = clientApp.URL + "/oauth-callback"
 
 	authRequest, err := http.NewRequest(http.MethodGet, config.AuthCodeURL(
 		"test-state",
@@ -216,14 +212,14 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 		return http.ErrUseLastResponse
 	}
 
-	// Drive the flow until it hits /callback — the server follows redirects
-	// through the dummy PDS and stops at the first non-redirect from /callback.
+	// Drive the flow until it hits /oauth-callback — the server follows redirects
+	// through the dummy PDS and stops at the first non-redirect from /oauth-callback.
 	httpClient := server.Client()
 	resp, err := httpClient.Do(authRequest)
 	require.NoError(t, err)
 	_ = resp.Body.Close()
 
-	// Follow redirects manually until we reach /callback.
+	// Follow redirects manually until we reach /oauth-callback.
 	for resp.StatusCode == http.StatusSeeOther {
 		loc := resp.Header.Get("Location")
 		nextReq, reqErr := http.NewRequest(http.MethodGet, loc, nil)
@@ -231,7 +227,7 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 		resp, err = httpClient.Do(nextReq)
 		require.NoError(t, err)
 		_ = resp.Body.Close()
-		if nextReq.URL.Path == "/callback" {
+		if nextReq.URL.Path == "/oauth-callback" {
 			break
 		}
 	}
@@ -260,7 +256,6 @@ func TestOAuthServerE2E(t *testing.T) {
 	oauthServer, err := NewOAuthServer(
 		secret,
 		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
-		sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -276,7 +271,7 @@ func TestOAuthServerE2E(t *testing.T) {
 		case "/authorize":
 			oauthServer.HandleAuthorize(w, r)
 			return
-		case "/callback":
+		case "/oauth-callback":
 			oauthServer.HandleCallback(w, r)
 			return
 		case "/token":
@@ -296,7 +291,7 @@ func TestOAuthServerE2E(t *testing.T) {
 	require.NoError(t, err, "failed to create cookie jar")
 	server.Client().Jar = jar
 	// set the server's oauthClient redirectUri now that we know the url
-	clientMetadata.RedirectUris = []string{server.URL + "/callback"}
+	clientMetadata.RedirectUris = []string{server.URL + "/oauth-callback"}
 
 	// setup client app that oauth server can make requests to
 	verifier := oauth2.GenerateVerifier()
@@ -313,13 +308,13 @@ func TestOAuthServerE2E(t *testing.T) {
 				w.Header().Set("Content-Type", "application/json")
 				err := json.NewEncoder(w).Encode(&pdsclient.ClientMetadata{
 					ClientId:      "http://" + r.Host + "/client-metadata.json",
-					RedirectUris:  []string{"http://" + r.Host + "/callback"},
+					RedirectUris:  []string{"http://" + r.Host + "/oauth-callback"},
 					ResponseTypes: []string{"code"},
 					GrantTypes:    []string{"authorization_code", "refresh_token"},
 				})
 				require.NoError(t, err, "failed to encode client metadata")
 				return
-			case "/callback":
+			case "/oauth-callback":
 				ctx := context.WithValue(r.Context(), oauth2.HTTPClient, server.Client())
 				token, err := config.Exchange(
 					ctx,
@@ -339,7 +334,7 @@ func TestOAuthServerE2E(t *testing.T) {
 
 	// Set the client app's OAuth configuration now that we know the url
 	config.ClientID = clientApp.URL + "/client-metadata.json"
-	config.RedirectURL = clientApp.URL + "/callback"
+	config.RedirectURL = clientApp.URL + "/oauth-callback"
 
 	// create authorize request
 	authRequest, err := http.NewRequest(http.MethodGet, config.AuthCodeURL(
@@ -414,7 +409,7 @@ func acquireAccessToken(t *testing.T, srv *OAuthServer, clientMetadata *pdsclien
 		switch r.URL.Path {
 		case "/authorize":
 			srv.HandleAuthorize(w, r)
-		case "/callback":
+		case "/oauth-callback":
 			srv.HandleCallback(w, r)
 		case "/token":
 			srv.HandleToken(w, r)
@@ -427,7 +422,7 @@ func acquireAccessToken(t *testing.T, srv *OAuthServer, clientMetadata *pdsclien
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 	flowServer.Client().Jar = jar
-	clientMetadata.RedirectUris = []string{flowServer.URL + "/callback"}
+	clientMetadata.RedirectUris = []string{flowServer.URL + "/oauth-callback"}
 
 	verifier := oauth2.GenerateVerifier()
 	oauthCfg := &oauth2.Config{
@@ -444,11 +439,11 @@ func acquireAccessToken(t *testing.T, srv *OAuthServer, clientMetadata *pdsclien
 			w.Header().Set("Content-Type", "application/json")
 			require.NoError(t, json.NewEncoder(w).Encode(&pdsclient.ClientMetadata{
 				ClientId:      "http://" + r.Host + "/client-metadata.json",
-				RedirectUris:  []string{"http://" + r.Host + "/callback"},
+				RedirectUris:  []string{"http://" + r.Host + "/oauth-callback"},
 				ResponseTypes: []string{"code"},
 				GrantTypes:    []string{"authorization_code", "refresh_token"},
 			}))
-		case "/callback":
+		case "/oauth-callback":
 			ctx := context.WithValue(r.Context(), oauth2.HTTPClient, flowServer.Client())
 			token, exchangeErr := oauthCfg.Exchange(ctx, r.URL.Query().Get("code"), oauth2.VerifierOption(verifier))
 			require.NoError(t, exchangeErr)
@@ -460,7 +455,7 @@ func acquireAccessToken(t *testing.T, srv *OAuthServer, clientMetadata *pdsclien
 	t.Cleanup(clientApp.Close)
 
 	oauthCfg.ClientID = clientApp.URL + "/client-metadata.json"
-	oauthCfg.RedirectURL = clientApp.URL + "/callback"
+	oauthCfg.RedirectURL = clientApp.URL + "/oauth-callback"
 
 	authReq, err := http.NewRequest(http.MethodGet,
 		oauthCfg.AuthCodeURL("test-state", oauth2.S256ChallengeOption(verifier))+"&handle=did:web:test",
@@ -493,7 +488,6 @@ func TestValidate(t *testing.T) {
 		s, srvErr := NewOAuthServer(
 			secret,
 			login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
-			sessions.NewCookieStore(securecookie.GenerateRandomKey(32)),
 			node.NewDummy(),
 			pdsclient.NewDummyDirectory("http://pds.url"),
 			credStore,

--- a/internal/org/server.go
+++ b/internal/org/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -351,7 +350,6 @@ func (s *Server) MintMemberIdentity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("got req", req)
 	id, err := s.org.CreateNewMemberIdentity(r.Context(), req.Token, req.Handle)
 	if errors.Is(err, ErrInvalidToken) {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
@@ -361,7 +359,6 @@ func (s *Server) MintMemberIdentity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("created identity", id)
 	output := habitat.NetworkHabitatOrgMintMemberIdentityOutput{
 		Did:    id.DID.String(),
 		Handle: id.Handle.String(),

--- a/internal/pdsclient/dummy_directory.go
+++ b/internal/pdsclient/dummy_directory.go
@@ -55,9 +55,6 @@ func (d *DummyDirectory) getIdentity(did string) *identity.Identity {
 			"atproto_pds": {
 				URL: d.pdsUrl,
 			},
-			"habitat": {
-				URL: "https://habitat.network",
-			},
 		},
 		Keys: map[string]identity.VerificationMethod{
 			"atproto": {

--- a/internal/pdsclient/dummy_directory.go
+++ b/internal/pdsclient/dummy_directory.go
@@ -9,14 +9,32 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
 
+type options struct {
+	withHabitatService bool
+}
+
+type Option func(*options)
+
+func WithHabitatService() Option {
+	return func(o *options) {
+		o.withHabitatService = true
+	}
+}
+
 type DummyDirectory struct {
+	options    *options
 	pdsUrl     string
 	PrivateKey *atcrypto.PrivateKeyK256
 }
 
-func NewDummyDirectory(pdsUrl string) *DummyDirectory {
+func NewDummyDirectory(pdsUrl string, opts ...Option) *DummyDirectory {
+	o := &options{}
+	for _, opt := range opts {
+		opt(o)
+	}
 	privateKey, _ := atcrypto.GeneratePrivateKeyK256()
 	return &DummyDirectory{
+		options:    o,
 		pdsUrl:     pdsUrl,
 		PrivateKey: privateKey,
 	}
@@ -49,7 +67,7 @@ func (d *DummyDirectory) Purge(ctx context.Context, atid syntax.AtIdentifier) er
 
 func (d *DummyDirectory) getIdentity(did string) *identity.Identity {
 	publicKey, _ := d.PrivateKey.PublicKey()
-	return &identity.Identity{
+	id := &identity.Identity{
 		DID: syntax.DID(did),
 		Services: map[string]identity.ServiceEndpoint{
 			"atproto_pds": {
@@ -63,4 +81,10 @@ func (d *DummyDirectory) getIdentity(did string) *identity.Identity {
 			},
 		},
 	}
+	if d.options.withHabitatService {
+		id.Services["habitat"] = identity.ServiceEndpoint{
+			URL: "https://habitat.network",
+		}
+	}
+	return id
 }

--- a/internal/xrpcchannel/xrpc_channel_test.go
+++ b/internal/xrpcchannel/xrpc_channel_test.go
@@ -22,7 +22,7 @@ func TestServiceProxyXrpcChannel(t *testing.T) {
 	channel := NewServiceProxyXrpcChannel(
 		"habitat",
 		pdsclient.NewDummyClientFactory(server.URL),
-		pdsclient.NewDummyDirectory(server.URL),
+		pdsclient.NewDummyDirectory(server.URL, pdsclient.WithHabitatService()),
 	)
 	req, err := http.NewRequest("GET", "/xrpc/network.habitat.repo.getRecord", nil)
 	require.NoError(t, err)

--- a/typescript/internal/src/authManager.ts
+++ b/typescript/internal/src/authManager.ts
@@ -86,12 +86,17 @@ export class AuthManager {
     }
     const state = localStorage.getItem(stateLocalStorageKey);
     if (!state) {
-      throw new Error("No state found");
+      // State is missing — the browser session was cleared or a prior exchange
+      // failed. Redirect to login so the user can retry.
+      window.location.href = `/oauth-login?error=${encodeURIComponent("Login session expired. Please try again.")}`;
+      return false;
     }
-    localStorage.removeItem(stateLocalStorageKey);
     const token = await client.authorizationCodeGrant(this.config, url, {
       expectedState: state,
     });
+    // Only remove state after a successful exchange so a failed exchange
+    // (network error, etc.) can be retried without losing the state.
+    localStorage.removeItem(stateLocalStorageKey);
     this.setAuthState(token);
     // Remove code and state from URL
     url.searchParams.delete("code");


### PR DESCRIPTION
Refactor the oauth server to take in login.Router which routes to login.Providers which do the actual flow + deal with any credentials. For now, always allow true from the habitat service login, just so we can start testing this.