### PR TITLE
[Org]: Add contact email to org creation flow

### DIFF
--- a/api-docs/static/api.json
+++ b/api-docs/static/api.json
@@ -2350,12 +2350,17 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "admin_handle"
+                  "admin_handle",
+                  "contact_email"
                 ],
                 "properties": {
                   "admin_handle": {
                     "type": "string",
                     "description": "Internal handle for the bootstrap admin (alphanumeric, 1-50 chars)."
+                  },
+                  "contact_email": {
+                    "type": "string",
+                    "description": "Email address for contacting the org about its account (not used for login)."
                   },
                   "admin_password": {
                     "type": "string",

--- a/api/habitat/org_create.go
+++ b/api/habitat/org_create.go
@@ -6,6 +6,7 @@ package habitat
 type NetworkHabitatOrgCreateInput struct {
 	AdminHandle     string `json:"admin_handle"`
 	AdminPassword   string `json:"admin_password,omitempty"`
+	ContactEmail    string `json:"contact_email"`
 	HandleSubdomain string `json:"handle_subdomain,omitempty"`
 	InviteToken     string `json:"invite_token,omitempty"`
 	LoginId         string `json:"login_id,omitempty"`

--- a/frontend/src/routes/org/create.tsx
+++ b/frontend/src/routes/org/create.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Field,
+  FieldDescription,
   FieldError,
   FieldLabel,
   Input,
@@ -27,6 +28,7 @@ interface FormValues {
   admin_password: string;
   login_method: "password" | "atproto" | "google";
   login_id: string;
+  contact_email: string;
   handle_subdomain: string;
   use_custom_instance: boolean;
   custom_domain: string;
@@ -91,6 +93,7 @@ function CreateOrgPage() {
       name: "My Organization",
       login_method: "password",
       login_id: "",
+      contact_email: "",
       use_custom_instance: false,
       custom_domain: "",
     },
@@ -99,6 +102,15 @@ function CreateOrgPage() {
   const loginMethod = watch("login_method");
   const useCustomInstance = watch("use_custom_instance");
   const customDomain = watch("custom_domain");
+  const googleLoginId = watch("login_id");
+
+  const [contactEmailTouched, setContactEmailTouched] = useState(false);
+
+  useEffect(() => {
+    if (loginMethod === "google" && !contactEmailTouched) {
+      setValue("contact_email", googleLoginId);
+    }
+  }, [loginMethod, googleLoginId, contactEmailTouched, setValue]);
 
   useEffect(() => {
     if (invite || !useCustomInstance || !customDomain) {
@@ -142,6 +154,7 @@ function CreateOrgPage() {
         name: values.name || undefined,
         login_method: values.login_method,
         handle_subdomain: values.handle_subdomain,
+        contact_email: values.contact_email,
         invite_token: token,
       };
       if (values.login_method === "password") {
@@ -214,6 +227,22 @@ function CreateOrgPage() {
             <FieldLabel>Organization Name</FieldLabel>
             <Input placeholder="My Organization" {...register("name")} />
             <FieldError errors={[errors.name]} />
+          </Field>
+          <Field>
+            <FieldLabel>Contact Email</FieldLabel>
+            <FieldDescription>
+              For contact purposes about your account.
+            </FieldDescription>
+            <Input
+              type="email"
+              placeholder="you@example.com"
+              {...register("contact_email", {
+                required: true,
+                onChange: () => setContactEmailTouched(true),
+                pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+              })}
+            />
+            <FieldError errors={[errors.contact_email]} />
           </Field>
           <Field>
             <FieldLabel>Handle Subdomain</FieldLabel>

--- a/integration/org_mint_identity_test.go
+++ b/integration/org_mint_identity_test.go
@@ -46,6 +46,7 @@ func TestMintThenLookup(t *testing.T) {
 		"password",
 		"",
 		"test-org",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 	testOrgID := orgIdIdent.DID

--- a/internal/oauthserver/oauth_server_test.go
+++ b/internal/oauthserver/oauth_server_test.go
@@ -34,7 +34,16 @@ import (
 func testStore(t *testing.T) org.Store {
 	t.Helper()
 	s := testutil.NewTestStore(t)
-	_, _, err := s.CreateOrg(t.Context(), "org-name", "admin", "password", "", "", "", "contact@example.com")
+	_, _, err := s.CreateOrg(
+		t.Context(),
+		"org-name",
+		"admin",
+		"password",
+		"",
+		"",
+		"",
+		"contact@example.com",
+	)
 	require.NoError(t, err)
 	return s
 }

--- a/internal/oauthserver/oauth_server_test.go
+++ b/internal/oauthserver/oauth_server_test.go
@@ -34,7 +34,7 @@ import (
 func testStore(t *testing.T) org.Store {
 	t.Helper()
 	s := testutil.NewTestStore(t)
-	_, _, err := s.CreateOrg(t.Context(), "org-name", "admin", "password", "", "", "")
+	_, _, err := s.CreateOrg(t.Context(), "org-name", "admin", "password", "", "", "", "contact@example.com")
 	require.NoError(t, err)
 	return s
 }
@@ -461,6 +461,7 @@ func TestOAuthServerAuthenticatesHiveServedIdentity(t *testing.T) {
 		"atproto",
 		pdsLoginDID,
 		"acme",
+		"contact@example.com",
 	)
 	require.NoError(t, err, "failed to create org with hive-served admin")
 

--- a/internal/org/login_router_test.go
+++ b/internal/org/login_router_test.go
@@ -43,6 +43,7 @@ func TestLoginRouter(t *testing.T) {
 		string(core.LoginMethodGoogle),
 		"test@gmail.com",
 		"subdomain",
+		"contact@example.com",
 	)
 	t.Logf("orgId: %s", orgId.DID.String())
 	t.Logf("adminId: %s", adminId.DID.String())
@@ -94,6 +95,7 @@ func TestExchange_RequireAdminForOrg(t *testing.T) {
 		string(core.LoginMethodGoogle),
 		"test@gmail.com",
 		"subdomain",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 	token, err := store.IssueIdentityToken(
@@ -131,6 +133,7 @@ func TestExchange_MismatchLoginID(t *testing.T) {
 		string(core.LoginMethodGoogle),
 		"test@gmail.com",
 		"subdomain",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 	router := LoginRouter{
@@ -158,6 +161,7 @@ func TestExchange_MissingMember(t *testing.T) {
 		string(core.LoginMethodGoogle),
 		"test@gmail.com",
 		"subdomain",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 	router := LoginRouter{

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -15,6 +15,7 @@ type organization struct {
 	SigningSecret   string           // base64-encoded HMAC-SHA256 key for invite tokens
 	CreatedAt       time.Time
 	HandleSubdomain string `gorm:"unique"`
+	ContactEmail    string `gorm:"not null"` // email for reaching out to the org about its account
 }
 
 // Keep track of members in the org.

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -15,7 +15,7 @@ type organization struct {
 	SigningSecret   string           // base64-encoded HMAC-SHA256 key for invite tokens
 	CreatedAt       time.Time
 	HandleSubdomain string `gorm:"unique"`
-	ContactEmail    string `gorm:"not null"` // email for reaching out to the org about its account
+	ContactEmail    string `gorm:"unique"` // email for reaching out to the org about its account
 }
 
 // Keep track of members in the org.

--- a/internal/org/server.go
+++ b/internal/org/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/mail"
 	"strings"
 	"time"
 
@@ -159,8 +160,13 @@ func (s *Server) CreateOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.AdminHandle == "" || req.Name == "" || req.LoginMethod == "" {
+	if req.AdminHandle == "" || req.Name == "" || req.LoginMethod == "" || req.ContactEmail == "" {
 		utils.LogAndHTTPError(r.Context(), w, nil, "missing required fields", http.StatusBadRequest)
+		return
+	}
+
+	if _, err := mail.ParseAddress(req.ContactEmail); err != nil {
+		utils.LogAndHTTPError(r.Context(), w, nil, "invalid contact email", http.StatusBadRequest)
 		return
 	}
 
@@ -215,6 +221,7 @@ func (s *Server) CreateOrg(w http.ResponseWriter, r *http.Request) {
 		req.LoginMethod,
 		req.LoginId,
 		req.HandleSubdomain,
+		req.ContactEmail,
 	)
 	if errors.Is(err, identity.ErrInvalidHandle) {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/org/server_test.go
+++ b/internal/org/server_test.go
@@ -60,6 +60,7 @@ func newTestServer(
 		"password",
 		"",
 		"",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 
@@ -221,6 +222,7 @@ func TestCreateOrg(t *testing.T) {
 		AdminPassword:   "securepassword123",
 		LoginMethod:     "password",
 		HandleSubdomain: "org",
+		ContactEmail:    "contact@example.com",
 	})
 	req := httptest.NewRequest(
 		http.MethodPost,
@@ -266,6 +268,7 @@ func TestCreateOrg_InvalidHandle(t *testing.T) {
 		AdminPassword:   "password",
 		LoginMethod:     "password",
 		HandleSubdomain: "org",
+		ContactEmail:    "contact@example.com",
 	})
 	req := httptest.NewRequest(
 		http.MethodPost,
@@ -278,12 +281,47 @@ func TestCreateOrg_InvalidHandle(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestCreateOrg_ContactEmailValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		contactEmail string
+	}{
+		{name: "missing", contactEmail: ""},
+		{name: "malformed", contactEmail: "not-an-email"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newCreateTestServer(t)
+
+			body, _ := json.Marshal(habitat.NetworkHabitatOrgCreateInput{
+				Name:            "My Org",
+				AdminHandle:     "admin",
+				AdminPassword:   "securepassword123",
+				LoginMethod:     "password",
+				HandleSubdomain: "org",
+				ContactEmail:    tt.contactEmail,
+			})
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/xrpc/network.habitat.org.create",
+				bytes.NewReader(body),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.CreateOrg(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
 func TestCreateOrg_MissingFields(t *testing.T) {
 	srv := newCreateTestServer(t)
 
 	body, _ := json.Marshal(habitat.NetworkHabitatOrgCreateInput{
 		AdminHandle:     "admin",
 		HandleSubdomain: "org",
+		ContactEmail:    "contact@example.com",
 	})
 	req := httptest.NewRequest(
 		http.MethodPost,
@@ -313,6 +351,7 @@ func TestCreateOrg_OpenPolicyIgnoresMissingToken(t *testing.T) {
 		AdminPassword:   "password",
 		LoginMethod:     "password",
 		HandleSubdomain: "test",
+		ContactEmail:    "contact@example.com",
 	})
 	req := httptest.NewRequest(
 		http.MethodPost,
@@ -342,6 +381,7 @@ func TestCreateOrg_InviteOnlyRejectsMissingToken(t *testing.T) {
 		AdminPassword:   "password",
 		LoginMethod:     "password",
 		HandleSubdomain: "test",
+		ContactEmail:    "contact@example.com",
 	})
 	req := httptest.NewRequest(
 		http.MethodPost,
@@ -371,6 +411,7 @@ func TestCreateOrg_InviteOnlyRejectsInvalidToken(t *testing.T) {
 		AdminPassword:   "password",
 		LoginMethod:     "password",
 		HandleSubdomain: "test",
+		ContactEmail:    "contact@example.com",
 		InviteToken:     "garbage",
 	})
 	req := httptest.NewRequest(
@@ -402,6 +443,7 @@ func TestCreateOrg_InviteOnlyAcceptsValidToken(t *testing.T) {
 		AdminPassword:   "password",
 		LoginMethod:     "password",
 		HandleSubdomain: "test",
+		ContactEmail:    "contact@example.com",
 		InviteToken:     "a-valid-token",
 	})
 	req := httptest.NewRequest(
@@ -443,6 +485,7 @@ func TestCreateOrg_InviteOnlyDoesNotMarkUsedOnCreateFailure(t *testing.T) {
 		"password",
 		"",
 		"test",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 
@@ -452,6 +495,7 @@ func TestCreateOrg_InviteOnlyDoesNotMarkUsedOnCreateFailure(t *testing.T) {
 		AdminPassword:   "password",
 		LoginMethod:     "password",
 		HandleSubdomain: "test",
+		ContactEmail:    "contact@example.com",
 		InviteToken:     "a-valid-token",
 	})
 	req := httptest.NewRequest(
@@ -496,6 +540,7 @@ func TestCreateOrg_InviteOnlyAcceptsRealIssuedToken(t *testing.T) {
 		AdminPassword:   "password",
 		LoginMethod:     "password",
 		HandleSubdomain: "test",
+		ContactEmail:    "contact@example.com",
 		InviteToken:     token,
 	})
 	req := httptest.NewRequest(

--- a/internal/org/store.go
+++ b/internal/org/store.go
@@ -44,6 +44,7 @@ type Store interface {
 		loginMethod string,
 		loginID string,
 		handleSubdomain string,
+		contactEmail string,
 	) (orgId *identity.Identity, id *identity.Identity, err error)
 
 	GetMember(ctx context.Context, did syntax.DID) (*Member, error)
@@ -159,6 +160,7 @@ func (s *storeImpl) CreateOrg(
 	method string,
 	loginID string,
 	handleSubdomain string,
+	contactEmail string,
 ) (*identity.Identity, *identity.Identity, error) {
 	secret := make([]byte, 32)
 	if _, err := rand.Read(secret); err != nil {
@@ -181,6 +183,7 @@ func (s *storeImpl) CreateOrg(
 			SigningSecret:   signingSecret,
 			CreatedAt:       time.Now(),
 			HandleSubdomain: handleSubdomain,
+			ContactEmail:    contactEmail,
 		}).Error; err != nil {
 			if isDuplicateError(err) {
 				return ErrOrgAlreadyExists

--- a/internal/org/store_test.go
+++ b/internal/org/store_test.go
@@ -46,6 +46,7 @@ func TestStore_CreateOrg(t *testing.T) {
 		"password",
 		"",
 		"",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, orgId)
@@ -64,6 +65,10 @@ func TestStore_CreateOrg(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, admins, 1)
 	require.Equal(t, adminId.DID, admins[0])
+
+	var stored organization
+	require.NoError(t, s.db.First(&stored, "id = ?", orgId.DID).Error)
+	require.Equal(t, "contact@example.com", stored.ContactEmail)
 }
 
 func TestStore_GetOrg_NotFound(t *testing.T) {
@@ -82,6 +87,7 @@ func TestStore_GetOrgForDID_Member(t *testing.T) {
 		"password",
 		"",
 		"",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 
@@ -118,6 +124,7 @@ func TestStore_GetMember_Existing(t *testing.T) {
 		"password",
 		"",
 		"",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 
@@ -153,6 +160,7 @@ func TestStore_GetOrgForDID_AfterMultipleOrgs(t *testing.T) {
 		"password",
 		"",
 		"org1",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 	orgId2, adminId2, err := s.CreateOrg(
@@ -163,6 +171,7 @@ func TestStore_GetOrgForDID_AfterMultipleOrgs(t *testing.T) {
 		"password",
 		"",
 		"org2",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 

--- a/internal/org/store_test.go
+++ b/internal/org/store_test.go
@@ -160,7 +160,7 @@ func TestStore_GetOrgForDID_AfterMultipleOrgs(t *testing.T) {
 		"password",
 		"",
 		"org1",
-		"contact@example.com",
+		"contact1@example.com",
 	)
 	require.NoError(t, err)
 	orgId2, adminId2, err := s.CreateOrg(
@@ -171,7 +171,7 @@ func TestStore_GetOrgForDID_AfterMultipleOrgs(t *testing.T) {
 		"password",
 		"",
 		"org2",
-		"contact@example.com",
+		"contact2@example.com",
 	)
 	require.NoError(t, err)
 

--- a/internal/sap/sap_test.go
+++ b/internal/sap/sap_test.go
@@ -315,6 +315,7 @@ func setupPear(
 		"atproto",
 		"loginId",
 		"org",
+		"contact@example.com",
 	)
 	require.NoError(t, err)
 

--- a/lexicons/network/habitat/org/create.json
+++ b/lexicons/network/habitat/org/create.json
@@ -9,11 +9,15 @@
                 "encoding": "application/json",
                 "schema": {
                     "type": "object",
-                    "required": ["admin_handle"],
+                    "required": ["admin_handle", "contact_email"],
                     "properties": {
                         "admin_handle": {
                             "type": "string",
                             "description": "Internal handle for the bootstrap admin (alphanumeric, 1-50 chars)."
+                        },
+                        "contact_email": {
+                            "type": "string",
+                            "description": "Email address for contacting the org about its account (not used for login)."
                         },
                         "admin_password": {
                             "type": "string",

--- a/typescript/api/lexicons.ts
+++ b/typescript/api/lexicons.ts
@@ -1972,12 +1972,17 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['admin_handle'],
+            required: ['admin_handle', 'contact_email'],
             properties: {
               admin_handle: {
                 type: 'string',
                 description:
                   'Internal handle for the bootstrap admin (alphanumeric, 1-50 chars).',
+              },
+              contact_email: {
+                type: 'string',
+                description:
+                  'Email address for contacting the org about its account (not used for login).',
               },
               admin_password: {
                 type: 'string',

--- a/typescript/api/types/network/habitat/org/create.ts
+++ b/typescript/api/types/network/habitat/org/create.ts
@@ -20,6 +20,8 @@ export type QueryParams = {}
 export interface InputSchema {
   /** Internal handle for the bootstrap admin (alphanumeric, 1-50 chars). */
   admin_handle: string
+  /** Email address for contacting the org about its account (not used for login). */
+  contact_email: string
   /** Password for the bootstrap admin account (required for password login method). */
   admin_password?: string
   /** Subdomain for all org member handles (e.g. 'acmecorp'). */

--- a/typescript/xrpc-openapi-gen/spec/api.json
+++ b/typescript/xrpc-openapi-gen/spec/api.json
@@ -2350,12 +2350,17 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "admin_handle"
+                  "admin_handle",
+                  "contact_email"
                 ],
                 "properties": {
                   "admin_handle": {
                     "type": "string",
                     "description": "Internal handle for the bootstrap admin (alphanumeric, 1-50 chars)."
+                  },
+                  "contact_email": {
+                    "type": "string",
+                    "description": "Email address for contacting the org about its account (not used for login)."
                   },
                   "admin_password": {
                     "type": "string",


### PR DESCRIPTION
Orgs now provide a required contact email on creation so Habitat can reach out to the person setting up the org. Threaded through the network.habitat.org.create lexicon, the organization store/model, and the create-org form (pre-filled from the Google login email when that login method is used).