### PR TITLE
[claude]: workflows

### DIFF
--- a/.github/workflows/claude-address-review.yml
+++ b/.github/workflows/claude-address-review.yml
@@ -6,7 +6,14 @@ on:
 
 jobs:
   fix:
-    if: ${{ github.event.review.state == 'changes_requested' && github.event.pull_request.draft == false && github.event.review.user.login != 'github-actions[bot]' }}
+    if: ${{
+      github.event.pull_request.draft == false &&
+      github.event.review.user.login != 'github-actions[bot]' &&
+      (
+        (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested' && contains(github.event.pull_request.labels.*.name, 'claude-address-review')) ||
+        (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'claude-address-review')
+      )
+    }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,6 +33,7 @@ jobs:
 
             Address the review comments on this PR.
             - Only fix what you are confident about and is straightforward.
+            - Only address comments that have not already been resolved, responded to, or fixed in the code.
             - Run tests before committing.
             - Commit with message "claude: <what you did>"
             - Post a PR comment summarizing what you addressed and what you left for the human

--- a/.github/workflows/claude-address-review.yml
+++ b/.github/workflows/claude-address-review.yml
@@ -9,6 +9,7 @@ jobs:
     if: ${{
       github.event.pull_request.draft == false &&
       github.event.review.user.login != 'github-actions[bot]' &&
+      (github.event.pull_request.user.login == 'arushibandi' || github.event.pull_request.user.login == 'sashankg') &&
       (
         (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested' && contains(github.event.pull_request.labels.*.name, 'claude-address-review')) ||
         (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'claude-address-review')

--- a/.github/workflows/claude-address-review.yml
+++ b/.github/workflows/claude-address-review.yml
@@ -1,0 +1,31 @@
+# .github/workflows/claude-address-review.yml
+name: Claude Address Review Comments
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  fix:
+    if: ${{ github.event.review.state == 'changes_requested' && github.event.pull_request.draft == false && github.event.review.user.login != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          max_turns: "10"
+          prompt: |
+            Read .claude/skills/pr-review/SKILL.md and follow it exactly. 
+
+            Address the review comments on this PR.
+            - Only fix what you are confident about and is straightforward.
+            - Run tests before committing.
+            - Commit with message "claude: <what you did>"
+            - Post a PR comment summarizing what you addressed and what you left for the human

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   implement:
-    if: github.event.label.name == 'for-claude'
+    if: ${{ github.event.label.name == 'for-claude' && (github.event.issue.user.login == 'arushibandi' || github.event.issue.user.login == 'sashankg') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,7 +19,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          max_turns: "25"
           prompt: |
+            Read CLAUDE.md before starting.
             Implement the feature described in this issue. 
             Follow all conventions in CLAUDE.md.
             Run tests before finishing.

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -1,0 +1,27 @@
+# .github/workflows/claude-implement.yml
+name: Claude Implement Feature
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: github.event.label.name == 'for-claude'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Implement the feature described in this issue. 
+            Follow all conventions in CLAUDE.md.
+            Run tests before finishing.
+            Open a PR referencing this issue when done.
+            If you get stuck or it starts to get complicated, stop, clean up your work and make a draft PR with why you stopped in the description.


### PR DESCRIPTION
I want to add two workflows:
1. Be able to create an issue and have claude go and try to implement it (doing this only on issues opened by arushi or sashank with the label `for-claude`). 
2. Have claude take a first pass to address PR review comments (this is helpful for me on frontend PR reviews from sashank because i pass a lot of these comments directly to claude anyways since i am not learning frontend at the moment)