### PR TITLE
Add /proxy XRPC endpoint to sap internal server

### DIFF
--- a/cmd/sap/main.go
+++ b/cmd/sap/main.go
@@ -101,6 +101,7 @@ func runSap(ctx context.Context, cmd *cli.Command) error {
 	internalMux.HandleFunc("/org/add", server.handleAddOrg)
 	internalMux.HandleFunc("/org/list", server.handleListOrgs)
 	internalMux.HandleFunc("/channel", server.handleOutboxChannel)
+	internalMux.HandleFunc("/proxy/", server.handleProxy)
 
 	slog.InfoContext(ctx, "listening",
 		"oauth_port", cmd.String(fPort),

--- a/cmd/sap/proxy_test.go
+++ b/cmd/sap/proxy_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/indigo/atproto/auth/oauth"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/habitat-network/habitat/internal/oauthclient"
+	"github.com/habitat-network/habitat/internal/sap"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const testProxyDID = "did:plc:testorg"
+
+// futureJWT returns a JWT whose only meaningful claim is an expiry far in the
+// future, so the OAuth transport treats the access token as valid and never
+// attempts a refresh. The signature is irrelevant: expiry is read via
+// ParseUnverified.
+func futureJWT(t *testing.T) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := tok.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return signed
+}
+
+// openProxyTestServer wires up a sap server whose managed org points at the
+// given pear host, returning an httptest server exposing the /proxy/ route.
+func openProxyTestServer(t *testing.T, pearHost string) *httptest.Server {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(t.TempDir()+"/test.db"), &gorm.Config{})
+	require.NoError(t, err)
+
+	store, err := oauthclient.NewGormStore(db)
+	require.NoError(t, err)
+
+	cfg := oauth.NewPublicConfig(
+		"https://example.com/client-metadata.json",
+		"https://example.com/oauth-callback",
+		[]string{"atproto"},
+	)
+	oauthApp := oauthclient.NewApp(&cfg, store)
+
+	s, err := sap.NewSap(sap.SapConfig{DB: db, OAuthClient: oauthApp})
+	require.NoError(t, err)
+
+	// Register the managed org and its OAuth session directly, avoiding the
+	// crawl/subscribe goroutines that AddManagedOrg would spawn.
+	require.NoError(t, db.Table("managed_orgs").Create(map[string]any{
+		"did":        testProxyDID,
+		"session_id": "session-1",
+	}).Error)
+	require.NoError(t, store.SaveSession(t.Context(), oauth.ClientSessionData{
+		AccountDID:  testProxyDID,
+		SessionID:   "session-1",
+		HostURL:     pearHost,
+		AccessToken: futureJWT(t),
+	}))
+
+	server := NewSapServer(s, oauthApp)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/proxy/", server.handleProxy)
+	httpServer := httptest.NewServer(mux)
+	t.Cleanup(httpServer.Close)
+	return httpServer
+}
+
+func TestServerProxyForwardsRequestToPear(t *testing.T) {
+	t.Parallel()
+
+	var gotReq *http.Request
+	var gotBody string
+	pear := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = r.Clone(r.Context())
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("X-Pear-Response", "ok")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"result":"created"}`))
+	}))
+	t.Cleanup(pear.Close)
+
+	httpServer := openProxyTestServer(t, pear.URL)
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		httpServer.URL+"/proxy/network.habitat.space.createRecord?collection=note",
+		strings.NewReader(`{"text":"hi"}`),
+	)
+	require.NoError(t, err)
+	req.Header.Set(habitatDIDHeader, testProxyDID)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The response from pear is passed through unchanged.
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.Equal(t, "ok", resp.Header.Get("X-Pear-Response"))
+	body, _ := io.ReadAll(resp.Body)
+	require.JSONEq(t, `{"result":"created"}`, string(body))
+
+	// The request reached pear as an /xrpc/ call with method, query, and body intact.
+	require.NotNil(t, gotReq)
+	require.Equal(t, http.MethodPost, gotReq.Method)
+	require.Equal(t, "/xrpc/network.habitat.space.createRecord", gotReq.URL.Path)
+	require.Equal(t, "note", gotReq.URL.Query().Get("collection"))
+	require.Equal(t, `{"text":"hi"}`, gotBody)
+	require.Equal(t, "application/json", gotReq.Header.Get("Content-Type"))
+
+	// The OAuth session's token is attached and the DID selector header is stripped.
+	require.NotEmpty(t, gotReq.Header.Get("Authorization"))
+	require.Equal(t, "oauth", gotReq.Header.Get("Habitat-Auth-Method"))
+	require.Empty(t, gotReq.Header.Get(habitatDIDHeader))
+}
+
+func TestServerProxyRejectsMissingDIDHeader(t *testing.T) {
+	t.Parallel()
+
+	httpServer := openProxyTestServer(t, "http://unused.example")
+
+	resp, err := http.Get(httpServer.URL + "/proxy/network.habitat.space.listSpaces")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestServerProxyUnknownDIDReturnsBadGateway(t *testing.T) {
+	t.Parallel()
+
+	httpServer := openProxyTestServer(t, "http://unused.example")
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		httpServer.URL+"/proxy/network.habitat.space.listSpaces",
+		nil,
+	)
+	require.NoError(t, err)
+	req.Header.Set(habitatDIDHeader, "did:plc:unknownorg")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}

--- a/cmd/sap/server.go
+++ b/cmd/sap/server.go
@@ -3,13 +3,26 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/habitat-network/habitat/internal/oauthclient"
 	"github.com/habitat-network/habitat/internal/sap"
 )
+
+// habitatDIDHeader names the DID the caller wants the proxied request to be
+// authenticated as. sap looks up the OAuth session it tracks for this DID.
+const habitatDIDHeader = "Habitat-Did"
+
+// hopByHopHeaders are connection-scoped and must not be forwarded to pear per
+// the HTTP/1.1 spec (RFC 7230 §6.1).
+var hopByHopHeaders = []string{
+	"Connection", "Transfer-Encoding", "Te", "Upgrade", "Keep-Alive",
+}
 
 type server struct {
 	sap         *sap.Sap
@@ -92,6 +105,82 @@ func (s *server) handleOAuthCallback(w http.ResponseWriter, r *http.Request) {
 
 	slog.InfoContext(r.Context(), "org oauth complete", "did", sessionData.AccountDID)
 	w.WriteHeader(http.StatusOK)
+}
+
+// handleProxy forwards an XRPC request to pear on behalf of a managed org,
+// authenticating with the OAuth session sap tracks for the DID named in the
+// Habitat-Did header. The path after /proxy/ is the XRPC method, forwarded to
+// pear as /xrpc/<method> with the original method, query params, headers, and
+// body preserved.
+func (s *server) handleProxy(w http.ResponseWriter, r *http.Request) {
+	didStr := r.Header.Get(habitatDIDHeader)
+	if didStr == "" {
+		http.Error(w, "missing "+habitatDIDHeader+" header", http.StatusBadRequest)
+		return
+	}
+	did, err := syntax.ParseDID(didStr)
+	if err != nil {
+		http.Error(
+			w,
+			fmt.Sprintf("invalid %s header: %s", habitatDIDHeader, err),
+			http.StatusBadRequest,
+		)
+		return
+	}
+
+	client, err := s.sap.GetClient(r.Context(), did)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("no tracked session for %s: %s", did, err), http.StatusBadGateway)
+		return
+	}
+
+	// The OAuth client's transport resolves this path-only URL against the org's
+	// Habitat host and attaches the access token.
+	nsid := strings.TrimPrefix(r.URL.Path, "/proxy/")
+	target := url.URL{Path: "/xrpc/" + nsid, RawQuery: r.URL.RawQuery}
+
+	var body io.Reader
+	if r.Body != nil {
+		body = r.Body
+	}
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, target.String(), body)
+	if err != nil {
+		http.Error(
+			w,
+			fmt.Sprintf("build forwarded request: %s", err),
+			http.StatusInternalServerError,
+		)
+		return
+	}
+
+	// Clone the caller's headers, then scrub hop-by-hop headers, any headers
+	// named in the Connection value, and the auth-related headers we replace.
+	outReq.Header = r.Header.Clone()
+	for _, h := range strings.Split(outReq.Header.Get("Connection"), ",") {
+		outReq.Header.Del(strings.TrimSpace(h))
+	}
+	for _, h := range hopByHopHeaders {
+		outReq.Header.Del(h)
+	}
+	outReq.Header.Del(habitatDIDHeader)
+	outReq.Header.Del("Authorization")
+
+	resp, err := client.Do(outReq)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("forward request: %s", err), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		slog.ErrorContext(r.Context(), "proxy: copy response body", "err", err)
+	}
 }
 
 func (s *server) handleClientMetadata(w http.ResponseWriter, r *http.Request) {

--- a/internal/sap/sap.go
+++ b/internal/sap/sap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -96,4 +97,16 @@ func (s *Sap) AddManagedOrg(ctx context.Context, did syntax.DID, sessionID strin
 
 func (s *Sap) ListManagedOrgs(ctx context.Context) ([]syntax.DID, error) {
 	return s.orgManager.ListManagedOrgs(ctx)
+}
+
+// GetClient returns an HTTP client that authenticates as the given managed org
+// DID using the OAuth session sap tracks for it. Requests made with the
+// returned client are resolved against the org's Habitat (pear) host and carry
+// the org's access token.
+func (s *Sap) GetClient(ctx context.Context, did syntax.DID) (*http.Client, error) {
+	org, err := s.orgManager.GetManagedOrg(ctx, did)
+	if err != nil {
+		return nil, err
+	}
+	return s.oauthClient.GetClient(ctx, did, org.SessionID)
 }


### PR DESCRIPTION
## Motivation

This lets users of `sap` interact with `pear` **without managing their own auth sessions**. `sap` already tracks OAuth sessions for the orgs it manages (crawling their repos, subscribing to their firehose). This endpoint reuses those sessions so a caller can proxy an XRPC request through `sap` and have it authenticated on the org's behalf — instead of every caller running its own OAuth flow and refreshing tokens.

## What changed

**`internal/sap/sap.go`** — added `Sap.GetClient(ctx, did)`. It resolves the managed org's tracked OAuth session (DID → `sessionID`, which only `sap` knows) and returns an authenticated `*http.Client` via the existing `oauthclient.App`. The client's transport resolves relative paths against the org's Habitat host and attaches the access token — the same path the crawler/resyncer already use.

**`cmd/sap/server.go`** — added `handleProxy`:
- Reads the target DID from the `Habitat-Did` request header (`400` if missing/invalid).
- Resolves it to the tracked session via `Sap.GetClient` (`502` if there's no session for that DID).
- Rewrites the path: everything after `/proxy/` becomes `/xrpc/<method>`, preserving the original HTTP method, query string, headers, and body.
- Clones the caller's headers, scrubs hop-by-hop headers and the `Habitat-Did`/`Authorization` headers we replace, then forwards. The OAuth transport attaches the bearer token.
- Streams pear's status, headers, and body straight back.

**`cmd/sap/main.go`** — registered `/proxy/` on the **internal** mux (alongside `/health`, `/org/*`, `/channel`), keeping it off the public OAuth port so access can be restricted to trusted callers.

**`cmd/sap/proxy_test.go`** — tests covering the happy path (method/query/body/token forwarded, `/xrpc/` rewrite, `Habitat-Did` stripped, response passed through) plus missing-header (`400`) and unknown-DID (`502`) cases.

## Usage

```
POST /proxy/network.habitat.space.createRecord?collection=note
Habitat-Did: did:plc:someorg
<body>
```

is forwarded to that org's pear as `POST /xrpc/network.habitat.space.createRecord?collection=note` with the org's OAuth token attached.

## Testing

- `go test ./...` in the `cmd/sap` module — pass
- `go build` / `go vet` on `cmd/sap` and `internal/sap` — clean
- `golangci-lint run` on both — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVvUZodx7VwMmxweE5eLFP)_