### PR TITLE
[Moon] Fix go filegroups

### DIFF
--- a/.moon/tasks/go.yml
+++ b/.moon/tasks/go.yml
@@ -4,9 +4,10 @@ fileGroups:
     - 'go.mod'
     - 'go.sum'
   src:
-    - '**/*{!_test}.go'
+    - '**/*.go'
+    - '!**/*_test.go'
   test:
-    - '**/*_test.go'
+    - '**/*.go'
 tasks:
   format-check:
     command: noop
@@ -39,7 +40,6 @@ tasks:
       - ^:test
     inputs:
     - '@group(mod)'
-    - '@group(src)'
     - '@group(test)'
     command: go
     args:

--- a/cmd/sap/main.go
+++ b/cmd/sap/main.go
@@ -93,8 +93,8 @@ func runSap(ctx context.Context, cmd *cli.Command) error {
 	// their own port. The org and channel endpoints are served on a separate
 	// internal port so the user can restrict access to trusted services.
 	oauthMux := http.NewServeMux()
-	oauthMux.Handle("/oauth-callback", server.handleOAuthCallback)
-	oauthMux.Handle("/client-metadata.json", server.handleClientMetadata)
+	oauthMux.HandleFunc("/oauth-callback", server.handleOAuthCallback)
+	oauthMux.HandleFunc("/client-metadata.json", server.handleClientMetadata)
 
 	internalMux := http.NewServeMux()
 	internalMux.HandleFunc("/health", server.handleHealth)

--- a/cmd/sap/main.go
+++ b/cmd/sap/main.go
@@ -93,8 +93,8 @@ func runSap(ctx context.Context, cmd *cli.Command) error {
 	// their own port. The org and channel endpoints are served on a separate
 	// internal port so the user can restrict access to trusted services.
 	oauthMux := http.NewServeMux()
-	oauthMux.Handle("/oauth-callback", s)
-	oauthMux.Handle("/client-metadata.json", s)
+	oauthMux.Handle("/oauth-callback", server.handleOAuthCallback)
+	oauthMux.Handle("/client-metadata.json", server.handleClientMetadata)
 
 	internalMux := http.NewServeMux()
 	internalMux.HandleFunc("/health", server.handleHealth)

--- a/moon.yml
+++ b/moon.yml
@@ -1,10 +1,19 @@
 layer: library
 fileGroups:
-  src:
-    - internal/**/*{!_test}.go
-  test:
-    - internal/**/*_test.go
+  internal_src:
+    - internal/**/*.go
+    - '!internal/**/*_test.go'
+  internal_test:
+    - internal/**/*.go
 tasks:
+  build:
+    inputs:
+      - '@group(mod)'
+      - '@group(internal_src)'
+  test:
+    inputs:
+      - '@group(mod)'
+      - '@group(internal_test)'
   format-check:
     command: golangci-lint fmt -d
     inputs:


### PR DESCRIPTION
https://github.com/habitat-network/habitat/actions/runs/28459865831/job/84344543790 ran without `sap:build` and `sap:test` even though there was a change was in `cmd/sap/main.go`. 

Realized I can change a file and run `moon query affected` to see which tasks will be triggered. If i make a change to a moon file i need to commit those so they aren't included by `moon query affected`. 

<!-- branch-stack-start -->

<!-- branch-stack-end -->
