### PR TITLE
Document HABITAT_ADMIN_PASSWORD in README

### DIFF
--- a/build/debian/pear/README.md
+++ b/build/debian/pear/README.md
@@ -65,6 +65,7 @@ All settings are configured via environment variables in your `.env` file.
 | `HABITAT_PDS_CRED_ENCRYPT_KEY` | auto-generated | — | 32-byte base64-encoded encryption key for PDS credentials |
 | `HABITAT_OAUTH_SERVER_SECRET` | auto-generated | — | 32-byte base64-encoded secret for the OAuth server |
 | `HABITAT_OAUTH_CLIENT_SECRET` | auto-generated | — | 32-byte base64-encoded secret for the OAuth client |
+| `HABITAT_ADMIN_PASSWORD` | auto-generated if not defined | — | password for the `admin` login at an instance-wide level for instance config |
 
 The three secrets at the bottom are generated automatically on first run. You can override them by setting them explicitly in `.env` — for example, if you are migrating an existing installation.
 


### PR DESCRIPTION
Added HABITAT_ADMIN_PASSWORD variable for instance config.