### PR TITLE
[Login] Show handle instead of DID on password login page

### DIFF
--- a/internal/login/password.go
+++ b/internal/login/password.go
@@ -59,13 +59,25 @@ func NewPasswordProvider(
 var _ Provider = (*PasswordLoginProvider)(nil)
 
 func (p *PasswordLoginProvider) Authorize(
-	_ context.Context,
+	ctx context.Context,
 	loginHint string,
 ) (string, []byte, error) {
+	// loginHint is the member's LoginID, which for password login is their DID
+	// (see CreateNewMemberIdentity), not a human-readable handle. Resolve it to
+	// a handle so the login page (typescript/apps/pear-pages) can display
+	// something readable instead of a DID; fall back to the DID if resolution
+	// fails.
+	display := loginHint
+	if did, err := syntax.ParseDID(loginHint); err == nil {
+		if id, err := p.dir.LookupDID(ctx, did); err == nil && !id.Handle.IsInvalidHandle() {
+			display = id.Handle.String()
+		}
+	}
+
 	// The member login page is served by pear itself as a pre-rendered page
 	// embedded under /ui/ (see internal/webui and typescript/apps/pear-pages).
 	redirect := "https://" + p.pearDomain + "/ui/login/habitat?handle=" + url.QueryEscape(
-		loginHint,
+		display,
 	)
 	return redirect, nil, nil
 }

--- a/internal/login/password_test.go
+++ b/internal/login/password_test.go
@@ -41,11 +41,21 @@ func TestLoginProvider_Authorize(t *testing.T) {
 	redirect, state, err := p.Authorize(context.Background(), "did:web:alice.example.com")
 	require.NoError(t, err)
 	require.Nil(t, state)
+	// loginHint is resolved from a DID to a handle (from the dummy directory)
+	// so the login page can display something readable.
 	require.Equal(
 		t,
-		"https://pear.example.com/ui/login/habitat?handle=did%3Aweb%3Aalice.example.com",
+		"https://pear.example.com/ui/login/habitat?handle=example.handle.com",
 		redirect,
 	)
+}
+
+func TestLoginProvider_Authorize_EmptyLoginHint(t *testing.T) {
+	p := newTestLoginProvider(t)
+	redirect, state, err := p.Authorize(context.Background(), "")
+	require.NoError(t, err)
+	require.Nil(t, state)
+	require.Equal(t, "https://pear.example.com/ui/login/habitat?handle=", redirect)
 }
 
 func TestLoginProvider_ExchangeRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary
- Password-login members' `LoginID` is their DID (set in `internal/org/org.go`), so `PasswordLoginProvider.Authorize` was passing the DID straight through as the `handle` query param on the redirect to the habitat login page.
- Resolve the DID to a handle via the existing `identity.Directory` before building the redirect, falling back to the DID if resolution fails or returns `handle.invalid`.

## Test plan
- [x] `go test ./internal/login/... ./internal/org/...`
- [x] `golangci-lint run internal/login/...`