### PR TITLE
[CI] Downgrade moon

### DIFF
--- a/.moon/toolchains.yml
+++ b/.moon/toolchains.yml
@@ -3,7 +3,6 @@ proto:
 go:
   version: null
   tidyOnChange: true
-  inferRelationships: false
   bins:
   # for some reason multiple bins in ci for >moon@v2.0.0 
   # keep getting stuck during installation. 

--- a/.prototools
+++ b/.prototools
@@ -1,7 +1,7 @@
 proto="0.57.2"
 go = "1.26.3"
 golangci-lint = "2.12.2"
-moon = "2.2.4"
+moon = "2.0.0"
 node = "26.1.0"
 pnpm = "11.1.1"
 caddy = "2.11.3"


### PR DESCRIPTION
newer versions of moon use `go list -deps` to infer relationships. for some reason that's really slow locally and takes >10 seconds to run any moon command. tried to fix this by disabling infer relationships but i think that's causing the dep graph to be incomplete. will just revert and see if this helps