### PR TITLE
Add multibasekeygen cmd for SAP_SECRET

### DIFF
--- a/cmd/multibasekeygen/main.go
+++ b/cmd/multibasekeygen/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bluesky-social/indigo/atproto/atcrypto"
+)
+
+func main() {
+	priv, err := atcrypto.GeneratePrivateKeyP256()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println(priv.Multibase())
+}

--- a/cmd/sap/main.go
+++ b/cmd/sap/main.go
@@ -23,6 +23,7 @@ import (
 
 func main() {
 	if err := run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "sap:", err)
 		slog.ErrorContext(context.Background(), "error running command", "err", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
sap's SAP_SECRET requires a multibase base58btc string. Added `/cmd/multibasekeygen` which creates such a string. 

Also print sap startup errors to stderr for easier debugging

Example showing the issue and the fix (note that originally, before adding the print error to stderr, it just exited 1 with no message):
```
$ SAP_DB=sqlite://sap.db SAP_DOMAIN=nixos.taila4a0bf.ts.net SAP_PORT=2580 SAP_INTERNAL_PORT=2581  go run ./cmd/sap
2026/07/18 22:58:02 INFO using no-op tracer provider
2026/07/18 22:58:02 INFO using no-op meter provider
2026/07/18 22:58:02 INFO using no-op logger provider
sap: parse secret: crypto: not a multibase base58btc string
exit status 1
$ go run ./cmd/multibasekeygen
z42tkez5t1RCLE6EioA4vqHYBVVjkFGBtrnrT7czTDq5vfju
$ SAP_DB=sqlite://sap.db SAP_DOMAIN=nixos.taila4a0bf.ts.net SAP_PORT=2580 SAP_INTERNAL_PORT=2581 SAP_SECRET="z42tkez5t1RCLE6EioA4vqHYBVVjkFGBtrnrT7czTDq5vfju" go run ./cmd/sap
2026/07/18 22:58:43 INFO using no-op tracer provider
2026/07/18 22:58:43 INFO using no-op meter provider
2026/07/18 22:58:43 INFO using no-op logger provider
## running 
```

I used GLM 5.2 to diagnose this issue and might be missing something, but it also makes sense from the error message

note that from my understanding, the already existing `/cmd/keygen` creates a different kind of key, which is used for HABITAT_OAUTH_SERVER_SECRET, HABITAT_OAUTH_CLIENT_SECRET, HABITAT_PDS_CRED_ENCRYPT_KEY (according to https://github.com/habitat-network/habitat/blob/master/CLAUDE.md), but this is a different key type than SAP_SECRET seems to expect 