### PR TITLE
[Auth] Support auth method per org

### DIFF
--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -183,7 +183,7 @@ func run(_ context.Context, cmd *cli.Command) error {
 	orgLoginProvider := org.NewLoginProvider(orgStore, cmd.String(fFrontendDomain), oauthSecret)
 
 	loginRouter := login.NewRouter(
-		login.NewPDSProvider(oauthClient, pdsCredStore),
+		login.NewPDSProvider(oauthClient, pdsCredStore, nil, dir),
 		orgLoginProvider,
 	)
 

--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -185,10 +185,11 @@ func run(_ context.Context, cmd *cli.Command) error {
 		cmd.String(fDomain),
 		cmd.String(fFrontendDomain),
 		oauthSecret,
+		dir,
 	)
 
 	loginRouter := login.NewRouter(
-		login.NewPDSProvider(oauthClient, pdsCredStore, nil, dir),
+		login.NewPDSProvider(oauthClient, pdsCredStore, dir),
 		orgLoginProvider,
 	)
 

--- a/docs/superpowers/plans/2026-05-15-oauth-login-methods-plan.md
+++ b/docs/superpowers/plans/2026-05-15-oauth-login-methods-plan.md
@@ -1,0 +1,938 @@
+# OAuth Login Methods Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route OAuth login providers based on an org's login method instead of inspecting identity services via `CanHandle`.
+
+**Architecture:** Each org stores a `LoginMethod` ("atproto", "google", "password"). The `Provider` interface replaces `Type()`/`CanHandle()` with `LoginMethod()`. The Router dispatches via `map[string]Provider` keyed by login method. `HandleAuthorize` looks up the org after resolving the handle to determine the provider. The `pdsProvider` gains a `PublicDIDMappingStore` to resolve org DIDs to public ATProto DIDs. A new `googleProvider` stubs Google Sign-In.
+
+**Tech Stack:** Go, Fosite, GORM, AT Protocol (indigo)
+
+---
+
+### Task 1: Org model — add LoginMethod
+
+**Files:**
+- Modify: `internal/org/models.go` (add field)
+- Modify: `internal/org/org.go` (add interface method)
+- Modify: `internal/org/store.go` (implement, propagate in CreateOrg)
+- Modify: `internal/org/public.go` (everyoneOrg implementation)
+- Test: `internal/org/org_test.go`, `internal/org/public_test.go`
+
+**Step 1.1: Add LoginMethod to the organization model**
+
+`internal/org/models.go` — add `LoginMethod` field:
+
+```go
+type organization struct {
+	ID            string `gorm:"primaryKey"`
+	Name          string // optional display name
+	LoginMethod   string // "atproto", "google", "password"
+	SigningSecret string // base64-encoded HMAC-SHA256 key for invite tokens
+	CreatedAt     time.Time
+}
+```
+
+**Step 1.2: Add LoginMethod to the Org interface**
+
+`internal/org/org.go` — add to `Org` interface:
+
+```go
+type Org interface {
+	// LoginMethod returns how users authenticate: "atproto", "google", or "password".
+	LoginMethod() string
+	// ... all existing methods unchanged ...
+}
+```
+
+**Step 1.3: Implement LoginMethod on orgImpl**
+
+`internal/org/store.go` — add to `orgImpl`:
+
+```go
+func (s *orgImpl) LoginMethod() string {
+	var org organization
+	if err := s.db.First(&org, "id = ?", s.orgID).Error; err != nil {
+		return "password" // safe default
+	}
+	return org.LoginMethod
+}
+```
+
+**Step 1.4: Update orgFromModel to propagate LoginMethod**
+
+`internal/org/store.go` — `orgFromModel` needs no changes since `orgImpl` reads LoginMethod from DB directly in step 1.3.
+
+**Step 1.5: Update CreateOrg to set LoginMethod**
+
+`internal/org/store.go` — in `CreateOrg`, update the org creation to include `LoginMethod`:
+
+```go
+err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	if err := tx.Create(&organization{
+		ID:            orgID,
+		Name:          name,
+		LoginMethod:   "password",  // new orgs default to password auth
+		SigningSecret: signingSecret,
+		CreatedAt:     time.Now(),
+	}).Error; err != nil {
+```
+
+**Step 1.6: Add LoginMethod to everyoneOrg**
+
+`internal/org/public.go`:
+
+```go
+func (e *everyoneOrg) LoginMethod() string {
+	return "atproto"
+}
+```
+
+**Step 1.7: Run existing tests to verify no regression**
+
+```bash
+go test ./internal/org/... -v -run "TestEveryoneOrg|TestIsMember|TestCreateOrg" -count=1
+```
+
+Expected: all pass.
+
+**Step 1.8: Commit**
+
+```bash
+git add internal/org/models.go internal/org/org.go internal/org/store.go internal/org/public.go
+git commit -m "feat: add LoginMethod field to org model and interface"
+```
+
+---
+
+### Task 2: Update LoginProvider (password) to new Provider interface
+
+**Files:**
+- Modify: `internal/org/login_provider.go`
+- Test: `internal/org/login_provider_test.go`
+
+**Step 2.1: Replace Type() with LoginMethod(), remove CanHandle()**
+
+`internal/org/login_provider.go`:
+
+```go
+func (p *LoginProvider) LoginMethod() string { return "password" }
+```
+
+Remove the `Type()` method and `CanHandle()` method entirely.
+
+**Step 2.2: Update tests**
+
+`internal/org/login_provider_test.go` — update `TestLoginProvider_Type`:
+
+```go
+func TestLoginProvider_LoginMethod(t *testing.T) {
+	p, _ := newTestLoginProvider(t)
+	require.Equal(t, "password", p.LoginMethod())
+}
+```
+
+Remove `TestLoginProvider_CanHandle` entirely.
+
+**Step 2.3: Run tests**
+
+```bash
+go test ./internal/org/... -v -run "TestLoginProvider" -count=1
+```
+
+Expected: TestLoginProvider_LoginMethod passes, TestLoginProvider_CanHandle no longer exists.
+
+**Step 2.4: Commit**
+
+```bash
+git add internal/org/login_provider.go internal/org/login_provider_test.go
+git commit -m "refactor: replace Type/CanHandle on LoginProvider with LoginMethod"
+```
+
+---
+
+### Task 3: Rewrite Provider interface and Router
+
+**Files:**
+- Modify: `internal/login/provider.go`
+- Test: `internal/login/login_test.go`
+
+**Step 3.1: Rewrite Provider interface and Router**
+
+`internal/login/provider.go` — replace entire file:
+
+```go
+package login
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+// Provider abstracts a login backend. Each implementation handles a specific
+// login method (e.g., "atproto", "google", "password") and is responsible for
+// its own credential storage.
+type Provider interface {
+	// LoginMethod returns a stable identifier used to route authorization
+	// requests to the correct provider based on the org's configured method.
+	LoginMethod() string
+
+	// Authorize starts the auth flow and returns the redirect URL plus opaque
+	// provider-specific state to be stored in the session flash.
+	Authorize(ctx context.Context, id *identity.Identity) (redirectUri string, state []byte, err error)
+
+	// Exchange exchanges the callback code for credentials and should persist
+	// whatever credentials the provider acquires.
+	Exchange(ctx context.Context, did syntax.DID, code string, issuer string, state []byte) error
+}
+
+// Router selects the correct Provider for a given login method.
+type Router struct {
+	providers map[string]Provider
+}
+
+func NewRouter(providers ...Provider) *Router {
+	r := &Router{providers: make(map[string]Provider, len(providers))}
+	for _, p := range providers {
+		r.providers[p.LoginMethod()] = p
+	}
+	return r
+}
+
+// ByLoginMethod returns the provider registered for the given login method.
+func (r *Router) ByLoginMethod(method string) (Provider, error) {
+	p, ok := r.providers[method]
+	if !ok {
+		return nil, fmt.Errorf("no login provider for method %q", method)
+	}
+	return p, nil
+}
+```
+
+**Step 3.2: Remove ProviderType constants** — they're gone. Remove `ProviderType`, `ProviderTypePDS`, `ProviderTypeHabitat`.
+
+**Step 3.3: Update tests**
+
+`internal/login/login_test.go` — update:
+
+Remove `TestPDSProvider_CanHandle`. Update `dummyProvider` to implement new interface:
+
+```go
+type dummyProvider struct{}
+
+func NewDummyProvider() Provider { return &dummyProvider{} }
+
+func (d *dummyProvider) LoginMethod() string { return "password" }
+func (d *dummyProvider) Authorize(_ context.Context, _ *identity.Identity) (string, []byte, error) {
+	return "https://dummy.example.com/login", nil, nil
+}
+func (d *dummyProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
+	return nil
+}
+```
+
+Replace Router tests:
+
+```go
+func newTestRouter() *Router {
+	return NewRouter(
+		NewPDSProvider(&stubOAuthClient{}, newStubCredStore(), &stubMappingStore{}, nil),
+		NewDummyProvider(),
+	)
+}
+
+func TestRouter_ByLoginMethod(t *testing.T) {
+	r := newTestRouter()
+
+	p, err := r.ByLoginMethod("atproto")
+	require.NoError(t, err)
+	require.Equal(t, "atproto", p.LoginMethod())
+
+	p, err = r.ByLoginMethod("password")
+	require.NoError(t, err)
+	require.Equal(t, "password", p.LoginMethod())
+
+	_, err = r.ByLoginMethod("unknown")
+	require.Error(t, err)
+}
+```
+
+Remove `TestRouter_For` and `TestRouter_ByType` entirely.
+
+Also update `TestPDSProvider_Authorize` and `TestPDSProvider_Exchange` — they call `NewPDSProvider` which now needs new args. Update them:
+
+```go
+func TestPDSProvider_Authorize(t *testing.T) {
+	client := &stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}
+	p := NewPDSProvider(client, newStubCredStore(), &stubMappingStore{}, nil)
+
+	redirect, state, err := p.Authorize(context.Background(), idWithPDSOnly())
+	require.NoError(t, err)
+	require.Equal(t, "https://pds.example.com/authorize", redirect)
+	require.NotEmpty(t, state)
+
+	var s pdsProviderState
+	require.NoError(t, unmarshalProviderState(state, &s))
+	require.NotEmpty(t, s.DpopKey)
+	require.Equal(t, "verifier", s.AuthorizeState.Verifier)
+}
+
+func TestPDSProvider_Exchange(t *testing.T) {
+	credStore := newStubCredStore()
+	p := NewPDSProvider(&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}, credStore, &stubMappingStore{}, nil)
+	did := syntax.DID("did:web:pds.example.com")
+
+	_, state, err := p.Authorize(context.Background(), idWithPDSOnly())
+	require.NoError(t, err)
+
+	err = p.Exchange(context.Background(), did, "code", "https://pds.example.com", state)
+	require.NoError(t, err)
+
+	creds, stored := credStore.upserted[did]
+	require.True(t, stored, "credentials should have been upserted")
+	require.Equal(t, "access", creds.AccessToken)
+	require.Equal(t, "refresh", creds.RefreshToken)
+	require.NotNil(t, creds.DpopKey)
+}
+```
+
+Add the stubMappingStore before the test file's type definitions:
+
+```go
+type stubMappingStore struct{}
+
+func (s *stubMappingStore) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
+	return nil, nil // no mapping — use identity as-is
+}
+```
+
+**Step 3.4: Run tests**
+
+```bash
+go test ./internal/login/... -v -count=1
+```
+
+Expected: all tests pass.
+
+**Step 3.5: Commit**
+
+```bash
+git add internal/login/provider.go internal/login/login_test.go
+git commit -m "refactor: replace ProviderType/CanHandle with LoginMethod-based routing"
+```
+
+---
+
+### Task 4: Update pdsProvider with mapping store
+
+**Files:**
+- Modify: `internal/login/pds.go`
+- Test: `internal/login/login_test.go` (already updated in Task 3)
+
+**Step 4.1: Add PublicDIDMappingStore interface and update pdsProvider**
+
+`internal/login/pds.go` — add interface at top of file, update struct and constructor:
+
+```go
+// PublicDIDMappingStore resolves an org's internal DID to its public
+// AT Protocol DID for the purposes of initiating PDS OAuth flows.
+type PublicDIDMappingStore interface {
+	GetPublicDID(ctx context.Context, orgDID syntax.DID) (*syntax.DID, error)
+}
+
+type pdsProvider struct {
+	loginMethod  string
+	oauthClient  pdsclient.PdsOAuthClient
+	credStore    pdscred.PDSCredentialStore
+	mappingStore PublicDIDMappingStore
+	dir          identity.Directory
+}
+
+func NewPDSProvider(oauthClient pdsclient.PdsOAuthClient, credStore pdscred.PDSCredentialStore, mappingStore PublicDIDMappingStore, dir identity.Directory) Provider {
+	return &pdsProvider{
+		loginMethod:  "atproto",
+		oauthClient:  oauthClient,
+		credStore:    credStore,
+		mappingStore: mappingStore,
+		dir:          dir,
+	}
+}
+```
+
+**Step 4.2: Replace Type() with LoginMethod(), remove CanHandle()**
+
+```go
+func (p *pdsProvider) LoginMethod() string { return p.loginMethod }
+```
+
+Remove `Type()` and `CanHandle()` methods.
+
+**Step 4.3: Update Authorize to check mapping**
+
+```go
+func (p *pdsProvider) Authorize(ctx context.Context, id *identity.Identity) (string, []byte, error) {
+	// If there's a mapping from org DID to public ATProto DID, resolve the
+	// public identity and use its PDS for the OAuth flow.
+	publicDID, err := p.mappingStore.GetPublicDID(ctx, id.DID)
+	if err == nil && publicDID != nil && p.dir != nil {
+		publicID, lookupErr := p.dir.LookupDID(ctx, *publicDID)
+		if lookupErr == nil {
+			id = publicID
+		}
+	}
+
+	dpopKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", nil, fmt.Errorf("generate dpop key: %w", err)
+	}
+	dpopClient := pdsclient.NewDpopHttpClient(dpopKey, &pdsclient.MemoryNonceProvider{})
+	redirect, state, err := p.oauthClient.Authorize(dpopClient, id)
+	if err != nil {
+		return "", nil, err
+	}
+	dpopKeyBytes, err := dpopKey.Bytes()
+	if err != nil {
+		return "", nil, fmt.Errorf("serialize dpop key: %w", err)
+	}
+	stateBytes, err := json.Marshal(pdsProviderState{DpopKey: dpopKeyBytes, AuthorizeState: *state})
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal pds provider state: %w", err)
+	}
+	return redirect, stateBytes, nil
+}
+```
+
+**Step 4.4: Add test for mapping store behavior**
+
+`internal/login/login_test.go` — add:
+
+```go
+func TestPDSProvider_AuthorizeWithMapping(t *testing.T) {
+	mappedDID := syntax.DID("did:plc:mapped-public")
+	mapping := &stubMappingStoreWithMapping{mapped: mappedDID}
+	client := &stubOAuthClient{redirectURL: "https://public-pds.example.com/authorize"}
+	dir := &stubDirectory{dids: map[syntax.DID]*identity.Identity{
+		mappedDID: {
+			DID:    mappedDID,
+			Handle: "org.public.example.com",
+			Services: map[string]identity.ServiceEndpoint{
+				"atproto_pds": {URL: "https://public-pds.example.com"},
+			},
+		},
+	}}
+	p := NewPDSProvider(client, newStubCredStore(), mapping, dir)
+
+	// An org-internal identity (habitat DID) should resolve to the mapped public identity
+	orgID := &identity.Identity{
+		DID: "did:web:internal.org.example.com",
+		Services: map[string]identity.ServiceEndpoint{
+			"habitat": {URL: "https://habitat.example.com"},
+		},
+	}
+	redirect, state, err := p.Authorize(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, "https://public-pds.example.com/authorize", redirect)
+	require.NotEmpty(t, state)
+}
+
+type stubMappingStoreWithMapping struct {
+	mapped syntax.DID
+}
+
+func (s *stubMappingStoreWithMapping) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
+	return &s.mapped, nil
+}
+
+type stubDirectory struct {
+	dids map[syntax.DID]*identity.Identity
+}
+
+func (d *stubDirectory) LookupHandle(_ context.Context, _ syntax.Handle) (*identity.Identity, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *stubDirectory) LookupDID(_ context.Context, did syntax.DID) (*identity.Identity, error) {
+	id, ok := d.dids[did]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return id, nil
+}
+
+func (d *stubDirectory) Purge(_ context.Context) {}
+```
+
+**Step 4.5: Run tests**
+
+```bash
+go test ./internal/login/... -v -count=1
+```
+
+Expected: all tests pass, including the new mapping test.
+
+**Step 4.6: Commit**
+
+```bash
+git add internal/login/pds.go internal/login/login_test.go
+git commit -m "feat: add public DID mapping store to pdsProvider"
+```
+
+---
+
+### Task 5: Create googleProvider stub
+
+**Files:**
+- Create: `internal/login/google.go`
+- Test: `internal/login/login_test.go`
+
+**Step 5.1: Create googleProvider**
+
+`internal/login/google.go`:
+
+```go
+package login
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+// GoogleEmailMappingStore resolves an org DID to the email address used
+// for Google Sign-In.
+type GoogleEmailMappingStore interface {
+	GetEmail(ctx context.Context, orgDID syntax.DID) (string, error)
+}
+
+type googleProvider struct {
+	loginMethod  string
+	mappingStore GoogleEmailMappingStore
+}
+
+func NewGoogleProvider(mappingStore GoogleEmailMappingStore) Provider {
+	return &googleProvider{
+		loginMethod:  "google",
+		mappingStore: mappingStore,
+	}
+}
+
+func (p *googleProvider) LoginMethod() string { return p.loginMethod }
+
+func (p *googleProvider) Authorize(ctx context.Context, id *identity.Identity) (string, []byte, error) {
+	email, err := p.mappingStore.GetEmail(ctx, id.DID)
+	if err != nil {
+		return "", nil, fmt.Errorf("lookup google email for org %s: %w", id.DID, err)
+	}
+	if email == "" {
+		return "", nil, fmt.Errorf("no google email configured for org %s", id.DID)
+	}
+	// TODO: implement Google OAuth initiation with login_hint=email
+	_ = email
+	return "", nil, fmt.Errorf("google provider not yet implemented")
+}
+
+func (p *googleProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
+	// TODO: implement Google OAuth callback handling
+	return fmt.Errorf("google provider not yet implemented")
+}
+```
+
+**Step 5.2: Add basic test for googleProvider**
+
+`internal/login/login_test.go` — add:
+
+```go
+func TestGoogleProvider_LoginMethod(t *testing.T) {
+	p := NewGoogleProvider(&stubGoogleMappingStore{})
+	require.Equal(t, "google", p.LoginMethod())
+}
+
+type stubGoogleMappingStore struct{}
+
+func (s *stubGoogleMappingStore) GetEmail(_ context.Context, _ syntax.DID) (string, error) {
+	return "", nil
+}
+```
+
+**Step 5.3: Run tests**
+
+```bash
+go test ./internal/login/... -v -count=1
+```
+
+Expected: all pass.
+
+**Step 5.4: Commit**
+
+```bash
+git add internal/login/google.go internal/login/login_test.go
+git commit -m "feat: add googleProvider stub"
+```
+
+---
+
+### Task 6: Update OAuth server — org-based routing
+
+**Files:**
+- Modify: `internal/oauthserver/oauth_server.go`
+- Test: `internal/oauthserver/oauth_server_test.go`
+
+**Step 6.1: Replace ProviderType with LoginMethod in authRequestFlash**
+
+`internal/oauthserver/oauth_server.go`:
+
+```go
+type authRequestFlash struct {
+	Form          url.Values  // Original authorization request form data
+	LoginMethod   string      // Which login method initiated this flow
+	ProviderState []byte      // Opaque provider-specific state
+	Did           syntax.DID  // DID of the user
+}
+```
+
+**Step 6.2: Update HandleAuthorize to lookup org and route by login method**
+
+Replace the relevant section:
+
+```go
+func (o *OAuthServer) HandleAuthorize(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	ctx := r.Context()
+	requester, err := o.provider.NewAuthorizeRequest(ctx, r)
+	if err != nil {
+		o.metrics.authorizeErr(err, fositeErrReason(err))
+		o.provider.WriteAuthorizeError(ctx, w, requester, err)
+		return
+	}
+	if err = r.ParseForm(); err != nil {
+		o.metrics.authorizeErr(err, "parse_form")
+		utils.LogAndHTTPError(w, err, "failed to parse form", http.StatusBadRequest)
+		return
+	}
+	handle := r.Form.Get("handle")
+	atid, err := syntax.ParseAtIdentifier(handle)
+	if err != nil {
+		o.metrics.authorizeErr(err, "parse_handle")
+		utils.LogAndHTTPError(w, err, "failed to parse handle", http.StatusBadRequest)
+		return
+	}
+	id, err := o.directory.Lookup(ctx, atid)
+	if err != nil {
+		o.metrics.authorizeErr(err, "lookup_atid")
+		utils.LogAndHTTPError(w, err, "failed to lookup identity", http.StatusInternalServerError)
+		return
+	}
+
+	// Look up org to determine the login method
+	org, err := o.orgStore.GetOrgForDID(ctx, id.DID)
+	if err != nil {
+		o.metrics.authorizeErr(err, "no_org")
+		utils.LogAndHTTPError(w, err, "no org found for identity", http.StatusBadRequest)
+		return
+	}
+
+	provider, err := o.loginRouter.ByLoginMethod(org.LoginMethod())
+	if err != nil {
+		o.metrics.authorizeErr(err, "no_provider")
+		utils.LogAndHTTPError(w, err, "no login provider for org", http.StatusBadRequest)
+		return
+	}
+	redirect, providerState, err := provider.Authorize(ctx, id)
+	if err != nil {
+		o.metrics.authorizeErr(err, "begin_login")
+		utils.LogAndHTTPError(w, err, "failed to initiate authorization", http.StatusInternalServerError)
+		return
+	}
+
+	// Generate opaque flash id to store in cookie
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		o.metrics.authorizeErr(err, "gen_flash_id")
+		utils.LogAndHTTPError(w, err, "failed to generate session id", http.StatusInternalServerError)
+		return
+	}
+	flashID := hex.EncodeToString(b)
+
+	o.flashMu.Lock()
+	o.flashStore[flashID] = &authRequestFlash{
+		Form:          requester.GetRequestForm(),
+		LoginMethod:   provider.LoginMethod(),
+		ProviderState: providerState,
+		Did:           id.DID,
+	}
+	o.flashMu.Unlock()
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionName,
+		Value:    flashID,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
+		Path:     "/oauth-callback",
+	})
+
+	http.Redirect(w, r, redirect, http.StatusSeeOther)
+	o.metrics.authorizeSuccess()
+}
+```
+
+**Step 6.3: Update HandleCallback to route by login method**
+
+Replace the relevant section:
+
+```go
+func (o *OAuthServer) HandleCallback(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	ctx := r.Context()
+	cookie, err := r.Cookie(sessionName)
+	if err != nil {
+		o.metrics.callbackErr(err, "get_session")
+		utils.LogAndHTTPError(w, err, "failed to get session cookie", http.StatusBadRequest)
+		return
+	}
+
+	// Lookup cookie --> flash
+	o.flashMu.Lock()
+	arf, ok := o.flashStore[cookie.Value]
+	delete(o.flashStore, cookie.Value)
+	o.flashMu.Unlock()
+
+	if !ok {
+		o.metrics.callbackErr(nil, "no_flash")
+		utils.LogAndHTTPError(w, nil, "no state found for session", http.StatusBadRequest)
+		return
+	}
+
+	recreatedRequest, err := http.NewRequest(http.MethodGet, "/?"+arf.Form.Encode(), nil)
+	if err != nil {
+		o.metrics.callbackErr(err, "recreate_req")
+		utils.LogAndHTTPError(w, err, "failed to recreate request", http.StatusBadRequest)
+		return
+	}
+	authRequest, err := o.provider.NewAuthorizeRequest(ctx, recreatedRequest)
+	if err != nil {
+		o.metrics.callbackErr(err, fositeErrReason(err))
+		utils.LogAndHTTPError(w, err, "failed to recreate request", http.StatusBadRequest)
+		return
+	}
+
+	// Check the DID allowlist after reconstructing authRequest so we can redirect
+	// errors back to the client via WriteAuthorizeError instead of returning a raw 401.
+	_, err = o.orgStore.GetOrgForDID(r.Context(), arf.Did)
+	if err != nil {
+		o.metrics.callbackErr(err, "allowlist_dids")
+		o.provider.WriteAuthorizeError(ctx, w, authRequest,
+			fosite.ErrAccessDenied.WithDescription("You are not a member of this habitat organization.").WithHint(""))
+		return
+	}
+	provider, err := o.loginRouter.ByLoginMethod(arf.LoginMethod)
+	if err != nil {
+		o.metrics.callbackErr(err, "no_provider")
+		utils.LogAndHTTPError(w, err, "no login provider for session", http.StatusBadRequest)
+		return
+	}
+	if err := provider.Exchange(
+		ctx,
+		arf.Did,
+		r.URL.Query().Get("code"),
+		r.URL.Query().Get("iss"),
+		arf.ProviderState,
+	); err != nil {
+		o.metrics.callbackErr(err, "complete_login")
+		utils.LogAndHTTPError(w, err, "failed to complete login", http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := o.provider.NewAuthorizeResponse(
+		ctx,
+		authRequest,
+		newAuthorizeSession(authRequest, arf.Did),
+	)
+	if err != nil {
+		o.metrics.callbackErr(err, fositeErrReason(err))
+		utils.LogAndHTTPError(w, err, "failed to create response", http.StatusInternalServerError)
+		return
+	}
+	o.provider.WriteAuthorizeResponse(r.Context(), w, authRequest, resp)
+	o.metrics.callbackSuccess()
+}
+```
+
+**Step 6.4: Update OAuth server tests**
+
+`internal/oauthserver/oauth_server_test.go` — update all `login.NewRouter(login.NewPDSProvider(oauthClient, credStore))` calls to include the new args:
+
+```go
+login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil))
+```
+
+Add a `stubMappingStore` in the test file:
+
+```go
+type stubMappingStore struct{}
+
+func (s *stubMappingStore) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
+	return nil, nil
+}
+```
+
+Also update the OAuth server comment that mentions `loginRouter: Routes login flows by DID service endpoint`:
+
+```go
+// loginRouter: Routes login flows by org login method
+```
+
+Also update `testStore` — it creates an org with `CreateOrg` which now sets `LoginMethod: "password"`. The dummy PDS provider's `LoginMethod()` returns `"atproto"`, but the test store creates a "password" org. The test uses `"did:web:test"` as handle which will resolve through the dummy directory. The dummy directory likely returns an identity that maps to the everyone org (which has login method "atproto"). So the tests should still work.
+
+Wait, let me think about this more carefully. The test creates an org via `testStore` → `CreateOrg`. That org's members are the admin user. The test then makes an authorize request with `handle=did:web:test`. The dummy directory resolves this to an identity with DID `did:web:test`. `GetOrgForDID` checks: is `did:web:test` in the member table? No (it's the admin handle's DID, not `did:web:test`). Then it resolves the DID → identity via directory. The dummy directory returns an identity. Does it have a habitat service? Probably not. So it falls through to the everyone org.
+
+The everyone org's `LoginMethod()` returns `"atproto"`. The router has a provider with `LoginMethod() == "atproto"` (the PDS provider). So the test should still work.
+
+Actually wait - looking at the dummy directory more carefully. The test uses `pdsclient.NewDummyDirectory("http://pds.url")`. I need to check what that returns. Let me look at what `NewDummyDirectory` does.
+
+Actually, I don't have the code for `NewDummyDirectory`. But from the test, we see that it resolves `did:web:test` to an identity, and the identity has a PDS service. So it goes to the everyone org → login method "atproto" → PDS provider. The test should work.
+
+But for the `TestOAuthServerErrorPaths` test, it creates a router with only a PDS provider (atproto). If the org created by `testStore` has login method "password", it would look for a "password" provider and not find one. But this test doesn't actually exercise the full authorize flow — it tests error paths like "missing OAuth params". So that should be fine.
+
+Wait, actually, let me look at the test more carefully. `TestOAuthServerErrorPaths` does:
+1. `NewOAuthServer(secret, login.NewRouter(login.NewPDSProvider(...)), ...)` — Router has only PDS provider
+2. `HandleAuthorize` with no params → Fosite rejects it (no client_id, etc.)
+3. So the OAuth flow never gets far enough to hit the org lookup
+
+The `TestHandleCallbackDIDNotInAllowlist` test:
+1. Creates a server with PDS provider only
+2. Makes an authorize request with `handle=did:web:test`
+3. The dummy directory resolves it
+4. The org lookup → everyone org (since `did:web:test` is not in any org)
+5. Login method "atproto" → PDS provider
+6. Authorize returns redirect
+7. Follows redirects to callback
+8. GetOrgForDID → everyone org → succeeds
+9. Exchange → succeeds
+10. Fosite authorize response → ...
+
+Wait, actually, this test drives the flow and expects it to succeed up to the authorise response. The org check in `HandleCallback` succeeds because `did:web:test` maps to the everyone org, and `IsMember` returns true for everyone. Then `ByLoginMethod("atproto")` finds the PDS provider. Exchange succeeds. Then Fosite issues the auth code redirect.
+
+But wait - the test expects `http.StatusSeeOther`. In the current test, it checks `require.Equal(t, http.StatusSeeOther, resp.StatusCode)` at the callback step where fosite would redirect with the auth code. But looking at the test more carefully:
+
+```go
+for resp.StatusCode == http.StatusSeeOther {
+    loc := resp.Header.Get("Location")
+    nextReq, reqErr := http.NewRequest(http.MethodGet, loc, nil)
+    require.NoError(t, reqErr)
+    resp, err = httpClient.Do(nextReq)
+    require.NoError(t, err)
+    _ = resp.Body.Close()
+    if nextReq.URL.Path == "/oauth-callback" {
+        break
+    }
+}
+require.Equal(t, http.StatusSeeOther, resp.StatusCode)
+```
+
+Hmm, actually the test stops at `/oauth-callback` and expects it to NOT be a redirect. It expects the fosite authorize error response, which uses `http.StatusSeeOther`. That would happen if GetOrgForDID fails with an error.
+
+Wait, this test is `TestHandleCallbackDIDNotInAllowlist`. Let me look at it more carefully.
+
+Looking at lines 150-256: The `testStore` creates an org with `"admin"` handle. The authorize request uses `handle=did:web:test`. The dummy directory at `http://pds.url` would resolve this. The org lookup would find the everyone org (since `did:web:test` isn't a member of any org). The everyone org's `IsMember` returns true. So the callback org check passes.
+
+Hmm, but then the test expects failure at `http.StatusSeeOther`. Maybe the failure comes from fosite's authorize response? Looking at the test again... the test uses `clientMetadata.RedirectUris = []string{server.URL + "/oauth-callback"}` which actually doesn't match the client metadata URL. The fosite client ID would be something else.
+
+Actually, I think this test is testing the case where fosite rejects the request at the final step (not at the org membership step). The test title is "TestHandleCallbackDIDNotInAllowlist" but it actually just verifies that a full OAuth flow with no valid memberships fails. The key point is whether our changes break the flow.
+
+Let me think about this differently. The test creates an org with `CreateOrg(ctx, "org-name", "admin", "password")`. This creates an org with login method "password" and admin DID = whatever `MintIdentity("admin")` returns. The authorize request is `handle=did:web:test`. `directory.Lookup("did:web:test")` returns an identity with DID `did:web:test` and some services. `GetOrgForDID(did:web:test)` → checks member table → no match → resolves DID → gets identity with PDS service → returns everyone org (not a habitat member on this pear).
+
+Everyone org's LoginMethod = "atproto". Router has PDS provider with LoginMethod "atproto". So `ByLoginMethod("atproto")` returns the PDS provider. Authorize succeeds. Flow continues. At callback, GetOrgForDID again returns everyone org. Login method still "atproto". Exchange succeeds. Fosite issues response.
+
+So the flow should succeed through callback. The `testStore` org membership doesn't interfere because `did:web:test` resolves to the everyone org.
+
+OK I think this will work without changes to the test logic, just the constructor call.
+
+But wait — the `testStore` creates an org with `CreateOrg`. That org is a password org with a specific member. But the `did:web:test` handle used in the test resolves to everyone org. So the PDS provider is used correctly. The test should pass.
+
+Actually, let me re-examine the `TestOAuthServerErrorPaths` test more carefully. It does:
+
+```go
+oauthSrv, err := NewOAuthServer(
+    secret,
+    login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
+    ...
+)
+```
+
+After my changes, `NewPDSProvider` needs `mappingStore` and `dir`. So I need to update this call. And `NewRouter` accepts `...Provider` as before.
+
+For the `testStore` function, `CreateOrg` now stores `LoginMethod: "password"`. This doesn't affect the test flow since the test uses `did:web:test` which maps to everyone org.
+
+Let me make sure I specify the exact changes needed for the test file.
+
+**Step 6.5: Run tests**
+
+```bash
+go test ./internal/oauthserver/... -v -count=1
+```
+
+Expected: all pass.
+
+**Step 6.6: Commit**
+
+```bash
+git add internal/oauthserver/oauth_server.go internal/oauthserver/oauth_server_test.go
+git commit -m "refactor: route OAuth providers by org login method"
+```
+
+---
+
+### Task 7: Wire up in main.go
+
+**Files:**
+- Modify: `cmd/pear/main.go`
+
+**Step 7.1: Update provider construction**
+
+In `cmd/pear/main.go`, find the section where `orgLoginProvider` and `loginRouter` are created:
+
+```go
+orgLoginProvider := org.NewLoginProvider(orgStore, frontendDomain, oauthSecret)
+loginRouter := login.NewRouter(
+    login.NewPDSProvider(pdsOAuthClient, pdsCredStore, mappingStoreImpl, directory),
+    // googleProvider not wired yet — mapping store not populated
+    orgLoginProvider,
+)
+```
+
+The `mappingStoreImpl` would need to be created. For now, since mappings aren't populated, we can pass a no-op implementation. Looking at what's available in main.go to determine if there's a DB we can use.
+
+Let me check what the main.go currently looks like... I don't have it. But based on the codebase exploration, I know the general shape. The key change is adding the mapping store parameter to `NewPDSProvider` and the org login provider now registering itself implicitly via its `LoginMethod()`.
+
+Actually, `LoginProvider` is in `org` package and implements `login.Provider`. The router is in `login` package. `LoginProvider.LoginMethod()` returns "password". So when we pass `orgLoginProvider` to `login.NewRouter`, it gets registered as "password".
+
+The PDS provider's `LoginMethod()` returns "atproto", so it gets registered as "atproto".
+
+The mapping store — we don't have an implementation yet. We can pass `nil` for now since the pdsProvider handles `nil` dir gracefully (it checks `p.dir != nil`). Or we can create a simple no-op implementation.
+
+Since the user said "don't worry about how those mappings are populated for now", passing nil or a no-op is fine.
+
+**Step 7.2: Verify build**
+
+```bash
+go build ./cmd/pear/
+```
+
+Expected: builds successfully.
+
+**Step 7.3: Commit**
+
+```bash
+git add cmd/pear/main.go
+git commit -m "chore: update provider wiring for login method routing"
+```

--- a/docs/superpowers/specs/2026-05-15-oauth-login-methods-design.md
+++ b/docs/superpowers/specs/2026-05-15-oauth-login-methods-design.md
@@ -1,0 +1,189 @@
+# OAuth Login Methods Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refactor the OAuth authorize flow to route login providers based on an org's login method instead of inspecting identity services via `CanHandle`.
+
+**Architecture:** The `Provider` interface loses `CanHandle` and `Type()`, gaining `LoginMethod() string`. The `Router` dispatches by login method (atproto, google, password) instead of probing identity services. Each org stores its login method, and the OAuth server looks up the org during `HandleAuthorize` to determine the provider. The `pdsProvider` gets a mapping store for org DID → public ATProto DID, enabling org-scoped PDS auth. A new `googleProvider` stubs out Google Sign-In with a similar mapping.
+
+**Tech Stack:** Go, Fosite (OAuth 2.0), GORM, AT Protocol (indigo)
+
+---
+
+## Changes
+
+### 1. Org model — LoginMethod field
+
+**File:** `internal/org/models.go`
+
+Add `LoginMethod` column to the `organization` struct. New orgs created via `CreateOrg` default to `"password"`.
+
+```go
+type organization struct {
+    ID            string `gorm:"primaryKey"`
+    Name          string
+    LoginMethod   string // "atproto", "google", "password"
+    SigningSecret string
+    CreatedAt     time.Time
+}
+```
+
+### 2. Org interface — add LoginMethod()
+
+**File:** `internal/org/org.go`
+
+Add `LoginMethod() string` to the `Org` interface.
+
+**File:** `internal/org/public.go`
+
+`everyoneOrg.LoginMethod()` returns `"atproto"`.
+
+**File:** `internal/org/store.go`
+
+The `orgImpl.LoginMethod()` reads from the `organization.LoginMethod` in the DB. `GetOrgForDID` and `CreateOrg` propagate login method. `CreateOrg` stores `"password"` as default for new orgs. `orgFromModel` maps it from the model.
+
+### 3. Provider interface — remove CanHandle and Type()
+
+**File:** `internal/login/provider.go`
+
+New interface:
+
+```go
+type Provider interface {
+    LoginMethod() string
+    Authorize(ctx context.Context, id *identity.Identity) (redirectUri string, state []byte, err error)
+    Exchange(ctx context.Context, did syntax.DID, code string, issuer string, state []byte) error
+}
+```
+
+The `LoginMethod()` replaces both `Type()` and `CanHandle(id)`.
+
+**Router changes:**
+
+```go
+type Router struct {
+    providers map[string]Provider
+}
+
+func NewRouter(providers ...Provider) *Router
+// ByLoginMethod returns the provider registered for the given login method.
+func (r *Router) ByLoginMethod(method string) (Provider, error)
+```
+
+Registration is explicit: each provider declares its login method in `LoginMethod()`. Remove `For(id)` (was CanHandle-based) and `ByType()`.
+
+The `ProviderType` and constants are removed.
+
+### 4. pdsProvider — mapping store for org DID → public ATProto DID
+
+**File:** `internal/login/pds.go`
+
+Requires a `PublicDIDMappingStore` interface and an `identity.Directory` to resolve public DIDs:
+
+```go
+type PublicDIDMappingStore interface {
+    GetPublicDID(ctx context.Context, orgDID syntax.DID) (*syntax.DID, error)
+}
+```
+
+In `Authorize`:
+- Look up the mapping for the caller's DID (which is the org DID)
+- If a mapping exists, resolve the public DID via directory and use that identity's PDS service for the OAuth flow
+- If no mapping (everyone org), use the passed identity directly (current behavior)
+
+Constructor gains `mappingStore PublicDIDMappingStore` and `dir identity.Directory`. The `LoginMethod()` returns `"atproto"`.
+
+`Authorize(ctx, id)` signature stays the same — the org DID is `id.DID`.
+
+### 5. googleProvider — new
+
+**File:** `internal/login/google.go` (new)
+
+```go
+type GoogleEmailMappingStore interface {
+    GetEmail(ctx context.Context, orgDID syntax.DID) (string, error)
+}
+```
+
+Stub implementation:
+- `LoginMethod()` returns `"google"`
+- `Authorize(ctx, id)` — looks up email mapping for `id.DID`, configures Google OAuth URL with `login_hint`, returns redirect. Falls back to empty/no-op if no mapping.
+- `Exchange(ctx, did, code, issuer, state)` — handles Google OAuth callback, stores credentials. Stub implementation that returns nil (no-op for now).
+
+### 6. HandleAuthorize — org-based provider routing
+
+**File:** `internal/oauthserver/oauth_server.go`
+
+Replace `authRequestFlash.ProviderType` with `LoginMethod string`. Current flow:
+
+```go
+id, _ := o.directory.Lookup(ctx, atid)
+provider, _ := o.loginRouter.For(id)   // CanHandle-based
+redirect, state, _ := provider.Authorize(ctx, id)
+flash := &authRequestFlash{
+    ProviderType: provider.Type(),
+    ...
+}
+```
+
+New flow:
+
+```go
+id, _ := o.directory.Lookup(ctx, atid)
+org, _ := o.orgStore.GetOrgForDID(ctx, id.DID)
+provider, _ := o.loginRouter.ByLoginMethod(org.LoginMethod())
+redirect, state, _ := provider.Authorize(ctx, id)
+flash := &authRequestFlash{
+    LoginMethod: provider.LoginMethod(),
+    ...
+}
+```
+
+### 7. HandleCallback — login method routing
+
+**File:** `internal/oauthserver/oauth_server.go`
+
+Current:
+
+```go
+o.orgStore.GetOrgForDID(r.Context(), arf.Did)   // membership check
+provider, _ := o.loginRouter.ByType(arf.ProviderType)
+provider.Exchange(ctx, arf.Did, code, issuer, arf.ProviderState)
+```
+
+New:
+
+```go
+o.orgStore.GetOrgForDID(r.Context(), arf.Did)   // membership check
+provider, _ := o.loginRouter.ByLoginMethod(arf.LoginMethod)
+provider.Exchange(ctx, arf.Did, code, issuer, arf.ProviderState)
+```
+
+### 8. Wire-up in cmd/pear/main.go
+
+```go
+pdsProvider := login.NewPDSProvider(pdsOAuthClient, pdsCredStore, mappingStore, directory)
+googleProvider := login.NewGoogleProvider(googleMappingStore, googleOAuthConfig) // stub
+passwordProvider := org.NewLoginProvider(orgStore, frontendDomain, oauthSecret)
+loginRouter := login.NewRouter(pdsProvider, googleProvider, passwordProvider)
+```
+
+Remove the `LoginProvider` being passed to `login.NewRouter` — actually it stays, but its `LoginMethod()` now returns `"password"` explicitly.
+
+**Note:** `org.NewLoginProvider` needs a `LoginMethod() string` method added that returns `"password"`.
+
+---
+
+## File Change Summary
+
+| File | Change |
+|---|---|
+| `internal/org/models.go` | Add `LoginMethod` column to `organization` |
+| `internal/org/org.go` | Add `LoginMethod() string` to `Org` interface |
+| `internal/org/store.go` | Implement `LoginMethod()` on `orgImpl`, update `orgFromModel`, `CreateOrg`, `GetOrgForDID` |
+| `internal/org/public.go` | Add `LoginMethod() string` to `everyoneOrg` (returns `"atproto"`) |
+| `internal/login/provider.go` | Remove `CanHandle`, `Type()`, `ProviderType`. Add `LoginMethod() string`. Rewrite Router to use `map[string]Provider` with `ByLoginMethod()` |
+| `internal/login/pds.go` | Add `PublicDIDMappingStore`, `identity.Directory` to struct. Update `Authorize` for org mapping |
+| `internal/login/google.go` | New file — `googleProvider` stub |
+| `internal/oauthserver/oauth_server.go` | Update `authRequestFlash` (ProviderType → LoginMethod), `HandleAuthorize` and `HandleCallback` to use org-based routing |
+| **Possibly** `cmd/pear/main.go` | Update wiring |

--- a/internal/login/google.go
+++ b/internal/login/google.go
@@ -1,0 +1,47 @@
+package login
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+// GoogleEmailMappingStore resolves an org DID to the email address used
+// for Google Sign-In.
+type GoogleEmailMappingStore interface {
+	GetEmail(ctx context.Context, orgDID syntax.DID) (string, error)
+}
+
+type googleProvider struct {
+	loginMethod  string
+	mappingStore GoogleEmailMappingStore
+}
+
+func NewGoogleProvider(mappingStore GoogleEmailMappingStore) Provider {
+	return &googleProvider{
+		loginMethod:  "google",
+		mappingStore: mappingStore,
+	}
+}
+
+func (p *googleProvider) LoginMethod() string { return p.loginMethod }
+
+func (p *googleProvider) Authorize(ctx context.Context, id *identity.Identity) (string, []byte, error) {
+	email, err := p.mappingStore.GetEmail(ctx, id.DID)
+	if err != nil {
+		return "", nil, fmt.Errorf("lookup google email for org %s: %w", id.DID, err)
+	}
+	if email == "" {
+		return "", nil, fmt.Errorf("no google email configured for org %s", id.DID)
+	}
+	// TODO: implement Google OAuth initiation with login_hint=email
+	_ = email
+	return "", nil, fmt.Errorf("google provider not yet implemented")
+}
+
+func (p *googleProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
+	// TODO: implement Google OAuth callback handling
+	return fmt.Errorf("google provider not yet implemented")
+}

--- a/internal/login/google.go
+++ b/internal/login/google.go
@@ -1,35 +1,27 @@
 package login
 
-import (
-	"context"
-	"fmt"
-
-	"github.com/bluesky-social/indigo/atproto/identity"
-	"github.com/bluesky-social/indigo/atproto/syntax"
-)
-
-type googleProvider struct {
-	loginMethod string
-}
-
-func NewGoogleProvider() Provider {
-	return &googleProvider{
-		loginMethod: "google",
-	}
-}
-
-func (p *googleProvider) LoginMethod() string { return p.loginMethod }
-
-func (p *googleProvider) Authorize(ctx context.Context, id *identity.Identity, loginID string) (string, []byte, error) {
-	if loginID == "" {
-		return "", nil, fmt.Errorf("no google email configured for org %s", id.DID)
-	}
-	// TODO: implement Google OAuth initiation with login_hint=loginID
-	_ = loginID
-	return "", nil, fmt.Errorf("google provider not yet implemented")
-}
-
-func (p *googleProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
-	// TODO: implement Google OAuth callback handling
-	return fmt.Errorf("google provider not yet implemented")
-}
+// type googleProvider struct {
+// 	loginMethod string
+// }
+//
+// func NewGoogleProvider() Provider {
+// 	return &googleProvider{
+// 		loginMethod: "google",
+// 	}
+// }
+//
+// func (p *googleProvider) LoginMethod() string { return p.loginMethod }
+//
+// func (p *googleProvider) Authorize(ctx context.Context, id *identity.Identity, loginID string) (string, []byte, error) {
+// 	if loginID == "" {
+// 		return "", nil, fmt.Errorf("no google email configured for org %s", id.DID)
+// 	}
+// 	// TODO: implement Google OAuth initiation with login_hint=loginID
+// 	_ = loginID
+// 	return "", nil, fmt.Errorf("google provider not yet implemented")
+// }
+//
+// func (p *googleProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
+// 	// TODO: implement Google OAuth callback handling
+// 	return fmt.Errorf("google provider not yet implemented")
+// }

--- a/internal/login/google.go
+++ b/internal/login/google.go
@@ -8,36 +8,24 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
 
-// GoogleEmailMappingStore resolves an org DID to the email address used
-// for Google Sign-In.
-type GoogleEmailMappingStore interface {
-	GetEmail(ctx context.Context, orgDID syntax.DID) (string, error)
-}
-
 type googleProvider struct {
-	loginMethod  string
-	mappingStore GoogleEmailMappingStore
+	loginMethod string
 }
 
-func NewGoogleProvider(mappingStore GoogleEmailMappingStore) Provider {
+func NewGoogleProvider() Provider {
 	return &googleProvider{
-		loginMethod:  "google",
-		mappingStore: mappingStore,
+		loginMethod: "google",
 	}
 }
 
 func (p *googleProvider) LoginMethod() string { return p.loginMethod }
 
-func (p *googleProvider) Authorize(ctx context.Context, id *identity.Identity) (string, []byte, error) {
-	email, err := p.mappingStore.GetEmail(ctx, id.DID)
-	if err != nil {
-		return "", nil, fmt.Errorf("lookup google email for org %s: %w", id.DID, err)
-	}
-	if email == "" {
+func (p *googleProvider) Authorize(ctx context.Context, id *identity.Identity, loginID string) (string, []byte, error) {
+	if loginID == "" {
 		return "", nil, fmt.Errorf("no google email configured for org %s", id.DID)
 	}
-	// TODO: implement Google OAuth initiation with login_hint=email
-	_ = email
+	// TODO: implement Google OAuth initiation with login_hint=loginID
+	_ = loginID
 	return "", nil, fmt.Errorf("google provider not yet implemented")
 }
 

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -243,6 +243,17 @@ func (d *stubDirectory) LookupDID(_ context.Context, did syntax.DID) (*identity.
 
 func (d *stubDirectory) Purge(_ context.Context, _ syntax.AtIdentifier) error { return nil }
 
+func TestGoogleProvider_LoginMethod(t *testing.T) {
+	p := NewGoogleProvider(&stubGoogleMappingStore{})
+	require.Equal(t, "google", p.LoginMethod())
+}
+
+type stubGoogleMappingStore struct{}
+
+func (s *stubGoogleMappingStore) GetEmail(_ context.Context, _ syntax.DID) (string, error) {
+	return "", nil
+}
+
 // unmarshalProviderState is a test helper to inspect the opaque pds state bytes.
 func unmarshalProviderState(b []byte, s *pdsProviderState) error {
 	return json.Unmarshal(b, s)

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -106,20 +106,17 @@ func idWithNoServices() *identity.Identity {
 	}
 }
 
-// --- pdsProvider ---
+type stubMappingStore struct{}
 
-func TestPDSProvider_CanHandle(t *testing.T) {
-	p := NewPDSProvider(&stubOAuthClient{}, newStubCredStore())
-
-	require.True(t, p.CanHandle(idWithPDSOnly()), "pds-only identity should be handled")
-	require.False(t, p.CanHandle(idWithHabitatOnly()), "habitat-only identity should not be handled")
-	require.False(t, p.CanHandle(idWithBothServices()), "identity with both services should not be handled")
-	require.False(t, p.CanHandle(idWithNoServices()), "identity with no services should not be handled")
+func (s *stubMappingStore) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
+	return nil, nil // no mapping — use identity as-is
 }
+
+// --- pdsProvider ---
 
 func TestPDSProvider_Authorize(t *testing.T) {
 	client := &stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}
-	p := NewPDSProvider(client, newStubCredStore())
+	p := NewPDSProvider(client, newStubCredStore(), &stubMappingStore{}, nil)
 
 	redirect, state, err := p.Authorize(context.Background(), idWithPDSOnly())
 	require.NoError(t, err)
@@ -135,7 +132,7 @@ func TestPDSProvider_Authorize(t *testing.T) {
 
 func TestPDSProvider_Exchange(t *testing.T) {
 	credStore := newStubCredStore()
-	p := NewPDSProvider(&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}, credStore)
+	p := NewPDSProvider(&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}, credStore, &stubMappingStore{}, nil)
 	did := syntax.DID("did:web:pds.example.com")
 
 	// Obtain valid state from Authorize.
@@ -157,12 +154,7 @@ type dummyProvider struct{}
 
 func NewDummyProvider() Provider { return &dummyProvider{} }
 
-func (d *dummyProvider) Type() ProviderType { return ProviderTypeHabitat }
-func (d *dummyProvider) CanHandle(id *identity.Identity) bool {
-	_, hasHabitat := id.Services["habitat"]
-	_, hasPDS := id.Services["atproto_pds"]
-	return hasHabitat && !hasPDS
-}
+func (d *dummyProvider) LoginMethod() string { return "password" }
 func (d *dummyProvider) Authorize(_ context.Context, _ *identity.Identity) (string, []byte, error) {
 	return "https://dummy.example.com/login", nil, nil
 }
@@ -174,41 +166,23 @@ func (d *dummyProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _
 
 func newTestRouter() *Router {
 	return NewRouter(
-		NewPDSProvider(&stubOAuthClient{}, newStubCredStore()),
+		NewPDSProvider(&stubOAuthClient{}, newStubCredStore(), &stubMappingStore{}, nil),
 		NewDummyProvider(),
 	)
 }
 
-func TestRouter_For(t *testing.T) {
+func TestRouter_ByLoginMethod(t *testing.T) {
 	r := newTestRouter()
 
-	p, err := r.For(idWithPDSOnly())
+	p, err := r.ByLoginMethod("atproto")
 	require.NoError(t, err)
-	require.Equal(t, ProviderTypePDS, p.Type())
+	require.Equal(t, "atproto", p.LoginMethod())
 
-	p, err = r.For(idWithHabitatOnly())
+	p, err = r.ByLoginMethod("password")
 	require.NoError(t, err)
-	require.Equal(t, ProviderTypeHabitat, p.Type())
+	require.Equal(t, "password", p.LoginMethod())
 
-	_, err = r.For(idWithBothServices())
-	require.Error(t, err, "identity with both services should have no provider")
-
-	_, err = r.For(idWithNoServices())
-	require.Error(t, err, "identity with no services should have no provider")
-}
-
-func TestRouter_ByType(t *testing.T) {
-	r := newTestRouter()
-
-	p, err := r.ByType(ProviderTypePDS)
-	require.NoError(t, err)
-	require.Equal(t, ProviderTypePDS, p.Type())
-
-	p, err = r.ByType(ProviderTypeHabitat)
-	require.NoError(t, err)
-	require.Equal(t, ProviderTypeHabitat, p.Type())
-
-	_, err = r.ByType("unknown")
+	_, err = r.ByLoginMethod("unknown")
 	require.Error(t, err)
 }
 

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -186,6 +186,63 @@ func TestRouter_ByLoginMethod(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPDSProvider_AuthorizeWithMapping(t *testing.T) {
+	mappedDID := syntax.DID("did:plc:mapped-public")
+	mapping := &stubMappingStoreWithMapping{mapped: mappedDID}
+	client := &stubOAuthClient{redirectURL: "https://public-pds.example.com/authorize"}
+	dir := &stubDirectory{dids: map[syntax.DID]*identity.Identity{
+		mappedDID: {
+			DID:    mappedDID,
+			Handle: "org.public.example.com",
+			Services: map[string]identity.ServiceEndpoint{
+				"atproto_pds": {URL: "https://public-pds.example.com"},
+			},
+		},
+	}}
+	p := NewPDSProvider(client, newStubCredStore(), mapping, dir)
+
+	orgID := &identity.Identity{
+		DID: "did:web:internal.org.example.com",
+		Services: map[string]identity.ServiceEndpoint{
+			"habitat": {URL: "https://habitat.example.com"},
+		},
+	}
+	redirect, state, err := p.Authorize(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, "https://public-pds.example.com/authorize", redirect)
+	require.NotEmpty(t, state)
+}
+
+type stubMappingStoreWithMapping struct {
+	mapped syntax.DID
+}
+
+func (s *stubMappingStoreWithMapping) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
+	return &s.mapped, nil
+}
+
+type stubDirectory struct {
+	dids map[syntax.DID]*identity.Identity
+}
+
+func (d *stubDirectory) LookupHandle(_ context.Context, _ syntax.Handle) (*identity.Identity, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *stubDirectory) Lookup(_ context.Context, _ syntax.AtIdentifier) (*identity.Identity, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *stubDirectory) LookupDID(_ context.Context, did syntax.DID) (*identity.Identity, error) {
+	id, ok := d.dids[did]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return id, nil
+}
+
+func (d *stubDirectory) Purge(_ context.Context, _ syntax.AtIdentifier) error { return nil }
+
 // unmarshalProviderState is a test helper to inspect the opaque pds state bytes.
 func unmarshalProviderState(b []byte, s *pdsProviderState) error {
 	return json.Unmarshal(b, s)

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -22,7 +22,10 @@ type stubOAuthClient struct {
 
 func (s *stubOAuthClient) ClientMetadata() *pdsclient.ClientMetadata { return nil }
 
-func (s *stubOAuthClient) Authorize(_ *pdsclient.DpopHttpClient, _ *identity.Identity) (string, *pdsclient.AuthorizeState, error) {
+func (s *stubOAuthClient) Authorize(
+	_ *pdsclient.DpopHttpClient,
+	_ *identity.Identity,
+) (string, *pdsclient.AuthorizeState, error) {
 	if s.authorizeErr != nil {
 		return "", nil, s.authorizeErr
 	}
@@ -33,7 +36,11 @@ func (s *stubOAuthClient) Authorize(_ *pdsclient.DpopHttpClient, _ *identity.Ide
 	}, nil
 }
 
-func (s *stubOAuthClient) ExchangeCode(_ *pdsclient.DpopHttpClient, _, _ string, _ *pdsclient.AuthorizeState) (*pdsclient.TokenResponse, error) {
+func (s *stubOAuthClient) ExchangeCode(
+	_ *pdsclient.DpopHttpClient,
+	_, _ string,
+	_ *pdsclient.AuthorizeState,
+) (*pdsclient.TokenResponse, error) {
 	if s.exchangeCodeErr != nil {
 		return nil, s.exchangeCodeErr
 	}
@@ -43,7 +50,12 @@ func (s *stubOAuthClient) ExchangeCode(_ *pdsclient.DpopHttpClient, _, _ string,
 	}, nil
 }
 
-func (s *stubOAuthClient) RefreshToken(_ *pdsclient.DpopHttpClient, _ *identity.Identity, _ string, _ string) (*pdsclient.TokenResponse, error) {
+func (s *stubOAuthClient) RefreshToken(
+	_ *pdsclient.DpopHttpClient,
+	_ *identity.Identity,
+	_ string,
+	_ string,
+) (*pdsclient.TokenResponse, error) {
 	return nil, errors.New("not used in these tests")
 }
 
@@ -57,7 +69,11 @@ func newStubCredStore() *stubCredStore {
 	return &stubCredStore{upserted: make(map[syntax.DID]*pdscred.Credentials)}
 }
 
-func (s *stubCredStore) UpsertCredentials(_ context.Context, did syntax.DID, creds *pdscred.Credentials) error {
+func (s *stubCredStore) UpsertCredentials(
+	_ context.Context,
+	did syntax.DID,
+	creds *pdscred.Credentials,
+) error {
 	if s.upsertErr != nil {
 		return s.upsertErr
 	}
@@ -65,7 +81,10 @@ func (s *stubCredStore) UpsertCredentials(_ context.Context, did syntax.DID, cre
 	return nil
 }
 
-func (s *stubCredStore) GetCredentials(_ context.Context, did syntax.DID) (*pdscred.Credentials, error) {
+func (s *stubCredStore) GetCredentials(
+	_ context.Context,
+	did syntax.DID,
+) (*pdscred.Credentials, error) {
 	return nil, errors.New("not used in these tests")
 }
 
@@ -100,7 +119,11 @@ func TestPDSProvider_Authorize(t *testing.T) {
 
 func TestPDSProvider_Exchange(t *testing.T) {
 	credStore := newStubCredStore()
-	p := NewPDSProvider(&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}, credStore, nil)
+	p := NewPDSProvider(
+		&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"},
+		credStore,
+		nil,
+	)
 	did := syntax.DID("did:web:pds.example.com")
 
 	// Obtain valid state from Authorize.
@@ -123,7 +146,12 @@ type dummyProvider struct{}
 func NewDummyProvider() Provider { return &dummyProvider{} }
 
 func (d *dummyProvider) LoginMethod() string { return "password" }
-func (d *dummyProvider) Authorize(_ context.Context, _ *identity.Identity, _ string) (string, []byte, error) {
+
+func (d *dummyProvider) Authorize(
+	_ context.Context,
+	_ *identity.Identity,
+	_ string,
+) (string, []byte, error) {
 	return "https://dummy.example.com/login", nil, nil
 }
 func (d *dummyProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
@@ -169,11 +197,6 @@ func TestPDSProvider_AuthorizeWithLoginID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "https://public-pds.example.com/authorize", redirect)
 	require.NotEmpty(t, state)
-}
-
-func TestGoogleProvider_LoginMethod(t *testing.T) {
-	p := NewGoogleProvider()
-	require.Equal(t, "google", p.LoginMethod())
 }
 
 // unmarshalProviderState is a test helper to inspect the opaque pds state bytes.

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -80,32 +80,6 @@ func idWithPDSOnly() *identity.Identity {
 	}
 }
 
-func idWithHabitatOnly() *identity.Identity {
-	return &identity.Identity{
-		DID: "did:web:habitat.example.com",
-		Services: map[string]identity.ServiceEndpoint{
-			"habitat": {URL: "https://habitat.example.com"},
-		},
-	}
-}
-
-func idWithBothServices() *identity.Identity {
-	return &identity.Identity{
-		DID: "did:web:both.example.com",
-		Services: map[string]identity.ServiceEndpoint{
-			"atproto_pds": {URL: "https://pds.example.com"},
-			"habitat":     {URL: "https://habitat.example.com"},
-		},
-	}
-}
-
-func idWithNoServices() *identity.Identity {
-	return &identity.Identity{
-		DID:      "did:web:nobody.example.com",
-		Services: map[string]identity.ServiceEndpoint{},
-	}
-}
-
 type stubMappingStore struct{}
 
 func (s *stubMappingStore) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
@@ -190,15 +164,7 @@ func TestPDSProvider_AuthorizeWithMapping(t *testing.T) {
 	mappedDID := syntax.DID("did:plc:mapped-public")
 	mapping := &stubMappingStoreWithMapping{mapped: mappedDID}
 	client := &stubOAuthClient{redirectURL: "https://public-pds.example.com/authorize"}
-	dir := &stubDirectory{dids: map[syntax.DID]*identity.Identity{
-		mappedDID: {
-			DID:    mappedDID,
-			Handle: "org.public.example.com",
-			Services: map[string]identity.ServiceEndpoint{
-				"atproto_pds": {URL: "https://public-pds.example.com"},
-			},
-		},
-	}}
+	dir := pdsclient.NewDummyDirectory("https://public-pds.example.com")
 	p := NewPDSProvider(client, newStubCredStore(), mapping, dir)
 
 	orgID := &identity.Identity{
@@ -220,28 +186,6 @@ type stubMappingStoreWithMapping struct {
 func (s *stubMappingStoreWithMapping) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
 	return &s.mapped, nil
 }
-
-type stubDirectory struct {
-	dids map[syntax.DID]*identity.Identity
-}
-
-func (d *stubDirectory) LookupHandle(_ context.Context, _ syntax.Handle) (*identity.Identity, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (d *stubDirectory) Lookup(_ context.Context, _ syntax.AtIdentifier) (*identity.Identity, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (d *stubDirectory) LookupDID(_ context.Context, did syntax.DID) (*identity.Identity, error) {
-	id, ok := d.dids[did]
-	if !ok {
-		return nil, errors.New("not found")
-	}
-	return id, nil
-}
-
-func (d *stubDirectory) Purge(_ context.Context, _ syntax.AtIdentifier) error { return nil }
 
 func TestGoogleProvider_LoginMethod(t *testing.T) {
 	p := NewGoogleProvider(&stubGoogleMappingStore{})

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/org"
 	"github.com/habitat-network/habitat/internal/pdsclient"
 	"github.com/habitat-network/habitat/internal/pdscred"
 	"github.com/stretchr/testify/require"
@@ -145,7 +146,7 @@ type dummyProvider struct{}
 
 func NewDummyProvider() Provider { return &dummyProvider{} }
 
-func (d *dummyProvider) LoginMethod() string { return "password" }
+func (d *dummyProvider) LoginMethod() org.LoginMethod { return org.LoginMethodPassword }
 
 func (d *dummyProvider) Authorize(
 	_ context.Context,
@@ -170,13 +171,13 @@ func newTestRouter() *Router {
 func TestRouter_ByLoginMethod(t *testing.T) {
 	r := newTestRouter()
 
-	p, err := r.ByLoginMethod("atproto")
+	p, err := r.ByLoginMethod(org.LoginMethodAtproto)
 	require.NoError(t, err)
-	require.Equal(t, "atproto", p.LoginMethod())
+	require.Equal(t, org.LoginMethodAtproto, p.LoginMethod())
 
-	p, err = r.ByLoginMethod("password")
+	p, err = r.ByLoginMethod(org.LoginMethodPassword)
 	require.NoError(t, err)
-	require.Equal(t, "password", p.LoginMethod())
+	require.Equal(t, org.LoginMethodPassword, p.LoginMethod())
 
 	_, err = r.ByLoginMethod("unknown")
 	require.Error(t, err)

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -80,19 +80,13 @@ func idWithPDSOnly() *identity.Identity {
 	}
 }
 
-type stubMappingStore struct{}
-
-func (s *stubMappingStore) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
-	return nil, nil // no mapping — use identity as-is
-}
-
 // --- pdsProvider ---
 
 func TestPDSProvider_Authorize(t *testing.T) {
 	client := &stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}
-	p := NewPDSProvider(client, newStubCredStore(), &stubMappingStore{}, nil)
+	p := NewPDSProvider(client, newStubCredStore(), nil)
 
-	redirect, state, err := p.Authorize(context.Background(), idWithPDSOnly())
+	redirect, state, err := p.Authorize(context.Background(), idWithPDSOnly(), "")
 	require.NoError(t, err)
 	require.Equal(t, "https://pds.example.com/authorize", redirect)
 	require.NotEmpty(t, state)
@@ -106,11 +100,11 @@ func TestPDSProvider_Authorize(t *testing.T) {
 
 func TestPDSProvider_Exchange(t *testing.T) {
 	credStore := newStubCredStore()
-	p := NewPDSProvider(&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}, credStore, &stubMappingStore{}, nil)
+	p := NewPDSProvider(&stubOAuthClient{redirectURL: "https://pds.example.com/authorize"}, credStore, nil)
 	did := syntax.DID("did:web:pds.example.com")
 
 	// Obtain valid state from Authorize.
-	_, state, err := p.Authorize(context.Background(), idWithPDSOnly())
+	_, state, err := p.Authorize(context.Background(), idWithPDSOnly(), "")
 	require.NoError(t, err)
 
 	err = p.Exchange(context.Background(), did, "code", "https://pds.example.com", state)
@@ -129,7 +123,7 @@ type dummyProvider struct{}
 func NewDummyProvider() Provider { return &dummyProvider{} }
 
 func (d *dummyProvider) LoginMethod() string { return "password" }
-func (d *dummyProvider) Authorize(_ context.Context, _ *identity.Identity) (string, []byte, error) {
+func (d *dummyProvider) Authorize(_ context.Context, _ *identity.Identity, _ string) (string, []byte, error) {
 	return "https://dummy.example.com/login", nil, nil
 }
 func (d *dummyProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _ []byte) error {
@@ -140,7 +134,7 @@ func (d *dummyProvider) Exchange(_ context.Context, _ syntax.DID, _, _ string, _
 
 func newTestRouter() *Router {
 	return NewRouter(
-		NewPDSProvider(&stubOAuthClient{}, newStubCredStore(), &stubMappingStore{}, nil),
+		NewPDSProvider(&stubOAuthClient{}, newStubCredStore(), nil),
 		NewDummyProvider(),
 	)
 }
@@ -160,12 +154,10 @@ func TestRouter_ByLoginMethod(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestPDSProvider_AuthorizeWithMapping(t *testing.T) {
-	mappedDID := syntax.DID("did:plc:mapped-public")
-	mapping := &stubMappingStoreWithMapping{mapped: mappedDID}
+func TestPDSProvider_AuthorizeWithLoginID(t *testing.T) {
 	client := &stubOAuthClient{redirectURL: "https://public-pds.example.com/authorize"}
 	dir := pdsclient.NewDummyDirectory("https://public-pds.example.com")
-	p := NewPDSProvider(client, newStubCredStore(), mapping, dir)
+	p := NewPDSProvider(client, newStubCredStore(), dir)
 
 	orgID := &identity.Identity{
 		DID: "did:web:internal.org.example.com",
@@ -173,29 +165,15 @@ func TestPDSProvider_AuthorizeWithMapping(t *testing.T) {
 			"habitat": {URL: "https://habitat.example.com"},
 		},
 	}
-	redirect, state, err := p.Authorize(context.Background(), orgID)
+	redirect, state, err := p.Authorize(context.Background(), orgID, "did:plc:mapped-public")
 	require.NoError(t, err)
 	require.Equal(t, "https://public-pds.example.com/authorize", redirect)
 	require.NotEmpty(t, state)
 }
 
-type stubMappingStoreWithMapping struct {
-	mapped syntax.DID
-}
-
-func (s *stubMappingStoreWithMapping) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
-	return &s.mapped, nil
-}
-
 func TestGoogleProvider_LoginMethod(t *testing.T) {
-	p := NewGoogleProvider(&stubGoogleMappingStore{})
+	p := NewGoogleProvider()
 	require.Equal(t, "google", p.LoginMethod())
-}
-
-type stubGoogleMappingStore struct{}
-
-func (s *stubGoogleMappingStore) GetEmail(_ context.Context, _ syntax.DID) (string, error) {
-	return "", nil
 }
 
 // unmarshalProviderState is a test helper to inspect the opaque pds state bytes.

--- a/internal/login/pds.go
+++ b/internal/login/pds.go
@@ -15,9 +15,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type mappingStore interface {
+	GetPublicDID(ctx context.Context, did syntax.DID) (*syntax.DID, error)
+}
+
 type pdsProvider struct {
-	oauthClient pdsclient.PdsOAuthClient
-	credStore   pdscred.PDSCredentialStore
+	oauthClient  pdsclient.PdsOAuthClient
+	credStore    pdscred.PDSCredentialStore
+	mappingStore mappingStore
+	dir          identity.Directory
 }
 
 // pdsProviderState is the opaque flash state for the PDS login flow.
@@ -26,17 +32,11 @@ type pdsProviderState struct {
 	AuthorizeState pdsclient.AuthorizeState `json:"authorize_state"`
 }
 
-func NewPDSProvider(oauthClient pdsclient.PdsOAuthClient, credStore pdscred.PDSCredentialStore) Provider {
-	return &pdsProvider{oauthClient: oauthClient, credStore: credStore}
+func NewPDSProvider(oauthClient pdsclient.PdsOAuthClient, credStore pdscred.PDSCredentialStore, ms mappingStore, dir identity.Directory) Provider {
+	return &pdsProvider{oauthClient: oauthClient, credStore: credStore, mappingStore: ms, dir: dir}
 }
 
-func (p *pdsProvider) Type() ProviderType { return ProviderTypePDS }
-
-func (p *pdsProvider) CanHandle(id *identity.Identity) bool {
-	_, hasPDS := id.Services["atproto_pds"]
-	_, hasHabitat := id.Services["habitat"]
-	return hasPDS && !hasHabitat
-}
+func (p *pdsProvider) LoginMethod() string { return "atproto" }
 
 func (p *pdsProvider) Authorize(_ context.Context, id *identity.Identity) (string, []byte, error) {
 	dpopKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/internal/login/pds.go
+++ b/internal/login/pds.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/org"
 	"github.com/habitat-network/habitat/internal/pdsclient"
 	"github.com/habitat-network/habitat/internal/pdscred"
 	"github.com/rs/zerolog/log"
@@ -27,13 +28,21 @@ type pdsProviderState struct {
 	AuthorizeState pdsclient.AuthorizeState `json:"authorize_state"`
 }
 
-func NewPDSProvider(oauthClient pdsclient.PdsOAuthClient, credStore pdscred.PDSCredentialStore, dir identity.Directory) Provider {
+func NewPDSProvider(
+	oauthClient pdsclient.PdsOAuthClient,
+	credStore pdscred.PDSCredentialStore,
+	dir identity.Directory,
+) Provider {
 	return &pdsProvider{oauthClient: oauthClient, credStore: credStore, dir: dir}
 }
 
-func (p *pdsProvider) LoginMethod() string { return "atproto" }
+func (p *pdsProvider) LoginMethod() org.LoginMethod { return org.LoginMethodAtproto }
 
-func (p *pdsProvider) Authorize(ctx context.Context, id *identity.Identity, loginID string) (string, []byte, error) {
+func (p *pdsProvider) Authorize(
+	ctx context.Context,
+	id *identity.Identity,
+	loginID string,
+) (string, []byte, error) {
 	// If the member has a public ATProto DID as their loginID, resolve it and use
 	// that identity's PDS for the OAuth flow. If no loginID (e.g. everyone org),
 	// use the identity as-is.
@@ -67,7 +76,13 @@ func (p *pdsProvider) Authorize(ctx context.Context, id *identity.Identity, logi
 	return redirect, stateBytes, nil
 }
 
-func (p *pdsProvider) Exchange(ctx context.Context, did syntax.DID, code string, issuer string, stateBytes []byte) error {
+func (p *pdsProvider) Exchange(
+	ctx context.Context,
+	did syntax.DID,
+	code string,
+	issuer string,
+	stateBytes []byte,
+) error {
 	var s pdsProviderState
 	if err := json.Unmarshal(stateBytes, &s); err != nil {
 		return fmt.Errorf("unmarshal pds provider state: %w", err)

--- a/internal/login/pds.go
+++ b/internal/login/pds.go
@@ -42,8 +42,11 @@ func (p *pdsProvider) Authorize(ctx context.Context, id *identity.Identity) (str
 	// If the org has a public ATProto DID mapping, resolve it and use
 	// that identity's PDS (the org's public identity) for the OAuth flow.
 	// If no mapping exists (e.g. everyone org), use the identity as-is.
-	publicDID, err := p.mappingStore.GetPublicDID(ctx, id.DID)
-	if err == nil && publicDID != nil && p.dir != nil {
+	var publicDID *syntax.DID
+	if p.mappingStore != nil {
+		publicDID, _ = p.mappingStore.GetPublicDID(ctx, id.DID)
+	}
+	if publicDID != nil && p.dir != nil {
 		publicID, lookupErr := p.dir.LookupDID(ctx, *publicDID)
 		if lookupErr == nil {
 			id = publicID

--- a/internal/login/pds.go
+++ b/internal/login/pds.go
@@ -15,15 +15,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type mappingStore interface {
-	GetPublicDID(ctx context.Context, did syntax.DID) (*syntax.DID, error)
-}
-
 type pdsProvider struct {
-	oauthClient  pdsclient.PdsOAuthClient
-	credStore    pdscred.PDSCredentialStore
-	mappingStore mappingStore
-	dir          identity.Directory
+	oauthClient pdsclient.PdsOAuthClient
+	credStore   pdscred.PDSCredentialStore
+	dir         identity.Directory
 }
 
 // pdsProviderState is the opaque flash state for the PDS login flow.
@@ -32,24 +27,23 @@ type pdsProviderState struct {
 	AuthorizeState pdsclient.AuthorizeState `json:"authorize_state"`
 }
 
-func NewPDSProvider(oauthClient pdsclient.PdsOAuthClient, credStore pdscred.PDSCredentialStore, ms mappingStore, dir identity.Directory) Provider {
-	return &pdsProvider{oauthClient: oauthClient, credStore: credStore, mappingStore: ms, dir: dir}
+func NewPDSProvider(oauthClient pdsclient.PdsOAuthClient, credStore pdscred.PDSCredentialStore, dir identity.Directory) Provider {
+	return &pdsProvider{oauthClient: oauthClient, credStore: credStore, dir: dir}
 }
 
 func (p *pdsProvider) LoginMethod() string { return "atproto" }
 
-func (p *pdsProvider) Authorize(ctx context.Context, id *identity.Identity) (string, []byte, error) {
-	// If the org has a public ATProto DID mapping, resolve it and use
-	// that identity's PDS (the org's public identity) for the OAuth flow.
-	// If no mapping exists (e.g. everyone org), use the identity as-is.
-	var publicDID *syntax.DID
-	if p.mappingStore != nil {
-		publicDID, _ = p.mappingStore.GetPublicDID(ctx, id.DID)
-	}
-	if publicDID != nil && p.dir != nil {
-		publicID, lookupErr := p.dir.LookupDID(ctx, *publicDID)
-		if lookupErr == nil {
-			id = publicID
+func (p *pdsProvider) Authorize(ctx context.Context, id *identity.Identity, loginID string) (string, []byte, error) {
+	// If the member has a public ATProto DID as their loginID, resolve it and use
+	// that identity's PDS for the OAuth flow. If no loginID (e.g. everyone org),
+	// use the identity as-is.
+	if loginID != "" && p.dir != nil {
+		publicDID, err := syntax.ParseDID(loginID)
+		if err == nil {
+			publicID, lookupErr := p.dir.LookupDID(ctx, publicDID)
+			if lookupErr == nil {
+				id = publicID
+			}
 		}
 	}
 

--- a/internal/login/pds.go
+++ b/internal/login/pds.go
@@ -46,14 +46,16 @@ func (p *pdsProvider) Authorize(
 	// If the member has a public ATProto DID as their loginID, resolve it and use
 	// that identity's PDS for the OAuth flow. If no loginID (e.g. everyone org),
 	// use the identity as-is.
-	if loginID != "" && p.dir != nil {
+	if loginID != "" {
 		publicDID, err := syntax.ParseDID(loginID)
-		if err == nil {
-			publicID, lookupErr := p.dir.LookupDID(ctx, publicDID)
-			if lookupErr == nil {
-				id = publicID
-			}
+		if err != nil {
+			return "", nil, fmt.Errorf("parse loginID: %w", err)
 		}
+		publicID, err := p.dir.LookupDID(ctx, publicDID)
+		if err != nil {
+			return "", nil, fmt.Errorf("lookup loginID: %w", err)
+		}
+		id = publicID
 	}
 
 	dpopKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/internal/login/pds.go
+++ b/internal/login/pds.go
@@ -38,7 +38,18 @@ func NewPDSProvider(oauthClient pdsclient.PdsOAuthClient, credStore pdscred.PDSC
 
 func (p *pdsProvider) LoginMethod() string { return "atproto" }
 
-func (p *pdsProvider) Authorize(_ context.Context, id *identity.Identity) (string, []byte, error) {
+func (p *pdsProvider) Authorize(ctx context.Context, id *identity.Identity) (string, []byte, error) {
+	// If the org has a public ATProto DID mapping, resolve it and use
+	// that identity's PDS (the org's public identity) for the OAuth flow.
+	// If no mapping exists (e.g. everyone org), use the identity as-is.
+	publicDID, err := p.mappingStore.GetPublicDID(ctx, id.DID)
+	if err == nil && publicDID != nil && p.dir != nil {
+		publicID, lookupErr := p.dir.LookupDID(ctx, *publicDID)
+		if lookupErr == nil {
+			id = publicID
+		}
+	}
+
 	dpopKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return "", nil, fmt.Errorf("generate dpop key: %w", err)

--- a/internal/login/provider.go
+++ b/internal/login/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/org"
 )
 
 // Provider abstracts a login backend. Each implementation handles a specific
@@ -14,13 +15,17 @@ import (
 type Provider interface {
 	// LoginMethod returns a stable identifier used to route authorization
 	// requests to the correct provider based on the org's configured method.
-	LoginMethod() string
+	LoginMethod() org.LoginMethod
 
 	// Authorize starts the auth flow and returns the redirect URL plus opaque
 	// provider-specific state to be stored in the session flash.
 	// loginID is the provider-specific identifier stored on the Member
 	// (e.g. password hash, public ATProto DID, google email).
-	Authorize(ctx context.Context, id *identity.Identity, loginID string) (redirectUri string, state []byte, err error)
+	Authorize(
+		ctx context.Context,
+		id *identity.Identity,
+		loginID string,
+	) (redirectUri string, state []byte, err error)
 
 	// Exchange exchanges the callback code for credentials and should persist
 	// whatever credentials the provider acquires.
@@ -29,11 +34,11 @@ type Provider interface {
 
 // Router selects the correct Provider for a given login method.
 type Router struct {
-	providers map[string]Provider
+	providers map[org.LoginMethod]Provider
 }
 
 func NewRouter(providers ...Provider) *Router {
-	r := &Router{providers: make(map[string]Provider, len(providers))}
+	r := &Router{providers: make(map[org.LoginMethod]Provider, len(providers))}
 	for _, p := range providers {
 		r.providers[p.LoginMethod()] = p
 	}
@@ -41,7 +46,7 @@ func NewRouter(providers ...Provider) *Router {
 }
 
 // ByLoginMethod returns the provider registered for the given login method.
-func (r *Router) ByLoginMethod(method string) (Provider, error) {
+func (r *Router) ByLoginMethod(method org.LoginMethod) (Provider, error) {
 	p, ok := r.providers[method]
 	if !ok {
 		return nil, fmt.Errorf("no login provider for method %q", method)

--- a/internal/login/provider.go
+++ b/internal/login/provider.go
@@ -18,7 +18,9 @@ type Provider interface {
 
 	// Authorize starts the auth flow and returns the redirect URL plus opaque
 	// provider-specific state to be stored in the session flash.
-	Authorize(ctx context.Context, id *identity.Identity) (redirectUri string, state []byte, err error)
+	// loginID is the provider-specific identifier stored on the Member
+	// (e.g. password hash, public ATProto DID, google email).
+	Authorize(ctx context.Context, id *identity.Identity, loginID string) (redirectUri string, state []byte, err error)
 
 	// Exchange exchanges the callback code for credentials and should persist
 	// whatever credentials the provider acquires.

--- a/internal/login/provider.go
+++ b/internal/login/provider.go
@@ -8,22 +8,13 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
 
-type ProviderType = string
-
-const (
-	ProviderTypePDS     ProviderType = "pds"
-	ProviderTypeHabitat ProviderType = "habitat"
-)
-
 // Provider abstracts a login backend. Each implementation handles a specific
-// login type (ex: PDS, habitat-org-password, Identity provider / SSO) and is responsible for its own credential storage.
+// login method (e.g., "atproto", "google", "password") and is responsible for
+// its own credential storage.
 type Provider interface {
-	// Type returns a stable identifier stored in the session flash so
-	// HandleCallback can route to the correct provider without re-resolving the DID.
-	Type() ProviderType
-
-	// CanHandle returns true if this provider handles the given identity.
-	CanHandle(id *identity.Identity) bool
+	// LoginMethod returns a stable identifier used to route authorization
+	// requests to the correct provider based on the org's configured method.
+	LoginMethod() string
 
 	// Authorize starts the auth flow and returns the redirect URL plus opaque
 	// provider-specific state to be stored in the session flash.
@@ -34,32 +25,24 @@ type Provider interface {
 	Exchange(ctx context.Context, did syntax.DID, code string, issuer string, state []byte) error
 }
 
-// Router selects the correct Provider for a given identity.
+// Router selects the correct Provider for a given login method.
 type Router struct {
-	providers []Provider
+	providers map[string]Provider
 }
 
 func NewRouter(providers ...Provider) *Router {
-	return &Router{providers: providers}
+	r := &Router{providers: make(map[string]Provider, len(providers))}
+	for _, p := range providers {
+		r.providers[p.LoginMethod()] = p
+	}
+	return r
 }
 
-// For returns the first provider whose CanHandle returns true.
-// It is assumed that only one provider matches the given identity (for now)
-func (r *Router) For(id *identity.Identity) (Provider, error) {
-	for _, p := range r.providers {
-		if p.CanHandle(id) {
-			return p, nil
-		}
+// ByLoginMethod returns the provider registered for the given login method.
+func (r *Router) ByLoginMethod(method string) (Provider, error) {
+	p, ok := r.providers[method]
+	if !ok {
+		return nil, fmt.Errorf("no login provider for method %q", method)
 	}
-	return nil, fmt.Errorf("no login provider for identity %s", id.DID)
-}
-
-// ByType returns the provider registered for the given ProviderType.
-func (r *Router) ByType(t ProviderType) (Provider, error) {
-	for _, p := range r.providers {
-		if p.Type() == t {
-			return p, nil
-		}
-	}
-	return nil, fmt.Errorf("no login provider of type %q", t)
+	return p, nil
 }

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -42,10 +42,10 @@ const (
 // This data is temporarily stored during the OAuth authorization flow to preserve
 // request context across redirects.
 type authRequestFlash struct {
-	Form          url.Values  // Original authorization request form data
-	LoginMethod   string      // Which login method initiated this flow
-	ProviderState []byte      // Opaque provider-specific state
-	Did           syntax.DID  // DID of the user
+	Form          url.Values // Original authorization request form data
+	LoginMethod   string     // Which login method initiated this flow
+	ProviderState []byte     // Opaque provider-specific state
+	Did           syntax.DID // DID of the user
 }
 
 type metrics struct {
@@ -298,7 +298,15 @@ func (o *OAuthServer) HandleAuthorize(
 		utils.LogAndHTTPError(w, err, "no login provider for org", http.StatusBadRequest)
 		return
 	}
-	redirect, providerState, err := provider.Authorize(ctx, id)
+
+	// Look up the member's login ID (provider-specific identifier) from the store.
+	// If the DID isn't a member (e.g. everyone org), loginID stays empty.
+	loginID := ""
+	if member, err := o.orgStore.GetMember(ctx, id.DID); err == nil {
+		loginID = member.LoginID
+	}
+
+	redirect, providerState, err := provider.Authorize(ctx, id, loginID)
 	if err != nil {
 		o.metrics.authorizeErr(err, "begin_login")
 		utils.LogAndHTTPError(w, err, "failed to initiate authorization", http.StatusInternalServerError)

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -321,12 +321,14 @@ func (o *OAuthServer) HandleAuthorize(
 
 	// Look up the member's login ID (provider-specific identifier) from the store.
 	// If the DID isn't a member (e.g. everyone org), loginID stays empty.
-	loginID := ""
-	if member, err := o.orgStore.GetMember(ctx, id.DID); err == nil {
-		loginID = member.LoginID
+	member, err := o.orgStore.GetMember(ctx, id.DID)
+	if err != nil {
+		o.metrics.authorizeErr(err, "get_member")
+		utils.LogAndHTTPError(w, err, "no member found for identity", http.StatusBadRequest)
+		return
 	}
 
-	redirect, providerState, err := provider.Authorize(ctx, id, loginID)
+	redirect, providerState, err := provider.Authorize(ctx, id, member.LoginID)
 	if err != nil {
 		o.metrics.authorizeErr(err, "begin_login")
 		utils.LogAndHTTPError(

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -42,10 +42,10 @@ const (
 // This data is temporarily stored during the OAuth authorization flow to preserve
 // request context across redirects.
 type authRequestFlash struct {
-	Form          url.Values // Original authorization request form data
-	LoginMethod   string     // Which login method initiated this flow
-	ProviderState []byte     // Opaque provider-specific state
-	Did           syntax.DID // DID of the user
+	Form          url.Values      // Original authorization request form data
+	LoginMethod   org.LoginMethod // Which login method initiated this flow
+	ProviderState []byte          // Opaque provider-specific state
+	Did           syntax.DID      // DID of the user
 }
 
 type metrics struct {
@@ -62,27 +62,47 @@ type metrics struct {
 }
 
 func newMetrics(meter metric.Meter) (*metrics, error) {
-	authorizeErrCtr, err := meter.Int64Counter("oauth.authorize.err", metric.WithUnit("Item"), metric.WithDescription("counts errors in OAuth /authorize implementation"))
+	authorizeErrCtr, err := meter.Int64Counter(
+		"oauth.authorize.err",
+		metric.WithUnit("Item"),
+		metric.WithDescription("counts errors in OAuth /authorize implementation"),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	authorizeSuccessCtr, err := meter.Int64Counter("oauth.authorize.success", metric.WithUnit("Item"), metric.WithDescription("counts successes in OAuth /authorize implementation"))
+	authorizeSuccessCtr, err := meter.Int64Counter(
+		"oauth.authorize.success",
+		metric.WithUnit("Item"),
+		metric.WithDescription("counts successes in OAuth /authorize implementation"),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	callbackErrCtr, err := meter.Int64Counter("oauth.callback.err", metric.WithUnit("Item"), metric.WithDescription("counts errors in OAuth /callback implementation"))
+	callbackErrCtr, err := meter.Int64Counter(
+		"oauth.callback.err",
+		metric.WithUnit("Item"),
+		metric.WithDescription("counts errors in OAuth /callback implementation"),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	callbackSuccessCtr, err := meter.Int64Counter("oauth.callback.success", metric.WithUnit("Item"), metric.WithDescription("counts successes in OAuth /callback implementation"))
+	callbackSuccessCtr, err := meter.Int64Counter(
+		"oauth.callback.success",
+		metric.WithUnit("Item"),
+		metric.WithDescription("counts successes in OAuth /callback implementation"),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	refreshTokenRequestCtr, err := meter.Int64Counter("oauth.refresh_token.request", metric.WithUnit("Item"), metric.WithDescription("counts request to refresh an OAuth token with habitat"))
+	refreshTokenRequestCtr, err := meter.Int64Counter(
+		"oauth.refresh_token.request",
+		metric.WithUnit("Item"),
+		metric.WithDescription("counts request to refresh an OAuth token with habitat"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +329,12 @@ func (o *OAuthServer) HandleAuthorize(
 	redirect, providerState, err := provider.Authorize(ctx, id, loginID)
 	if err != nil {
 		o.metrics.authorizeErr(err, "begin_login")
-		utils.LogAndHTTPError(w, err, "failed to initiate authorization", http.StatusInternalServerError)
+		utils.LogAndHTTPError(
+			w,
+			err,
+			"failed to initiate authorization",
+			http.StatusInternalServerError,
+		)
 		return
 	}
 
@@ -317,7 +342,12 @@ func (o *OAuthServer) HandleAuthorize(
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		o.metrics.authorizeErr(err, "gen_flash_id")
-		utils.LogAndHTTPError(w, err, "failed to generate session id", http.StatusInternalServerError)
+		utils.LogAndHTTPError(
+			w,
+			err,
+			"failed to generate session id",
+			http.StatusInternalServerError,
+		)
 		return
 	}
 	flashID := hex.EncodeToString(b)
@@ -401,8 +431,13 @@ func (o *OAuthServer) HandleCallback(
 	_, err = o.orgStore.GetOrgForDID(r.Context(), arf.Did)
 	if err != nil {
 		o.metrics.callbackErr(err, "allowlist_dids")
-		o.provider.WriteAuthorizeError(ctx, w, authRequest,
-			fosite.ErrAccessDenied.WithDescription("You are not a member of this habitat organization.").WithHint(""))
+		o.provider.WriteAuthorizeError(
+			ctx,
+			w,
+			authRequest,
+			fosite.ErrAccessDenied.WithDescription("You are not a member of this habitat organization.").
+				WithHint(""),
+		)
 		return
 	}
 	provider, err := o.loginRouter.ByLoginMethod(arf.LoginMethod)
@@ -506,13 +541,21 @@ func (o *OAuthServer) Validate(
 	if err != nil || !ok {
 		// TODO: we should delegate the response to o.provider.WriteIntrospectionError(ctx, w, err)
 		// Unfortunately that was returning a 200 http response, so we write our own error here.
-		utils.WriteHTTPError(w, fmt.Errorf("unable to validate oauth token: %w", err), http.StatusUnauthorized)
+		utils.WriteHTTPError(
+			w,
+			fmt.Errorf("unable to validate oauth token: %w", err),
+			http.StatusUnauthorized,
+		)
 		return "", false
 	}
 
 	_, err = o.orgStore.GetOrgForDID(r.Context(), did)
 	if err != nil {
-		utils.WriteHTTPError(w, fmt.Errorf("not a member of this organization"), http.StatusUnauthorized)
+		utils.WriteHTTPError(
+			w,
+			fmt.Errorf("not a member of this organization"),
+			http.StatusUnauthorized,
+		)
 		return "", false
 	}
 

--- a/internal/oauthserver/oauth_server.go
+++ b/internal/oauthserver/oauth_server.go
@@ -42,10 +42,10 @@ const (
 // This data is temporarily stored during the OAuth authorization flow to preserve
 // request context across redirects.
 type authRequestFlash struct {
-	Form          url.Values         // Original authorization request form data
-	ProviderType  login.ProviderType // Which login provider initiated this flow
-	ProviderState []byte             // Opaque provider-specific state
-	Did           syntax.DID         // DID of the user
+	Form          url.Values  // Original authorization request form data
+	LoginMethod   string      // Which login method initiated this flow
+	ProviderState []byte      // Opaque provider-specific state
+	Did           syntax.DID  // DID of the user
 }
 
 type metrics struct {
@@ -152,7 +152,7 @@ type OAuthServer struct {
 
 	provider    fosite.OAuth2Provider
 	credStore   pdscred.PDSCredentialStore // Database storage for OAuth sessions
-	loginRouter *login.Router              // Routes login flows by DID service endpoint
+	loginRouter *login.Router              // Routes login flows by org login method
 	directory   identity.Directory         // AT Protocol identity directory for handle resolution
 	storage     *store
 
@@ -284,10 +284,18 @@ func (o *OAuthServer) HandleAuthorize(
 		return
 	}
 
-	provider, err := o.loginRouter.For(id)
+	// Look up org to determine the login method
+	org, err := o.orgStore.GetOrgForDID(ctx, id.DID)
+	if err != nil {
+		o.metrics.authorizeErr(err, "no_org")
+		utils.LogAndHTTPError(w, err, "no org found for identity", http.StatusBadRequest)
+		return
+	}
+
+	provider, err := o.loginRouter.ByLoginMethod(org.LoginMethod())
 	if err != nil {
 		o.metrics.authorizeErr(err, "no_provider")
-		utils.LogAndHTTPError(w, err, "no login provider for identity", http.StatusBadRequest)
+		utils.LogAndHTTPError(w, err, "no login provider for org", http.StatusBadRequest)
 		return
 	}
 	redirect, providerState, err := provider.Authorize(ctx, id)
@@ -309,7 +317,7 @@ func (o *OAuthServer) HandleAuthorize(
 	o.flashMu.Lock()
 	o.flashStore[flashID] = &authRequestFlash{
 		Form:          requester.GetRequestForm(),
-		ProviderType:  provider.Type(),
+		LoginMethod:   provider.LoginMethod(),
 		ProviderState: providerState,
 		Did:           id.DID,
 	}
@@ -389,7 +397,7 @@ func (o *OAuthServer) HandleCallback(
 			fosite.ErrAccessDenied.WithDescription("You are not a member of this habitat organization.").WithHint(""))
 		return
 	}
-	provider, err := o.loginRouter.ByType(arf.ProviderType)
+	provider, err := o.loginRouter.ByLoginMethod(arf.LoginMethod)
 	if err != nil {
 		o.metrics.callbackErr(err, "no_provider")
 		utils.LogAndHTTPError(w, err, "no login provider for session", http.StatusBadRequest)

--- a/internal/oauthserver/oauth_server_test.go
+++ b/internal/oauthserver/oauth_server_test.go
@@ -28,12 +28,6 @@ import (
 	"gorm.io/gorm"
 )
 
-type stubMappingStore struct{}
-
-func (s *stubMappingStore) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
-	return nil, nil
-}
-
 // testStore creates a Store with a seeded test org.
 func testStore(t *testing.T) org.Store {
 	t.Helper()
@@ -71,7 +65,7 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 	require.NoError(t, err)
 	oauthSrv, err := NewOAuthServer(
 		secret,
-		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil)),
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, nil)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -168,7 +162,7 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 
 	oauthServer, err := NewOAuthServer(
 		bytes,
-		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil)),
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, nil)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -284,7 +278,7 @@ func TestOAuthServerE2E(t *testing.T) {
 
 	oauthServer, err := NewOAuthServer(
 		bytes,
-		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil)),
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, nil)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -532,7 +526,7 @@ func TestValidate(t *testing.T) {
 	newSrv := func(st org.Store) *OAuthServer {
 		s, srvErr := NewOAuthServer(
 			bytes,
-			login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil)),
+			login.NewRouter(login.NewPDSProvider(oauthClient, credStore, nil)),
 			node.NewDummy(),
 			pdsclient.NewDummyDirectory("http://pds.url"),
 			credStore,

--- a/internal/oauthserver/oauth_server_test.go
+++ b/internal/oauthserver/oauth_server_test.go
@@ -28,6 +28,12 @@ import (
 	"gorm.io/gorm"
 )
 
+type stubMappingStore struct{}
+
+func (s *stubMappingStore) GetPublicDID(_ context.Context, _ syntax.DID) (*syntax.DID, error) {
+	return nil, nil
+}
+
 // testStore creates a Store with a seeded test org.
 func testStore(t *testing.T) org.Store {
 	t.Helper()
@@ -65,7 +71,7 @@ func TestOAuthServerErrorPaths(t *testing.T) {
 	require.NoError(t, err)
 	oauthSrv, err := NewOAuthServer(
 		secret,
-		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -162,7 +168,7 @@ func TestHandleCallbackDIDNotInAllowlist(t *testing.T) {
 
 	oauthServer, err := NewOAuthServer(
 		bytes,
-		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -278,7 +284,7 @@ func TestOAuthServerE2E(t *testing.T) {
 
 	oauthServer, err := NewOAuthServer(
 		bytes,
-		login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
+		login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil)),
 		node.NewDummy(),
 		pdsclient.NewDummyDirectory("http://pds.url"),
 		credStore,
@@ -526,7 +532,7 @@ func TestValidate(t *testing.T) {
 	newSrv := func(st org.Store) *OAuthServer {
 		s, srvErr := NewOAuthServer(
 			bytes,
-			login.NewRouter(login.NewPDSProvider(oauthClient, credStore)),
+			login.NewRouter(login.NewPDSProvider(oauthClient, credStore, &stubMappingStore{}, nil)),
 			node.NewDummy(),
 			pdsclient.NewDummyDirectory("http://pds.url"),
 			credStore,

--- a/internal/org/login_provider.go
+++ b/internal/org/login_provider.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/alexedwards/argon2id"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	jose "github.com/go-jose/go-jose/v3"
@@ -54,6 +52,7 @@ func (p *LoginProvider) LoginMethod() string { return "password" }
 func (p *LoginProvider) Authorize(
 	_ context.Context,
 	id *identity.Identity,
+	_ string,
 ) (string, []byte, error) {
 	redirect := "https://" + p.frontendDomain + "/login/habitat?handle=" + url.QueryEscape(
 		string(id.Handle),
@@ -107,16 +106,20 @@ func (p *LoginProvider) HandlePasswordLogin(w http.ResponseWriter, r *http.Reque
 	}
 
 	id, err := p.dir.Lookup(r.Context(), atid)
+	if err != nil {
+		http.Error(w, "invalid handle", http.StatusUnauthorized)
+		return
+	}
 
 	member, err := p.store.GetMember(r.Context(), id.DID)
-	ok, err := verifyPassword(req.Password, member.PasswordHash)
-	if !errors.Is(err, argon2id.ErrInvalidHash) {
-		utils.LogAndHTTPError(
-			w,
-			fmt.Errorf("error while authenticating"),
-			err.Error(),
-			http.StatusInternalServerError,
-		)
+	if err != nil {
+		http.Error(w, "invalid credentials", http.StatusUnauthorized)
+		return
+	}
+	ok, err := verifyPassword(req.Password, member.LoginID)
+	if err != nil {
+		utils.LogAndHTTPError(w, err, "error while authenticating", http.StatusInternalServerError)
+		return
 	}
 	if !ok {
 		http.Error(w, "invalid credentials", http.StatusUnauthorized)

--- a/internal/org/login_provider.go
+++ b/internal/org/login_provider.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/alexedwards/argon2id"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	jose "github.com/go-jose/go-jose/v3"
@@ -28,20 +29,32 @@ type LoginProvider struct {
 	store          Store
 	frontendDomain string
 	signingSecret  []byte
+	dir            identity.Directory
 }
 
-func NewLoginProvider(store Store, frontendDomain string, signingSecret []byte) *LoginProvider {
+func NewLoginProvider(
+	store Store,
+	frontendDomain string,
+	signingSecret []byte,
+	dir identity.Directory,
+) *LoginProvider {
 	return &LoginProvider{
 		store:          store,
 		frontendDomain: frontendDomain,
 		signingSecret:  signingSecret,
+		dir:            dir,
 	}
 }
 
 func (p *LoginProvider) LoginMethod() string { return "password" }
 
-func (p *LoginProvider) Authorize(_ context.Context, id *identity.Identity) (string, []byte, error) {
-	redirect := "https://" + p.frontendDomain + "/login/habitat?handle=" + url.QueryEscape(string(id.Handle))
+func (p *LoginProvider) Authorize(
+	_ context.Context,
+	id *identity.Identity,
+) (string, []byte, error) {
+	redirect := "https://" + p.frontendDomain + "/login/habitat?handle=" + url.QueryEscape(
+		string(id.Handle),
+	)
 	return redirect, nil, nil
 }
 
@@ -84,10 +97,23 @@ func (p *LoginProvider) HandlePasswordLogin(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	ok, err := p.store.AuthenticateMember(r.Context(), req.Handle, req.Password)
+	atid, err := syntax.ParseAtIdentifier(req.Handle)
 	if err != nil {
-		utils.LogAndHTTPError(w, fmt.Errorf("error while authenticating"), err.Error(), http.StatusInternalServerError)
+		utils.LogAndHTTPError(w, err, "parsing at identifier", http.StatusBadRequest)
 		return
+	}
+
+	id, err := p.dir.Lookup(r.Context(), atid)
+
+	member, err := p.store.GetMember(r.Context(), id.DID)
+	ok, err := verifyPassword(req.Password, member.PasswordHash)
+	if !errors.Is(err, argon2id.ErrInvalidHash) {
+		utils.LogAndHTTPError(
+			w,
+			fmt.Errorf("error while authenticating"),
+			err.Error(),
+			http.StatusInternalServerError,
+		)
 	}
 	if !ok {
 		http.Error(w, "invalid credentials", http.StatusUnauthorized)

--- a/internal/org/login_provider.go
+++ b/internal/org/login_provider.go
@@ -38,13 +38,7 @@ func NewLoginProvider(store Store, frontendDomain string, signingSecret []byte) 
 	}
 }
 
-func (p *LoginProvider) Type() string { return "habitat" }
-
-func (p *LoginProvider) CanHandle(id *identity.Identity) bool {
-	_, hasHabitat := id.Services["habitat"]
-	_, hasPDS := id.Services["atproto_pds"]
-	return hasHabitat && !hasPDS
-}
+func (p *LoginProvider) LoginMethod() string { return "password" }
 
 func (p *LoginProvider) Authorize(_ context.Context, id *identity.Identity) (string, []byte, error) {
 	redirect := "https://" + p.frontendDomain + "/login/habitat?handle=" + url.QueryEscape(string(id.Handle))

--- a/internal/org/login_provider.go
+++ b/internal/org/login_provider.go
@@ -47,7 +47,7 @@ func NewLoginProvider(
 	}
 }
 
-func (p *LoginProvider) LoginMethod() string { return "password" }
+func (p *LoginProvider) LoginMethod() LoginMethod { return LoginMethodPassword }
 
 func (p *LoginProvider) Authorize(
 	_ context.Context,

--- a/internal/org/login_provider_test.go
+++ b/internal/org/login_provider_test.go
@@ -43,6 +43,7 @@ func newTestLoginProvider(t *testing.T) (*LoginProvider, *orgImpl) {
 		"pear.example.com",
 		"frontend.example.com",
 		testSigningSecret,
+		h,
 	), scoped.(*orgImpl)
 }
 
@@ -56,7 +57,7 @@ func TestLoginProvider_Authorize(t *testing.T) {
 	id := &identity.Identity{
 		Handle: "alice.example.com",
 	}
-	redirect, state, err := p.Authorize(context.Background(), id)
+	redirect, state, err := p.Authorize(context.Background(), id, "")
 	require.NoError(t, err)
 	require.Nil(t, state)
 	require.Equal(
@@ -71,7 +72,7 @@ func TestLoginProvider_Authorize_HandleEscaping(t *testing.T) {
 	id := &identity.Identity{
 		Handle: "alice bob",
 	}
-	redirect, _, err := p.Authorize(context.Background(), id)
+	redirect, _, err := p.Authorize(context.Background(), id, "")
 	require.NoError(t, err)
 	require.Contains(t, redirect, "handle=alice+bob")
 }

--- a/internal/org/login_provider_test.go
+++ b/internal/org/login_provider_test.go
@@ -40,42 +40,9 @@ func newTestLoginProvider(t *testing.T) (*LoginProvider, *orgImpl) {
 	return NewLoginProvider(s, "frontend.example.com", testSigningSecret), scoped.(*orgImpl)
 }
 
-func TestLoginProvider_Type(t *testing.T) {
+func TestLoginProvider_LoginMethod(t *testing.T) {
 	p, _ := newTestLoginProvider(t)
-	require.Equal(t, "habitat", p.Type())
-}
-
-func TestLoginProvider_CanHandle(t *testing.T) {
-	p, _ := newTestLoginProvider(t)
-
-	habitatOnly := &identity.Identity{
-		DID: "did:web:habitat.example.com",
-		Services: map[string]identity.ServiceEndpoint{
-			"habitat": {URL: "https://habitat.example.com"},
-		},
-	}
-	pdsOnly := &identity.Identity{
-		DID: "did:web:pds.example.com",
-		Services: map[string]identity.ServiceEndpoint{
-			"atproto_pds": {URL: "https://pds.example.com"},
-		},
-	}
-	both := &identity.Identity{
-		DID: "did:web:both.example.com",
-		Services: map[string]identity.ServiceEndpoint{
-			"atproto_pds": {URL: "https://pds.example.com"},
-			"habitat":     {URL: "https://habitat.example.com"},
-		},
-	}
-	none := &identity.Identity{
-		DID:      "did:web:nobody.example.com",
-		Services: map[string]identity.ServiceEndpoint{},
-	}
-
-	require.True(t, p.CanHandle(habitatOnly))
-	require.False(t, p.CanHandle(pdsOnly))
-	require.False(t, p.CanHandle(both))
-	require.False(t, p.CanHandle(none))
+	require.Equal(t, "password", p.LoginMethod())
 }
 
 func TestLoginProvider_Authorize(t *testing.T) {

--- a/internal/org/login_provider_test.go
+++ b/internal/org/login_provider_test.go
@@ -49,7 +49,7 @@ func newTestLoginProvider(t *testing.T) (*LoginProvider, *orgImpl) {
 
 func TestLoginProvider_LoginMethod(t *testing.T) {
 	p, _ := newTestLoginProvider(t)
-	require.Equal(t, "password", p.LoginMethod())
+	require.Equal(t, LoginMethodPassword, p.LoginMethod())
 }
 
 func TestLoginProvider_Authorize(t *testing.T) {

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -1,6 +1,10 @@
 package org
 
-import "time"
+import (
+	"time"
+
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
 
 type LoginMethod string
 
@@ -24,8 +28,8 @@ type organization struct {
 type member struct {
 	OrgID        string       `gorm:"primaryKey"`
 	Organization organization `gorm:"foreignKey:OrgID"`
-	Did          string       `gorm:"primaryKey"`
-	Role         string       `gorm:"not null"`
+	Did          syntax.DID   `gorm:"primaryKey"`
+	Role         Role         `gorm:"not null"`
 	LoginID      string       `gorm:"not null"` // provider-specific identifier (password hash, public ATProto DID, google email, etc.)
 
 	// Automatically populated by gorm

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -2,12 +2,20 @@ package org
 
 import "time"
 
+type LoginMethod string
+
+const (
+	LoginMethodAtproto  LoginMethod = "atproto"
+	LoginMethodGoogle   LoginMethod = "google"
+	LoginMethodPassword LoginMethod = "password"
+)
+
 // organization represents a managed org on a pear instance.
 type organization struct {
-	ID            string `gorm:"primaryKey"`
-	Name          string // optional display name
-	LoginMethod   string // "atproto", "google", "password"
-	SigningSecret string // base64-encoded HMAC-SHA256 key for invite tokens
+	ID            string      `gorm:"primaryKey"`
+	Name          string      // optional display name
+	LoginMethod   LoginMethod // "atproto", "google", "password"
+	SigningSecret string      // base64-encoded HMAC-SHA256 key for invite tokens
 	CreatedAt     time.Time
 }
 

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -24,8 +24,8 @@ type organization struct {
 type Member struct {
 	OrgID   string `gorm:"primaryKey"`
 	Member  string `gorm:"primaryKey"`
-	Role    string
-	LoginID string // provider-specific identifier (password hash, public ATProto DID, google email, etc.)
+	Role    string `gorm:"not null"`
+	LoginID string `gorm:"not null"` // provider-specific identifier (password hash, public ATProto DID, google email, etc.)
 
 	// Automatically populated by gorm
 	CreatedAt time.Time

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -14,10 +14,10 @@ type organization struct {
 // Keep track of members in the org.
 // Each Member belongs to exactly one org.
 type Member struct {
-	OrgID        string `gorm:"primaryKey"`
-	Member       string `gorm:"primaryKey"`
-	Role         string
-	PasswordHash string `gorm:"not null"`
+	OrgID   string `gorm:"primaryKey"`
+	Member  string `gorm:"primaryKey"`
+	Role    string
+	LoginID string // provider-specific identifier (password hash, public ATProto DID, google email, etc.)
 
 	// Automatically populated by gorm
 	CreatedAt time.Time

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -6,6 +6,7 @@ import "time"
 type organization struct {
 	ID            string `gorm:"primaryKey"`
 	Name          string // optional display name
+	LoginMethod   string // "atproto", "google", "password"
 	SigningSecret string // base64-encoded HMAC-SHA256 key for invite tokens
 	CreatedAt     time.Time
 }

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -20,12 +20,13 @@ type organization struct {
 }
 
 // Keep track of members in the org.
-// Each Member belongs to exactly one org.
-type Member struct {
-	OrgID   string `gorm:"primaryKey"`
-	Member  string `gorm:"primaryKey"`
-	Role    string `gorm:"not null"`
-	LoginID string `gorm:"not null"` // provider-specific identifier (password hash, public ATProto DID, google email, etc.)
+// Each member belongs to exactly one org.
+type member struct {
+	OrgID        string       `gorm:"primaryKey"`
+	Organization organization `gorm:"foreignKey:OrgID"`
+	Did          string       `gorm:"primaryKey"`
+	Role         string       `gorm:"not null"`
+	LoginID      string       `gorm:"not null"` // provider-specific identifier (password hash, public ATProto DID, google email, etc.)
 
 	// Automatically populated by gorm
 	CreatedAt time.Time

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -12,8 +12,8 @@ type organization struct {
 }
 
 // Keep track of members in the org.
-// Each member belongs to exactly one org.
-type member struct {
+// Each Member belongs to exactly one org.
+type Member struct {
 	OrgID        string `gorm:"primaryKey"`
 	Member       string `gorm:"primaryKey"`
 	Role         string

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -58,7 +58,7 @@ type Org interface {
 	IsMember(ctx context.Context, did syntax.DID) (bool, error)
 
 	// LoginMethod returns how users authenticate: "atproto", "google", or "password".
-	LoginMethod() string
+	LoginMethod() LoginMethod
 
 	// Org member identity management; may eventually replace some of the methods above
 	IssueIdentityToken(
@@ -106,7 +106,7 @@ func NewOrg(
 	}, nil
 }
 
-func (s *orgImpl) LoginMethod() string {
+func (s *orgImpl) LoginMethod() LoginMethod {
 	var org organization
 	if err := s.db.First(&org, "id = ?", s.orgID).Error; err != nil {
 		return "password" // safe default

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/alexedwards/argon2id"
@@ -21,8 +20,8 @@ import (
 type Role string
 
 const (
-	Admin  Role = "admin"
-	Member Role = "member"
+	AdminRole  Role = "admin"
+	MemberRole Role = "member"
 )
 
 var (
@@ -74,21 +73,6 @@ type Org interface {
 		internalHandle string,
 		password string,
 	) (*identity.Identity, error)
-	AuthenticateMember(ctx context.Context, handle string, password string) (bool, error)
-}
-
-// Store is the registry of all orgs on a pear instance.
-// It routes DIDs to their org and provides cross-org membership checks.
-type Store interface {
-	GetOrg(ctx context.Context, orgID string) (Org, error)
-	GetOrgForDID(ctx context.Context, did syntax.DID) (Org, error)
-	AuthenticateMember(ctx context.Context, handle string, password string) (bool, error)
-	CreateOrg(
-		ctx context.Context,
-		name string,
-		adminHandle string,
-		adminPassword string,
-	) (orgID string, id *identity.Identity, err error)
 }
 
 type inviteTokenClaims struct {
@@ -111,7 +95,7 @@ func NewOrg(
 	db *gorm.DB,
 	signingSecret []byte,
 ) (*orgImpl, error) {
-	if err := db.AutoMigrate(&member{}, &spentToken{}); err != nil {
+	if err := db.AutoMigrate(&Member{}, &spentToken{}); err != nil {
 		return nil, err
 	}
 	return &orgImpl{
@@ -131,9 +115,9 @@ func (s *orgImpl) LoginMethod() string {
 }
 
 func (s *orgImpl) AddAdmin(ctx context.Context, admin syntax.DID) error {
-	result := s.db.WithContext(ctx).Model(&member{}).
+	result := s.db.WithContext(ctx).Model(&Member{}).
 		Where("org_id = ? AND member = ?", s.orgID, admin.String()).
-		Update("role", Admin)
+		Update("role", AdminRole)
 	if result.Error != nil {
 		return result.Error
 	}
@@ -156,10 +140,10 @@ func (s *orgImpl) addMemberTx(
 	return tx.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "org_id"}, {Name: "member"}},
 		DoNothing: true,
-	}).Create(&member{
+	}).Create(&Member{
 		OrgID:        s.orgID,
 		Member:       did.String(),
-		Role:         string(Member),
+		Role:         string(MemberRole),
 		PasswordHash: passwordHash,
 		CreatedAt:    time.Now(),
 	}).Error
@@ -173,9 +157,9 @@ func (s *store) bootstrapAdmin(ctx context.Context, bootstrapSecret string, admi
 */
 
 func (s *orgImpl) GetAdmins(ctx context.Context) ([]syntax.DID, error) {
-	var rows []member
+	var rows []Member
 	if err := s.db.WithContext(ctx).
-		Where("org_id = ? AND role = ?", s.orgID, Admin).
+		Where("org_id = ? AND role = ?", s.orgID, AdminRole).
 		Find(&rows).
 		Error; err != nil {
 		return nil, err
@@ -192,7 +176,7 @@ func (s *orgImpl) GetAdmins(ctx context.Context) ([]syntax.DID, error) {
 }
 
 func (s *orgImpl) GetMembers(ctx context.Context) ([]syntax.DID, error) {
-	var rows []member
+	var rows []Member
 	if err := s.db.WithContext(ctx).Where("org_id = ?", s.orgID).Find(&rows).Error; err != nil {
 		return nil, err
 	}
@@ -210,8 +194,8 @@ func (s *orgImpl) GetMembers(ctx context.Context) ([]syntax.DID, error) {
 func (s *orgImpl) DowngradeAdmin(ctx context.Context, admin syntax.DID) error {
 	var adminCount int64
 	if err := s.db.WithContext(ctx).
-		Model(&member{}).
-		Where("org_id = ? AND role = ?", s.orgID, Admin).
+		Model(&Member{}).
+		Where("org_id = ? AND role = ?", s.orgID, AdminRole).
 		Count(&adminCount).
 		Error; err != nil {
 		return err
@@ -220,17 +204,17 @@ func (s *orgImpl) DowngradeAdmin(ctx context.Context, admin syntax.DID) error {
 		return ErrLastAdmin
 	}
 	return s.db.WithContext(ctx).
-		Model(&member{}).
-		Where("org_id = ? AND member = ? AND role = ?", s.orgID, admin.String(), Admin).
-		Update("role", Member).
+		Model(&Member{}).
+		Where("org_id = ? AND member = ? AND role = ?", s.orgID, admin.String(), AdminRole).
+		Update("role", MemberRole).
 		Error
 }
 
 func (s *orgImpl) RemoveAdmin(ctx context.Context, admin syntax.DID) error {
 	var adminCount int64
 	if err := s.db.WithContext(ctx).
-		Model(&member{}).
-		Where("org_id = ? AND role = ?", s.orgID, Admin).
+		Model(&Member{}).
+		Where("org_id = ? AND role = ?", s.orgID, AdminRole).
 		Count(&adminCount).
 		Error; err != nil {
 		return err
@@ -239,8 +223,8 @@ func (s *orgImpl) RemoveAdmin(ctx context.Context, admin syntax.DID) error {
 		return ErrLastAdmin
 	}
 	return s.db.WithContext(ctx).
-		Where("org_id = ? AND member = ? AND role = ?", s.orgID, admin.String(), Admin).
-		Delete(&member{}).
+		Where("org_id = ? AND member = ? AND role = ?", s.orgID, admin.String(), AdminRole).
+		Delete(&Member{}).
 		Error
 }
 
@@ -250,15 +234,15 @@ func (s *orgImpl) RemoveMembers(ctx context.Context, members []syntax.DID) error
 		dids = append(dids, did.String())
 	}
 	return s.db.WithContext(ctx).
-		Where("org_id = ? AND member IN ? AND role = ?", s.orgID, dids, Member).
-		Delete(&member{}).
+		Where("org_id = ? AND member IN ? AND role = ?", s.orgID, dids, MemberRole).
+		Delete(&Member{}).
 		Error
 }
 
 func (s *orgImpl) IsAdmin(ctx context.Context, did syntax.DID) (bool, error) {
-	var row member
+	var row Member
 	err := s.db.WithContext(ctx).
-		Where("org_id = ? AND member = ? AND role = ?", s.orgID, did.String(), Admin).
+		Where("org_id = ? AND member = ? AND role = ?", s.orgID, did.String(), AdminRole).
 		First(&row).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -268,7 +252,7 @@ func (s *orgImpl) IsAdmin(ctx context.Context, did syntax.DID) (bool, error) {
 }
 
 func (s *orgImpl) IsMember(ctx context.Context, did syntax.DID) (bool, error) {
-	var row member
+	var row Member
 	err := s.db.WithContext(ctx).
 		Where("org_id = ? AND member = ?", s.orgID, did.String()).
 		First(&row).
@@ -387,7 +371,7 @@ func (s *orgImpl) AuthenticateMember(
 		return false, nil
 	}
 
-	var row member
+	var row Member
 	err = s.db.WithContext(ctx).
 		Where("org_id = ? AND member = ?", s.orgID, id.DID.String()).
 		First(&row).
@@ -405,162 +389,4 @@ func (s *orgImpl) AuthenticateMember(
 		return false, nil
 	}
 	return ok, err
-}
-
-// storeImpl is the Store implementation backed by gorm and the identity directory.
-type storeImpl struct {
-	db         *gorm.DB
-	hive       hive.Hive
-	dir        identity.Directory
-	pearDomain string
-	everyone   Org
-}
-
-var _ Store = &storeImpl{}
-
-// NewStore creates a Store that manages multiple orgs on a pear instance.
-func NewStore(
-	db *gorm.DB,
-	hve hive.Hive,
-	dir identity.Directory,
-	pearDomain string,
-) (Store, error) {
-	if err := db.AutoMigrate(&organization{}, &member{}, &spentToken{}); err != nil {
-		return nil, err
-	}
-	return &storeImpl{
-		db:         db,
-		hive:       hve,
-		dir:        dir,
-		pearDomain: pearDomain,
-		everyone:   NewEveryoneOrg(),
-	}, nil
-}
-
-func (s *storeImpl) orgFromModel(org *organization) (*orgImpl, error) {
-	signingSecret, err := base64.StdEncoding.DecodeString(org.SigningSecret)
-	if err != nil {
-		return nil, err
-	}
-	return &orgImpl{
-		orgID:         org.ID,
-		hive:          s.hive,
-		db:            s.db,
-		signingSecret: signingSecret,
-	}, nil
-}
-
-// GetOrg returns the org with the given ID.
-func (s *storeImpl) GetOrg(ctx context.Context, orgID string) (Org, error) {
-	var org organization
-	if err := s.db.WithContext(ctx).Where("id = ?", orgID).First(&org).Error; err != nil {
-		return nil, ErrOrgNotFound
-	}
-	return s.orgFromModel(&org)
-}
-
-// GetOrgForDID returns the org the given DID belongs to.
-// First checks the member table. If the DID isn't in any org, checks if
-// it's managed by our hive. Otherwise returns the everyone org for external DIDs.
-func (s *storeImpl) GetOrgForDID(ctx context.Context, did syntax.DID) (Org, error) {
-	var m member
-	if err := s.db.WithContext(ctx).Where("member = ?", did.String()).First(&m).Error; err == nil {
-		return s.GetOrg(ctx, m.OrgID)
-	}
-
-	id, err := s.dir.LookupDID(ctx, did)
-	if err != nil {
-		return s.everyone, nil
-	}
-
-	svc, hasHabitat := id.Services["habitat"]
-	if hasHabitat && svc.URL == "https://"+s.pearDomain {
-		return nil, ErrMemberNotFound
-	}
-
-	return s.everyone, nil
-}
-
-// AuthenticateMember authenticates a member by handle across all orgs.
-func (s *storeImpl) AuthenticateMember(
-	ctx context.Context,
-	handle string,
-	password string,
-) (bool, error) {
-	id, err := s.hive.LookupHandle(ctx, syntax.Handle(handle))
-	if err != nil {
-		return false, nil
-	}
-
-	org, err := s.GetOrgForDID(ctx, id.DID)
-	if err != nil {
-		return false, nil
-	}
-
-	return org.AuthenticateMember(ctx, handle, password)
-}
-
-// CreateOrg creates a new org with a bootstrap admin member and returns the generated org ID and the admin identity.
-func (s *storeImpl) CreateOrg(
-	ctx context.Context,
-	name string,
-	adminHandle string,
-	adminPassword string,
-) (string, *identity.Identity, error) {
-	// Generate a random org ID
-	orgBytes := make([]byte, 16)
-	if _, err := rand.Read(orgBytes); err != nil {
-		return "", nil, err
-	}
-	orgID := fmt.Sprintf("%x", orgBytes)
-
-	// Generate signing secret
-	secret := make([]byte, 32)
-	if _, err := rand.Read(secret); err != nil {
-		return "", nil, err
-	}
-	signingSecret := base64.StdEncoding.EncodeToString(secret)
-
-	// Hash the admin password
-	passwordHash, err := hashPassword(adminPassword)
-	if err != nil {
-		return "", nil, err
-	}
-
-	// Mint identity for the admin
-	id, persistIdent, err := s.hive.MintIdentity(adminHandle)
-	if err != nil {
-		return "", nil, err
-	}
-
-	// Persist org, identity, and admin member in a single transaction
-	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Create(&organization{
-			ID:            orgID,
-			Name:          name,
-			LoginMethod:   "password", // new orgs default to password auth
-			SigningSecret: signingSecret,
-			CreatedAt:     time.Now(),
-		}).Error; err != nil {
-			if isDuplicateError(err) {
-				return ErrOrgAlreadyExists
-			}
-			return err
-		}
-		if err := persistIdent(tx); err != nil {
-			return err
-		}
-		return tx.Create(&member{
-			OrgID:        orgID,
-			Member:       id.DID.String(),
-			Role:         string(Admin),
-			PasswordHash: passwordHash,
-			CreatedAt:    time.Now(),
-		}).Error
-	})
-	if err != nil {
-		return "", nil, err
-	}
-
-	return orgID, id, nil
 }

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -116,7 +116,7 @@ func (s *orgImpl) LoginMethod() LoginMethod {
 
 func (s *orgImpl) AddAdmin(ctx context.Context, admin syntax.DID) error {
 	result := s.db.WithContext(ctx).Model(&member{}).
-		Where("org_id = ? AND did = ?", s.orgID, admin.String()).
+		Where("org_id = ? AND did = ?", s.orgID, admin).
 		Update("role", AdminRole)
 	if result.Error != nil {
 		return result.Error
@@ -142,8 +142,8 @@ func (s *orgImpl) addMemberTx(
 		DoNothing: true,
 	}).Create(&member{
 		OrgID:     s.orgID,
-		Did:       did.String(),
-		Role:      string(MemberRole),
+		Did:       did,
+		Role:      MemberRole,
 		LoginID:   loginID,
 		CreatedAt: time.Now(),
 	}).Error
@@ -166,11 +166,7 @@ func (s *orgImpl) GetAdmins(ctx context.Context) ([]syntax.DID, error) {
 	}
 	dids := make([]syntax.DID, 0, len(rows))
 	for _, r := range rows {
-		did, err := syntax.ParseDID(r.Did)
-		if err != nil {
-			return nil, err
-		}
-		dids = append(dids, did)
+		dids = append(dids, r.Did)
 	}
 	return dids, nil
 }
@@ -182,11 +178,7 @@ func (s *orgImpl) GetMembers(ctx context.Context) ([]syntax.DID, error) {
 	}
 	dids := make([]syntax.DID, 0, len(rows))
 	for _, r := range rows {
-		did, err := syntax.ParseDID(r.Did)
-		if err != nil {
-			return nil, err
-		}
-		dids = append(dids, did)
+		dids = append(dids, r.Did)
 	}
 	return dids, nil
 }
@@ -205,7 +197,7 @@ func (s *orgImpl) DowngradeAdmin(ctx context.Context, admin syntax.DID) error {
 	}
 	return s.db.WithContext(ctx).
 		Model(&member{}).
-		Where("org_id = ? AND did = ? AND role = ?", s.orgID, admin.String(), AdminRole).
+		Where("org_id = ? AND did = ? AND role = ?", s.orgID, admin, AdminRole).
 		Update("role", MemberRole).
 		Error
 }
@@ -223,18 +215,14 @@ func (s *orgImpl) RemoveAdmin(ctx context.Context, admin syntax.DID) error {
 		return ErrLastAdmin
 	}
 	return s.db.WithContext(ctx).
-		Where("org_id = ? AND did = ? AND role = ?", s.orgID, admin.String(), AdminRole).
+		Where("org_id = ? AND did = ? AND role = ?", s.orgID, admin, AdminRole).
 		Delete(&member{}).
 		Error
 }
 
 func (s *orgImpl) RemoveMembers(ctx context.Context, members []syntax.DID) error {
-	dids := make([]string, 0, len(members))
-	for _, did := range members {
-		dids = append(dids, did.String())
-	}
 	return s.db.WithContext(ctx).
-		Where("org_id = ? AND did IN ? AND role = ?", s.orgID, dids, MemberRole).
+		Where("org_id = ? AND did IN ? AND role = ?", s.orgID, members, MemberRole).
 		Delete(&member{}).
 		Error
 }
@@ -242,7 +230,7 @@ func (s *orgImpl) RemoveMembers(ctx context.Context, members []syntax.DID) error
 func (s *orgImpl) IsAdmin(ctx context.Context, did syntax.DID) (bool, error) {
 	var row member
 	err := s.db.WithContext(ctx).
-		Where("org_id = ? AND did = ? AND role = ?", s.orgID, did.String(), AdminRole).
+		Where("org_id = ? AND did = ? AND role = ?", s.orgID, did, AdminRole).
 		First(&row).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -254,7 +242,7 @@ func (s *orgImpl) IsAdmin(ctx context.Context, did syntax.DID) (bool, error) {
 func (s *orgImpl) IsMember(ctx context.Context, did syntax.DID) (bool, error) {
 	var row member
 	err := s.db.WithContext(ctx).
-		Where("org_id = ? AND did = ?", s.orgID, did.String()).
+		Where("org_id = ? AND did = ?", s.orgID, did).
 		First(&row).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -373,7 +361,7 @@ func (s *orgImpl) AuthenticateMember(
 
 	var row member
 	err = s.db.WithContext(ctx).
-		Where("org_id = ? AND did = ?", s.orgID, id.DID.String()).
+		Where("org_id = ? AND did = ?", s.orgID, id.DID).
 		First(&row).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -95,7 +95,7 @@ func NewOrg(
 	db *gorm.DB,
 	signingSecret []byte,
 ) (*orgImpl, error) {
-	if err := db.AutoMigrate(&Member{}, &spentToken{}); err != nil {
+	if err := db.AutoMigrate(&member{}, &spentToken{}); err != nil {
 		return nil, err
 	}
 	return &orgImpl{
@@ -115,8 +115,8 @@ func (s *orgImpl) LoginMethod() LoginMethod {
 }
 
 func (s *orgImpl) AddAdmin(ctx context.Context, admin syntax.DID) error {
-	result := s.db.WithContext(ctx).Model(&Member{}).
-		Where("org_id = ? AND member = ?", s.orgID, admin.String()).
+	result := s.db.WithContext(ctx).Model(&member{}).
+		Where("org_id = ? AND did = ?", s.orgID, admin.String()).
 		Update("role", AdminRole)
 	if result.Error != nil {
 		return result.Error
@@ -138,11 +138,11 @@ func (s *orgImpl) addMemberTx(
 	loginID string,
 ) error {
 	return tx.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "org_id"}, {Name: "member"}},
+		Columns:   []clause.Column{{Name: "org_id"}, {Name: "did"}},
 		DoNothing: true,
-	}).Create(&Member{
+	}).Create(&member{
 		OrgID:     s.orgID,
-		Member:    did.String(),
+		Did:       did.String(),
 		Role:      string(MemberRole),
 		LoginID:   loginID,
 		CreatedAt: time.Now(),
@@ -157,7 +157,7 @@ func (s *store) bootstrapAdmin(ctx context.Context, bootstrapSecret string, admi
 */
 
 func (s *orgImpl) GetAdmins(ctx context.Context) ([]syntax.DID, error) {
-	var rows []Member
+	var rows []member
 	if err := s.db.WithContext(ctx).
 		Where("org_id = ? AND role = ?", s.orgID, AdminRole).
 		Find(&rows).
@@ -166,7 +166,7 @@ func (s *orgImpl) GetAdmins(ctx context.Context) ([]syntax.DID, error) {
 	}
 	dids := make([]syntax.DID, 0, len(rows))
 	for _, r := range rows {
-		did, err := syntax.ParseDID(r.Member)
+		did, err := syntax.ParseDID(r.Did)
 		if err != nil {
 			return nil, err
 		}
@@ -176,13 +176,13 @@ func (s *orgImpl) GetAdmins(ctx context.Context) ([]syntax.DID, error) {
 }
 
 func (s *orgImpl) GetMembers(ctx context.Context) ([]syntax.DID, error) {
-	var rows []Member
+	var rows []member
 	if err := s.db.WithContext(ctx).Where("org_id = ?", s.orgID).Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	dids := make([]syntax.DID, 0, len(rows))
 	for _, r := range rows {
-		did, err := syntax.ParseDID(r.Member)
+		did, err := syntax.ParseDID(r.Did)
 		if err != nil {
 			return nil, err
 		}
@@ -194,7 +194,7 @@ func (s *orgImpl) GetMembers(ctx context.Context) ([]syntax.DID, error) {
 func (s *orgImpl) DowngradeAdmin(ctx context.Context, admin syntax.DID) error {
 	var adminCount int64
 	if err := s.db.WithContext(ctx).
-		Model(&Member{}).
+		Model(&member{}).
 		Where("org_id = ? AND role = ?", s.orgID, AdminRole).
 		Count(&adminCount).
 		Error; err != nil {
@@ -204,8 +204,8 @@ func (s *orgImpl) DowngradeAdmin(ctx context.Context, admin syntax.DID) error {
 		return ErrLastAdmin
 	}
 	return s.db.WithContext(ctx).
-		Model(&Member{}).
-		Where("org_id = ? AND member = ? AND role = ?", s.orgID, admin.String(), AdminRole).
+		Model(&member{}).
+		Where("org_id = ? AND did = ? AND role = ?", s.orgID, admin.String(), AdminRole).
 		Update("role", MemberRole).
 		Error
 }
@@ -213,7 +213,7 @@ func (s *orgImpl) DowngradeAdmin(ctx context.Context, admin syntax.DID) error {
 func (s *orgImpl) RemoveAdmin(ctx context.Context, admin syntax.DID) error {
 	var adminCount int64
 	if err := s.db.WithContext(ctx).
-		Model(&Member{}).
+		Model(&member{}).
 		Where("org_id = ? AND role = ?", s.orgID, AdminRole).
 		Count(&adminCount).
 		Error; err != nil {
@@ -223,8 +223,8 @@ func (s *orgImpl) RemoveAdmin(ctx context.Context, admin syntax.DID) error {
 		return ErrLastAdmin
 	}
 	return s.db.WithContext(ctx).
-		Where("org_id = ? AND member = ? AND role = ?", s.orgID, admin.String(), AdminRole).
-		Delete(&Member{}).
+		Where("org_id = ? AND did = ? AND role = ?", s.orgID, admin.String(), AdminRole).
+		Delete(&member{}).
 		Error
 }
 
@@ -234,15 +234,15 @@ func (s *orgImpl) RemoveMembers(ctx context.Context, members []syntax.DID) error
 		dids = append(dids, did.String())
 	}
 	return s.db.WithContext(ctx).
-		Where("org_id = ? AND member IN ? AND role = ?", s.orgID, dids, MemberRole).
-		Delete(&Member{}).
+		Where("org_id = ? AND did IN ? AND role = ?", s.orgID, dids, MemberRole).
+		Delete(&member{}).
 		Error
 }
 
 func (s *orgImpl) IsAdmin(ctx context.Context, did syntax.DID) (bool, error) {
-	var row Member
+	var row member
 	err := s.db.WithContext(ctx).
-		Where("org_id = ? AND member = ? AND role = ?", s.orgID, did.String(), AdminRole).
+		Where("org_id = ? AND did = ? AND role = ?", s.orgID, did.String(), AdminRole).
 		First(&row).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -252,9 +252,9 @@ func (s *orgImpl) IsAdmin(ctx context.Context, did syntax.DID) (bool, error) {
 }
 
 func (s *orgImpl) IsMember(ctx context.Context, did syntax.DID) (bool, error) {
-	var row Member
+	var row member
 	err := s.db.WithContext(ctx).
-		Where("org_id = ? AND member = ?", s.orgID, did.String()).
+		Where("org_id = ? AND did = ?", s.orgID, did.String()).
 		First(&row).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -371,9 +371,9 @@ func (s *orgImpl) AuthenticateMember(
 		return false, nil
 	}
 
-	var row Member
+	var row member
 	err = s.db.WithContext(ctx).
-		Where("org_id = ? AND member = ?", s.orgID, id.DID.String()).
+		Where("org_id = ? AND did = ?", s.orgID, id.DID.String()).
 		First(&row).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -58,6 +58,9 @@ type Org interface {
 	IsAdmin(ctx context.Context, did syntax.DID) (bool, error)
 	IsMember(ctx context.Context, did syntax.DID) (bool, error)
 
+	// LoginMethod returns how users authenticate: "atproto", "google", or "password".
+	LoginMethod() string
+
 	// Org member identity management; may eventually replace some of the methods above
 	IssueIdentityToken(
 		ctx context.Context,
@@ -117,6 +120,14 @@ func NewOrg(
 		db:            db,
 		signingSecret: signingSecret,
 	}, nil
+}
+
+func (s *orgImpl) LoginMethod() string {
+	var org organization
+	if err := s.db.First(&org, "id = ?", s.orgID).Error; err != nil {
+		return "password" // safe default
+	}
+	return org.LoginMethod
 }
 
 func (s *orgImpl) AddAdmin(ctx context.Context, admin syntax.DID) error {
@@ -527,6 +538,7 @@ func (s *storeImpl) CreateOrg(
 		if err := tx.Create(&organization{
 			ID:            orgID,
 			Name:          name,
+			LoginMethod:   "password", // new orgs default to password auth
 			SigningSecret: signingSecret,
 			CreatedAt:     time.Now(),
 		}).Error; err != nil {

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -127,25 +127,25 @@ func (s *orgImpl) AddAdmin(ctx context.Context, admin syntax.DID) error {
 	return nil
 }
 
-func (s *orgImpl) addMember(ctx context.Context, did syntax.DID, passwordHash string) error {
-	return s.addMemberTx(ctx, s.db, did, passwordHash)
+func (s *orgImpl) addMember(ctx context.Context, did syntax.DID, loginID string) error {
+	return s.addMemberTx(ctx, s.db, did, loginID)
 }
 
 func (s *orgImpl) addMemberTx(
 	ctx context.Context,
 	tx *gorm.DB,
 	did syntax.DID,
-	passwordHash string,
+	loginID string,
 ) error {
 	return tx.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "org_id"}, {Name: "member"}},
 		DoNothing: true,
 	}).Create(&Member{
-		OrgID:        s.orgID,
-		Member:       did.String(),
-		Role:         string(MemberRole),
-		PasswordHash: passwordHash,
-		CreatedAt:    time.Now(),
+		OrgID:     s.orgID,
+		Member:    did.String(),
+		Role:      string(MemberRole),
+		LoginID:   loginID,
+		CreatedAt: time.Now(),
 	}).Error
 }
 
@@ -383,7 +383,7 @@ func (s *orgImpl) AuthenticateMember(
 		return false, err
 	}
 
-	ok, err := verifyPassword(password, row.PasswordHash)
+	ok, err := verifyPassword(password, row.LoginID)
 	if errors.Is(err, argon2id.ErrInvalidHash) {
 		// Members created before passwords were required have no usable hash.
 		return false, nil

--- a/internal/org/org_test.go
+++ b/internal/org/org_test.go
@@ -15,7 +15,7 @@ import (
 
 var testSigningSecret = []byte("test-signing-secret-for-org-00000")
 
-func newTestStore(t *testing.T) *orgImpl {
+func newTestOrg(t *testing.T) *orgImpl {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
@@ -24,7 +24,7 @@ func newTestStore(t *testing.T) *orgImpl {
 	return s
 }
 
-func newTestStoreWithHive(t *testing.T) *orgImpl {
+func newTestOrgWithHive(t *testing.T) *orgImpl {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
@@ -44,13 +44,13 @@ const testPasswordHash = "testhash"
 const testPassword = "test-password-123"
 
 func TestLoginMethod_Default(t *testing.T) {
-	s := newTestStore(t)
+	s := newTestOrg(t)
 	require.Equal(t, LoginMethodPassword, s.LoginMethod())
 }
 
 func TestIsMember(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStore(t)
+	s := newTestOrg(t)
 
 	ok, err := s.IsMember(ctx, did1)
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestIsMember(t *testing.T) {
 
 func TestAddAdmin_GetAdmins(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStore(t)
+	s := newTestOrg(t)
 
 	require.NoError(t, s.addMember(ctx, did1, testPasswordHash))
 	require.NoError(t, s.AddAdmin(ctx, did1))
@@ -78,7 +78,7 @@ func TestAddAdmin_GetAdmins(t *testing.T) {
 
 func TestAddAdmin_NotMember(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStore(t)
+	s := newTestOrg(t)
 
 	err := s.AddAdmin(ctx, did1)
 	require.ErrorIs(t, err, ErrNotMember)
@@ -86,7 +86,7 @@ func TestAddAdmin_NotMember(t *testing.T) {
 
 func TestRemoveAdmin_LastAdmin(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStore(t)
+	s := newTestOrg(t)
 
 	require.NoError(t, s.addMember(ctx, did1, testPasswordHash))
 	require.NoError(t, s.AddAdmin(ctx, did1))
@@ -97,7 +97,7 @@ func TestRemoveAdmin_LastAdmin(t *testing.T) {
 
 func TestRemoveAdmin_MultipleAdmins(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStore(t)
+	s := newTestOrg(t)
 
 	require.NoError(t, s.addMember(ctx, did1, testPasswordHash))
 	require.NoError(t, s.addMember(ctx, did2, testPasswordHash))
@@ -113,7 +113,7 @@ func TestRemoveAdmin_MultipleAdmins(t *testing.T) {
 
 func TestGetMembers(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStore(t)
+	s := newTestOrg(t)
 
 	members, err := s.GetMembers(ctx)
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestGetMembers(t *testing.T) {
 
 func TestRemoveMembers(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStore(t)
+	s := newTestOrg(t)
 
 	require.NoError(t, s.addMember(ctx, did1, testPasswordHash))
 	require.NoError(t, s.addMember(ctx, did2, testPasswordHash))
@@ -146,7 +146,7 @@ func TestRemoveMembers(t *testing.T) {
 
 func TestGenerateAndUseIdentityToken(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStoreWithHive(t)
+	s := newTestOrgWithHive(t)
 
 	token, err := s.IssueIdentityToken(ctx, did1, false, time.Now().Add(time.Hour))
 	require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestGenerateAndUseIdentityToken(t *testing.T) {
 
 func TestIdentityToken_CannotReuse(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStoreWithHive(t)
+	s := newTestOrgWithHive(t)
 
 	token, err := s.IssueIdentityToken(ctx, did1, false, time.Now().Add(time.Hour))
 	require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestIdentityToken_CannotReuse(t *testing.T) {
 
 func TestMintIdentity_DuplicateHandle(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStoreWithHive(t)
+	s := newTestOrgWithHive(t)
 
 	token1, err := s.IssueIdentityToken(ctx, did1, false, time.Now().Add(time.Hour))
 	require.NoError(t, err)
@@ -190,7 +190,7 @@ func TestMintIdentity_DuplicateHandle(t *testing.T) {
 
 func TestIdentityToken_Reusable(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStoreWithHive(t)
+	s := newTestOrgWithHive(t)
 
 	token, err := s.IssueIdentityToken(ctx, did1, true, time.Now().Add(time.Hour))
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestIdentityToken_Reusable(t *testing.T) {
 
 func TestCreateNewMemberIdentity_AuthenticateMember(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStoreWithHive(t)
+	s := newTestOrgWithHive(t)
 
 	token, err := s.IssueIdentityToken(ctx, did1, false, time.Now().Add(time.Hour))
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestCreateNewMemberIdentity_AuthenticateMember(t *testing.T) {
 
 func TestIssueIdentityToken_ExpiryTooLate(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStoreWithHive(t)
+	s := newTestOrgWithHive(t)
 
 	_, err := s.IssueIdentityToken(ctx, did1, false, time.Now().AddDate(0, 1, 1))
 	require.ErrorIs(t, err, ErrInvalidTokenExpiry)

--- a/internal/org/org_test.go
+++ b/internal/org/org_test.go
@@ -45,7 +45,7 @@ const testPassword = "test-password-123"
 
 func TestLoginMethod_Default(t *testing.T) {
 	s := newTestStore(t)
-	require.Equal(t, "password", s.LoginMethod())
+	require.Equal(t, LoginMethodPassword, s.LoginMethod())
 }
 
 func TestIsMember(t *testing.T) {

--- a/internal/org/org_test.go
+++ b/internal/org/org_test.go
@@ -43,6 +43,11 @@ var (
 const testPasswordHash = "testhash"
 const testPassword = "test-password-123"
 
+func TestLoginMethod_Default(t *testing.T) {
+	s := newTestStore(t)
+	require.Equal(t, "password", s.LoginMethod())
+}
+
 func TestIsMember(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)

--- a/internal/org/password.go
+++ b/internal/org/password.go
@@ -2,6 +2,8 @@ package org
 
 import (
 	// Use this argon2id wrapper rather than rolling our own auth
+	"errors"
+
 	"github.com/alexedwards/argon2id"
 )
 
@@ -14,5 +16,9 @@ func hashPassword(password string) (string, error) {
 // VerifyPassword checks a plaintext password against an encoded argon2id hash.
 // Returns false, nil on mismatch; error only if the hash is malformed.
 func verifyPassword(password, encodedHash string) (bool, error) {
-	return argon2id.ComparePasswordAndHash(password, encodedHash)
+	ok, err := argon2id.ComparePasswordAndHash(password, encodedHash)
+	if errors.Is(err, argon2id.ErrInvalidHash) {
+		return false, nil
+	}
+	return ok, err
 }

--- a/internal/org/public.go
+++ b/internal/org/public.go
@@ -17,8 +17,8 @@ var (
 	ErrNotSupportedPublic = errors.New("method not supported on public org")
 )
 
-func (e *everyoneOrg) LoginMethod() string {
-	return "atproto"
+func (e *everyoneOrg) LoginMethod() LoginMethod {
+	return LoginMethodAtproto
 }
 
 // GetMetadata implements Org.
@@ -73,17 +73,31 @@ func (e *everyoneOrg) IsMember(ctx context.Context, member syntax.DID) (bool, er
 }
 
 // IssueIdentityToken implements Org.
-func (e *everyoneOrg) IssueIdentityToken(ctx context.Context, caller syntax.DID, reusable bool, expiresAt time.Time) (token string, err error) {
+func (e *everyoneOrg) IssueIdentityToken(
+	ctx context.Context,
+	caller syntax.DID,
+	reusable bool,
+	expiresAt time.Time,
+) (token string, err error) {
 	return "", ErrNotSupportedPublic
 }
 
 // CreateNewMemberIdentity implements Org.
-func (e *everyoneOrg) CreateNewMemberIdentity(ctx context.Context, token string, internalHandle string, password string) (*identity.Identity, error) {
+func (e *everyoneOrg) CreateNewMemberIdentity(
+	ctx context.Context,
+	token string,
+	internalHandle string,
+	password string,
+) (*identity.Identity, error) {
 	return nil, ErrNotSupportedPublic
 }
 
 // AuthenticateMember implements Org.
-func (e *everyoneOrg) AuthenticateMember(ctx context.Context, handle string, password string) (bool, error) {
+func (e *everyoneOrg) AuthenticateMember(
+	ctx context.Context,
+	handle string,
+	password string,
+) (bool, error) {
 	return false, ErrNotSupportedPublic
 }
 

--- a/internal/org/public.go
+++ b/internal/org/public.go
@@ -17,6 +17,10 @@ var (
 	ErrNotSupportedPublic = errors.New("method not supported on public org")
 )
 
+func (e *everyoneOrg) LoginMethod() string {
+	return "atproto"
+}
+
 // GetMetadata implements Org.
 func (e *everyoneOrg) GetMetadata() habitat.NetworkHabitatOrgGetMetadataOutput {
 	return habitat.NetworkHabitatOrgGetMetadataOutput{}

--- a/internal/org/public_test.go
+++ b/internal/org/public_test.go
@@ -15,6 +15,11 @@ func TestEveryoneOrg_IsMember(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestEveryoneOrg_LoginMethod(t *testing.T) {
+	o := NewEveryoneOrg()
+	require.Equal(t, "atproto", o.LoginMethod())
+}
+
 func TestEveryoneOrg_ErrorMethods(t *testing.T) {
 	o := NewEveryoneOrg()
 	ctx := context.Background()

--- a/internal/org/public_test.go
+++ b/internal/org/public_test.go
@@ -17,7 +17,7 @@ func TestEveryoneOrg_IsMember(t *testing.T) {
 
 func TestEveryoneOrg_LoginMethod(t *testing.T) {
 	o := NewEveryoneOrg()
-	require.Equal(t, "atproto", o.LoginMethod())
+	require.Equal(t, LoginMethodAtproto, o.LoginMethod())
 }
 
 func TestEveryoneOrg_ErrorMethods(t *testing.T) {

--- a/internal/org/server_test.go
+++ b/internal/org/server_test.go
@@ -150,6 +150,8 @@ func TestCreateOrg(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, admins, 1)
 	require.Equal(t, adminDID, admins[0])
+
+	require.Equal(t, "password", org.LoginMethod())
 }
 
 func TestCreateOrg_InvalidHandle(t *testing.T) {

--- a/internal/org/server_test.go
+++ b/internal/org/server_test.go
@@ -151,7 +151,7 @@ func TestCreateOrg(t *testing.T) {
 	require.Len(t, admins, 1)
 	require.Equal(t, adminDID, admins[0])
 
-	require.Equal(t, "password", org.LoginMethod())
+	require.Equal(t, LoginMethodPassword, org.LoginMethod())
 }
 
 func TestCreateOrg_InvalidHandle(t *testing.T) {

--- a/internal/org/store.go
+++ b/internal/org/store.go
@@ -153,11 +153,11 @@ func (s *storeImpl) CreateOrg(
 			return err
 		}
 		return tx.Create(&Member{
-			OrgID:        orgID,
-			Member:       id.DID.String(),
-			Role:         string(AdminRole),
-			PasswordHash: passwordHash,
-			CreatedAt:    time.Now(),
+			OrgID:     orgID,
+			Member:    id.DID.String(),
+			Role:      string(AdminRole),
+			LoginID:   passwordHash,
+			CreatedAt: time.Now(),
 		}).Error
 	})
 	if err != nil {

--- a/internal/org/store.go
+++ b/internal/org/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,6 +13,13 @@ import (
 	"github.com/habitat-network/habitat/internal/hive"
 	"gorm.io/gorm"
 )
+
+type OrgMember struct {
+	Org     Org
+	DID     syntax.DID
+	Role    Role
+	LoginID string
+}
 
 // Store is the registry of all orgs on a pear instance.
 // It routes DIDs to their org and provides cross-org membership checks.
@@ -25,7 +33,7 @@ type Store interface {
 		adminPassword string,
 	) (orgID string, id *identity.Identity, err error)
 
-	GetMember(ctx context.Context, did syntax.DID) (*Member, error)
+	GetMember(ctx context.Context, did syntax.DID) (*OrgMember, error)
 }
 
 // storeImpl is the Store implementation backed by gorm and the identity directory.
@@ -46,7 +54,7 @@ func NewStore(
 	dir identity.Directory,
 	pearDomain string,
 ) (Store, error) {
-	if err := db.AutoMigrate(&organization{}, &Member{}, &spentToken{}); err != nil {
+	if err := db.AutoMigrate(&organization{}, &member{}, &spentToken{}); err != nil {
 		return nil, err
 	}
 	return &storeImpl{
@@ -84,8 +92,8 @@ func (s *storeImpl) GetOrg(ctx context.Context, orgID string) (Org, error) {
 // First checks the member table. If the DID isn't in any org, checks if
 // it's managed by our hive. Otherwise returns the everyone org for external DIDs.
 func (s *storeImpl) GetOrgForDID(ctx context.Context, did syntax.DID) (Org, error) {
-	var m Member
-	if err := s.db.WithContext(ctx).Where("member = ?", did.String()).First(&m).Error; err == nil {
+	var m member
+	if err := s.db.WithContext(ctx).Where("did = ?", did.String()).First(&m).Error; err == nil {
 		return s.GetOrg(ctx, m.OrgID)
 	}
 
@@ -152,9 +160,9 @@ func (s *storeImpl) CreateOrg(
 		if err := persistIdent(tx); err != nil {
 			return err
 		}
-		return tx.Create(&Member{
+		return tx.Create(&member{
 			OrgID:     orgID,
-			Member:    id.DID.String(),
+			Did:       id.DID.String(),
 			Role:      string(AdminRole),
 			LoginID:   passwordHash,
 			CreatedAt: time.Now(),
@@ -167,10 +175,27 @@ func (s *storeImpl) CreateOrg(
 	return orgID, id, nil
 }
 
-func (s *storeImpl) GetMember(ctx context.Context, did syntax.DID) (*Member, error) {
-	var m Member
-	if err := s.db.WithContext(ctx).Where("member = ?", did.String()).First(&m).Error; err != nil {
-		return nil, ErrMemberNotFound
+func (s *storeImpl) GetMember(ctx context.Context, did syntax.DID) (*OrgMember, error) {
+	var m member
+	if err := s.db.WithContext(ctx).Where("did = ?", did.String()).First(&m).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return &OrgMember{
+				Org:     s.everyone,
+				DID:     did,
+				Role:    MemberRole,
+				LoginID: "",
+			}, nil
+		}
+		return nil, fmt.Errorf("failed to get member: %w", err)
 	}
-	return &m, nil
+	org, err := s.orgFromModel(&m.Organization)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get org from model: %w", err)
+	}
+	return &OrgMember{
+		Org:     org,
+		DID:     syntax.DID(m.Did),
+		Role:    Role(m.Role),
+		LoginID: m.LoginID,
+	}, nil
 }

--- a/internal/org/store.go
+++ b/internal/org/store.go
@@ -1,0 +1,176 @@
+package org
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/hive"
+	"gorm.io/gorm"
+)
+
+// Store is the registry of all orgs on a pear instance.
+// It routes DIDs to their org and provides cross-org membership checks.
+type Store interface {
+	GetOrg(ctx context.Context, orgID string) (Org, error)
+	GetOrgForDID(ctx context.Context, did syntax.DID) (Org, error)
+	CreateOrg(
+		ctx context.Context,
+		name string,
+		adminHandle string,
+		adminPassword string,
+	) (orgID string, id *identity.Identity, err error)
+
+	GetMember(ctx context.Context, did syntax.DID) (*Member, error)
+}
+
+// storeImpl is the Store implementation backed by gorm and the identity directory.
+type storeImpl struct {
+	db         *gorm.DB
+	hive       hive.Hive
+	dir        identity.Directory
+	pearDomain string
+	everyone   Org
+}
+
+var _ Store = &storeImpl{}
+
+// NewStore creates a Store that manages multiple orgs on a pear instance.
+func NewStore(
+	db *gorm.DB,
+	hve hive.Hive,
+	dir identity.Directory,
+	pearDomain string,
+) (Store, error) {
+	if err := db.AutoMigrate(&organization{}, &Member{}, &spentToken{}); err != nil {
+		return nil, err
+	}
+	return &storeImpl{
+		db:         db,
+		hive:       hve,
+		dir:        dir,
+		pearDomain: pearDomain,
+		everyone:   NewEveryoneOrg(),
+	}, nil
+}
+
+func (s *storeImpl) orgFromModel(org *organization) (*orgImpl, error) {
+	signingSecret, err := base64.StdEncoding.DecodeString(org.SigningSecret)
+	if err != nil {
+		return nil, err
+	}
+	return &orgImpl{
+		orgID:         org.ID,
+		hive:          s.hive,
+		db:            s.db,
+		signingSecret: signingSecret,
+	}, nil
+}
+
+// GetOrg returns the org with the given ID.
+func (s *storeImpl) GetOrg(ctx context.Context, orgID string) (Org, error) {
+	var org organization
+	if err := s.db.WithContext(ctx).Where("id = ?", orgID).First(&org).Error; err != nil {
+		return nil, ErrOrgNotFound
+	}
+	return s.orgFromModel(&org)
+}
+
+// GetOrgForDID returns the org the given DID belongs to.
+// First checks the member table. If the DID isn't in any org, checks if
+// it's managed by our hive. Otherwise returns the everyone org for external DIDs.
+func (s *storeImpl) GetOrgForDID(ctx context.Context, did syntax.DID) (Org, error) {
+	var m Member
+	if err := s.db.WithContext(ctx).Where("member = ?", did.String()).First(&m).Error; err == nil {
+		return s.GetOrg(ctx, m.OrgID)
+	}
+
+	id, err := s.dir.LookupDID(ctx, did)
+	if err != nil {
+		return s.everyone, nil
+	}
+
+	svc, hasHabitat := id.Services["habitat"]
+	if hasHabitat && svc.URL == "https://"+s.pearDomain {
+		return nil, ErrMemberNotFound
+	}
+
+	return s.everyone, nil
+}
+
+// CreateOrg creates a new org with a bootstrap admin member and returns the generated org ID and the admin identity.
+func (s *storeImpl) CreateOrg(
+	ctx context.Context,
+	name string,
+	adminHandle string,
+	adminPassword string,
+) (string, *identity.Identity, error) {
+	// Generate a random org ID
+	orgBytes := make([]byte, 16)
+	if _, err := rand.Read(orgBytes); err != nil {
+		return "", nil, err
+	}
+	orgID := fmt.Sprintf("%x", orgBytes)
+
+	// Generate signing secret
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return "", nil, err
+	}
+	signingSecret := base64.StdEncoding.EncodeToString(secret)
+
+	// Hash the admin password
+	passwordHash, err := hashPassword(adminPassword)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Mint identity for the admin
+	id, persistIdent, err := s.hive.MintIdentity(adminHandle)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Persist org, identity, and admin member in a single transaction
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&organization{
+			ID:            orgID,
+			Name:          name,
+			LoginMethod:   "password", // new orgs default to password auth
+			SigningSecret: signingSecret,
+			CreatedAt:     time.Now(),
+		}).Error; err != nil {
+			if isDuplicateError(err) {
+				return ErrOrgAlreadyExists
+			}
+			return err
+		}
+		if err := persistIdent(tx); err != nil {
+			return err
+		}
+		return tx.Create(&Member{
+			OrgID:        orgID,
+			Member:       id.DID.String(),
+			Role:         string(AdminRole),
+			PasswordHash: passwordHash,
+			CreatedAt:    time.Now(),
+		}).Error
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	return orgID, id, nil
+}
+
+func (s *storeImpl) GetMember(ctx context.Context, did syntax.DID) (*Member, error) {
+	var m Member
+	if err := s.db.WithContext(ctx).Where("member = ?", did.String()).First(&m).Error; err != nil {
+		return nil, ErrMemberNotFound
+	}
+	return &m, nil
+}

--- a/internal/org/store.go
+++ b/internal/org/store.go
@@ -93,7 +93,7 @@ func (s *storeImpl) GetOrg(ctx context.Context, orgID string) (Org, error) {
 // it's managed by our hive. Otherwise returns the everyone org for external DIDs.
 func (s *storeImpl) GetOrgForDID(ctx context.Context, did syntax.DID) (Org, error) {
 	var m member
-	if err := s.db.WithContext(ctx).Where("did = ?", did.String()).First(&m).Error; err == nil {
+	if err := s.db.WithContext(ctx).Where("did = ?", did).First(&m).Error; err == nil {
 		return s.GetOrg(ctx, m.OrgID)
 	}
 
@@ -162,8 +162,8 @@ func (s *storeImpl) CreateOrg(
 		}
 		return tx.Create(&member{
 			OrgID:     orgID,
-			Did:       id.DID.String(),
-			Role:      string(AdminRole),
+			Did:       id.DID,
+			Role:      AdminRole,
 			LoginID:   passwordHash,
 			CreatedAt: time.Now(),
 		}).Error
@@ -177,7 +177,7 @@ func (s *storeImpl) CreateOrg(
 
 func (s *storeImpl) GetMember(ctx context.Context, did syntax.DID) (*OrgMember, error) {
 	var m member
-	if err := s.db.WithContext(ctx).Where("did = ?", did.String()).First(&m).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("did = ?", did).First(&m).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &OrgMember{
 				Org:     s.everyone,
@@ -194,8 +194,8 @@ func (s *storeImpl) GetMember(ctx context.Context, did syntax.DID) (*OrgMember, 
 	}
 	return &OrgMember{
 		Org:     org,
-		DID:     syntax.DID(m.Did),
-		Role:    Role(m.Role),
+		DID:     m.Did,
+		Role:    m.Role,
 		LoginID: m.LoginID,
 	}, nil
 }

--- a/internal/org/store_test.go
+++ b/internal/org/store_test.go
@@ -1,0 +1,134 @@
+package org
+
+import (
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/hive"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newTestStore(t *testing.T) Store {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Discard})
+	require.NoError(t, err)
+	h, err := hive.NewHive("example.com", "pear.example.com", db)
+	require.NoError(t, err)
+	s, err := NewStore(db, h, identity.DefaultDirectory(), "pear.example.com")
+	require.NoError(t, err)
+	return s
+}
+
+func TestStore_CreateOrg(t *testing.T) {
+	s := newTestStore(t)
+	orgID, id, err := s.CreateOrg(t.Context(), "test-org", "admin", "password")
+	require.NoError(t, err)
+	require.NotEmpty(t, orgID)
+	require.NotNil(t, id)
+	require.Contains(t, id.Handle.String(), "admin")
+
+	org, err := s.GetOrg(t.Context(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, LoginMethodPassword, org.LoginMethod())
+
+	members, err := org.GetMembers(t.Context())
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	require.Equal(t, id.DID, members[0])
+
+	admins, err := org.GetAdmins(t.Context())
+	require.NoError(t, err)
+	require.Len(t, admins, 1)
+	require.Equal(t, id.DID, admins[0])
+}
+
+func TestStore_GetOrg_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.GetOrg(t.Context(), "nonexistent")
+	require.ErrorIs(t, err, ErrOrgNotFound)
+}
+
+func TestStore_GetOrgForDID_Member(t *testing.T) {
+	s := newTestStore(t)
+	orgID, id, err := s.CreateOrg(t.Context(), "test-org", "admin", "password")
+	require.NoError(t, err)
+
+	org, err := s.GetOrgForDID(t.Context(), id.DID)
+	require.NoError(t, err)
+	require.Equal(t, LoginMethodPassword, org.LoginMethod())
+
+	gotOrgID := ""
+	switch o := org.(type) {
+	case *orgImpl:
+		gotOrgID = o.orgID
+	}
+	require.Equal(t, orgID, gotOrgID)
+}
+
+func TestStore_GetOrgForDID_Everyone(t *testing.T) {
+	s := newTestStore(t)
+	unknown := syntax.DID("did:plc:unknown")
+	org, err := s.GetOrgForDID(t.Context(), unknown)
+	require.NoError(t, err)
+	require.Equal(t, LoginMethodAtproto, org.LoginMethod())
+
+	ok, err := org.IsMember(t.Context(), unknown)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestStore_GetMember_Existing(t *testing.T) {
+	s := newTestStore(t)
+	_, id, err := s.CreateOrg(t.Context(), "test-org", "admin", "password")
+	require.NoError(t, err)
+
+	member, err := s.GetMember(t.Context(), id.DID)
+	require.NoError(t, err)
+	require.Equal(t, id.DID, member.DID)
+	require.Equal(t, AdminRole, member.Role)
+	require.NotEmpty(t, member.LoginID)
+}
+
+func TestStore_GetMember_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	unknown := syntax.DID("did:plc:unknown")
+	member, err := s.GetMember(t.Context(), unknown)
+	require.NoError(t, err)
+	require.Equal(t, unknown, member.DID)
+	require.Equal(t, MemberRole, member.Role)
+	require.Empty(t, member.LoginID)
+
+	ok, err := member.Org.IsMember(t.Context(), unknown)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestStore_GetOrgForDID_AfterMultipleOrgs(t *testing.T) {
+	s := newTestStore(t)
+	orgID1, id1, err := s.CreateOrg(t.Context(), "org1", "admin1", "password1")
+	require.NoError(t, err)
+	orgID2, id2, err := s.CreateOrg(t.Context(), "org2", "admin2", "password2")
+	require.NoError(t, err)
+
+	org, err := s.GetOrgForDID(t.Context(), id1.DID)
+	require.NoError(t, err)
+	gotID1 := ""
+	switch o := org.(type) {
+	case *orgImpl:
+		gotID1 = o.orgID
+	}
+	require.Equal(t, orgID1, gotID1)
+
+	org, err = s.GetOrgForDID(t.Context(), id2.DID)
+	require.NoError(t, err)
+	gotID2 := ""
+	switch o := org.(type) {
+	case *orgImpl:
+		gotID2 = o.orgID
+	}
+	require.Equal(t, orgID2, gotID2)
+}


### PR DESCRIPTION
- **feat: add LoginMethod field to org model and interface**
- **test: add LoginMethod coverage for everyoneOrg, orgImpl, and CreateOrg**
- **refactor: replace Type/CanHandle on LoginProvider with LoginMethod**
- **refactor: replace ProviderType/CanHandle with LoginMethod-based routing**
- **feat: wire mapping store into pdsProvider Authorize with test**
- **feat: add googleProvider stub**
- **refactor: use pdsclient.DummyDirectory in mapping test, remove unused test helpers**
- **refactor: route OAuth providers by org login method, wire main.go**
- **commit plan**


<!-- branch-stack-start -->

-------------------------
- master
  - **[Auth] Support auth method per org** :point_left:
    - #326
    - #325

<sup>[Stack](https://www.git-town.com/how-to/proposal-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->
