### PR TITLE
[prod]: db bugfixes

### DIFF
--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -8,597 +8,597 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as RequireAuthRouteImport } from './routes/_requireAuth'
-import { Route as DevtoolsRouteImport } from './routes/devtools'
-import { Route as ExploreRouteImport } from './routes/explore'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as OauthLoginRouteImport } from './routes/oauth-login'
-import { Route as OnboardRouteImport } from './routes/onboard'
-import { Route as RequireAuthIndexRouteImport } from './routes/_requireAuth/index'
-import { Route as RequireAuthDataRouteImport } from './routes/_requireAuth/data'
-import { Route as RequireAuthPermissionsRouteImport } from './routes/_requireAuth/permissions'
-import { Route as CommunityCreateRouteImport } from './routes/community/create'
-import { Route as LoginHabitatRouteImport } from './routes/login/habitat'
-import { Route as OrgCreateRouteImport } from './routes/org/create'
-import { Route as OrgJoinRouteImport } from './routes/org/join'
-import { Route as RequireAuthBlobTestIndexRouteImport } from './routes/_requireAuth/blob-test/index'
-import { Route as RequireAuthCollectionsIndexRouteImport } from './routes/_requireAuth/collections/index'
-import { Route as RequireAuthCollectionsCollectionRouteImport } from './routes/_requireAuth/collections/$collection'
-import { Route as RequireAuthGroupsIndexRouteImport } from './routes/_requireAuth/groups/index'
-import { Route as RequireAuthGroupsGroupRouteImport } from './routes/_requireAuth/groups/$group'
-import { Route as RequireAuthOrgIndexRouteImport } from './routes/_requireAuth/org/index'
-import { Route as RequireAuthPearTestIndexRouteImport } from './routes/_requireAuth/pear-test/index'
-import { Route as RequireAuthPearTestViewRouteImport } from './routes/_requireAuth/pear-test/view'
-import { Route as RequireAuthPermissionsIndexRouteImport } from './routes/_requireAuth/permissions/index'
-import { Route as RequireAuthPermissionsLexiconsRouteImport } from './routes/_requireAuth/permissions/lexicons'
-import { Route as RequireAuthPermissionsPeopleRouteImport } from './routes/_requireAuth/permissions/people'
-import { Route as RequireAuthSpacesIndexRouteImport } from './routes/_requireAuth/spaces/index'
-import { Route as RequireAuthSpacesSpaceRouteImport } from './routes/_requireAuth/spaces/$space'
-import { Route as RequireAuthPermissionsLexiconsIndexRouteImport } from './routes/_requireAuth/permissions/lexicons/index'
-import { Route as RequireAuthPermissionsLexiconsCollectionRouteImport } from './routes/_requireAuth/permissions/lexicons/$collection'
-import { Route as RequireAuthPermissionsPeopleDidRouteImport } from './routes/_requireAuth/permissions/people/$did'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as RequireAuthRouteImport } from "./routes/_requireAuth";
+import { Route as DevtoolsRouteImport } from "./routes/devtools";
+import { Route as ExploreRouteImport } from "./routes/explore";
+import { Route as LoginRouteImport } from "./routes/login";
+import { Route as OauthLoginRouteImport } from "./routes/oauth-login";
+import { Route as OnboardRouteImport } from "./routes/onboard";
+import { Route as RequireAuthIndexRouteImport } from "./routes/_requireAuth/index";
+import { Route as RequireAuthDataRouteImport } from "./routes/_requireAuth/data";
+import { Route as RequireAuthPermissionsRouteImport } from "./routes/_requireAuth/permissions";
+import { Route as CommunityCreateRouteImport } from "./routes/community/create";
+import { Route as LoginHabitatRouteImport } from "./routes/login/habitat";
+import { Route as OrgCreateRouteImport } from "./routes/org/create";
+import { Route as OrgJoinRouteImport } from "./routes/org/join";
+import { Route as RequireAuthBlobTestIndexRouteImport } from "./routes/_requireAuth/blob-test/index";
+import { Route as RequireAuthCollectionsIndexRouteImport } from "./routes/_requireAuth/collections/index";
+import { Route as RequireAuthCollectionsCollectionRouteImport } from "./routes/_requireAuth/collections/$collection";
+import { Route as RequireAuthGroupsIndexRouteImport } from "./routes/_requireAuth/groups/index";
+import { Route as RequireAuthGroupsGroupRouteImport } from "./routes/_requireAuth/groups/$group";
+import { Route as RequireAuthOrgIndexRouteImport } from "./routes/_requireAuth/org/index";
+import { Route as RequireAuthPearTestIndexRouteImport } from "./routes/_requireAuth/pear-test/index";
+import { Route as RequireAuthPearTestViewRouteImport } from "./routes/_requireAuth/pear-test/view";
+import { Route as RequireAuthPermissionsIndexRouteImport } from "./routes/_requireAuth/permissions/index";
+import { Route as RequireAuthPermissionsLexiconsRouteImport } from "./routes/_requireAuth/permissions/lexicons";
+import { Route as RequireAuthPermissionsPeopleRouteImport } from "./routes/_requireAuth/permissions/people";
+import { Route as RequireAuthSpacesIndexRouteImport } from "./routes/_requireAuth/spaces/index";
+import { Route as RequireAuthSpacesSpaceRouteImport } from "./routes/_requireAuth/spaces/$space";
+import { Route as RequireAuthPermissionsLexiconsIndexRouteImport } from "./routes/_requireAuth/permissions/lexicons/index";
+import { Route as RequireAuthPermissionsLexiconsCollectionRouteImport } from "./routes/_requireAuth/permissions/lexicons/$collection";
+import { Route as RequireAuthPermissionsPeopleDidRouteImport } from "./routes/_requireAuth/permissions/people/$did";
 
 const RequireAuthRoute = RequireAuthRouteImport.update({
-  id: '/_requireAuth',
+  id: "/_requireAuth",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DevtoolsRoute = DevtoolsRouteImport.update({
-  id: '/devtools',
-  path: '/devtools',
+  id: "/devtools",
+  path: "/devtools",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ExploreRoute = ExploreRouteImport.update({
-  id: '/explore',
-  path: '/explore',
+  id: "/explore",
+  path: "/explore",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
+  id: "/login",
+  path: "/login",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const OauthLoginRoute = OauthLoginRouteImport.update({
-  id: '/oauth-login',
-  path: '/oauth-login',
+  id: "/oauth-login",
+  path: "/oauth-login",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const OnboardRoute = OnboardRouteImport.update({
-  id: '/onboard',
-  path: '/onboard',
+  id: "/onboard",
+  path: "/onboard",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const RequireAuthIndexRoute = RequireAuthIndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const RequireAuthDataRoute = RequireAuthDataRouteImport.update({
-  id: '/data',
-  path: '/data',
+  id: "/data",
+  path: "/data",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const RequireAuthPermissionsRoute = RequireAuthPermissionsRouteImport.update({
-  id: '/permissions',
-  path: '/permissions',
+  id: "/permissions",
+  path: "/permissions",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const CommunityCreateRoute = CommunityCreateRouteImport.update({
-  id: '/community/create',
-  path: '/community/create',
+  id: "/community/create",
+  path: "/community/create",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LoginHabitatRoute = LoginHabitatRouteImport.update({
-  id: '/habitat',
-  path: '/habitat',
+  id: "/habitat",
+  path: "/habitat",
   getParentRoute: () => LoginRoute,
-} as any)
+} as any);
 const OrgCreateRoute = OrgCreateRouteImport.update({
-  id: '/org/create',
-  path: '/org/create',
+  id: "/org/create",
+  path: "/org/create",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const OrgJoinRoute = OrgJoinRouteImport.update({
-  id: '/org/join',
-  path: '/org/join',
+  id: "/org/join",
+  path: "/org/join",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const RequireAuthBlobTestIndexRoute =
   RequireAuthBlobTestIndexRouteImport.update({
-    id: '/blob-test/',
-    path: '/blob-test/',
+    id: "/blob-test/",
+    path: "/blob-test/",
     getParentRoute: () => RequireAuthRoute,
-  } as any)
+  } as any);
 const RequireAuthCollectionsIndexRoute =
   RequireAuthCollectionsIndexRouteImport.update({
-    id: '/collections/',
-    path: '/collections/',
+    id: "/collections/",
+    path: "/collections/",
     getParentRoute: () => RequireAuthRoute,
-  } as any)
+  } as any);
 const RequireAuthCollectionsCollectionRoute =
   RequireAuthCollectionsCollectionRouteImport.update({
-    id: '/collections/$collection',
-    path: '/collections/$collection',
+    id: "/collections/$collection",
+    path: "/collections/$collection",
     getParentRoute: () => RequireAuthRoute,
-  } as any)
+  } as any);
 const RequireAuthGroupsIndexRoute = RequireAuthGroupsIndexRouteImport.update({
-  id: '/groups/',
-  path: '/groups/',
+  id: "/groups/",
+  path: "/groups/",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const RequireAuthGroupsGroupRoute = RequireAuthGroupsGroupRouteImport.update({
-  id: '/groups/$group',
-  path: '/groups/$group',
+  id: "/groups/$group",
+  path: "/groups/$group",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const RequireAuthOrgIndexRoute = RequireAuthOrgIndexRouteImport.update({
-  id: '/org/',
-  path: '/org/',
+  id: "/org/",
+  path: "/org/",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const RequireAuthPearTestIndexRoute =
   RequireAuthPearTestIndexRouteImport.update({
-    id: '/pear-test/',
-    path: '/pear-test/',
+    id: "/pear-test/",
+    path: "/pear-test/",
     getParentRoute: () => RequireAuthRoute,
-  } as any)
+  } as any);
 const RequireAuthPearTestViewRoute = RequireAuthPearTestViewRouteImport.update({
-  id: '/pear-test/view',
-  path: '/pear-test/view',
+  id: "/pear-test/view",
+  path: "/pear-test/view",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const RequireAuthPermissionsIndexRoute =
   RequireAuthPermissionsIndexRouteImport.update({
-    id: '/',
-    path: '/',
+    id: "/",
+    path: "/",
     getParentRoute: () => RequireAuthPermissionsRoute,
-  } as any)
+  } as any);
 const RequireAuthPermissionsLexiconsRoute =
   RequireAuthPermissionsLexiconsRouteImport.update({
-    id: '/lexicons',
-    path: '/lexicons',
+    id: "/lexicons",
+    path: "/lexicons",
     getParentRoute: () => RequireAuthPermissionsRoute,
-  } as any)
+  } as any);
 const RequireAuthPermissionsPeopleRoute =
   RequireAuthPermissionsPeopleRouteImport.update({
-    id: '/people',
-    path: '/people',
+    id: "/people",
+    path: "/people",
     getParentRoute: () => RequireAuthPermissionsRoute,
-  } as any)
+  } as any);
 const RequireAuthSpacesIndexRoute = RequireAuthSpacesIndexRouteImport.update({
-  id: '/spaces/',
-  path: '/spaces/',
+  id: "/spaces/",
+  path: "/spaces/",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const RequireAuthSpacesSpaceRoute = RequireAuthSpacesSpaceRouteImport.update({
-  id: '/spaces/$space',
-  path: '/spaces/$space',
+  id: "/spaces/$space",
+  path: "/spaces/$space",
   getParentRoute: () => RequireAuthRoute,
-} as any)
+} as any);
 const RequireAuthPermissionsLexiconsIndexRoute =
   RequireAuthPermissionsLexiconsIndexRouteImport.update({
-    id: '/',
-    path: '/',
+    id: "/",
+    path: "/",
     getParentRoute: () => RequireAuthPermissionsLexiconsRoute,
-  } as any)
+  } as any);
 const RequireAuthPermissionsLexiconsCollectionRoute =
   RequireAuthPermissionsLexiconsCollectionRouteImport.update({
-    id: '/$collection',
-    path: '/$collection',
+    id: "/$collection",
+    path: "/$collection",
     getParentRoute: () => RequireAuthPermissionsLexiconsRoute,
-  } as any)
+  } as any);
 const RequireAuthPermissionsPeopleDidRoute =
   RequireAuthPermissionsPeopleDidRouteImport.update({
-    id: '/$did',
-    path: '/$did',
+    id: "/$did",
+    path: "/$did",
     getParentRoute: () => RequireAuthPermissionsPeopleRoute,
-  } as any)
+  } as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof RequireAuthIndexRoute
-  '/devtools': typeof DevtoolsRoute
-  '/explore': typeof ExploreRoute
-  '/login': typeof LoginRouteWithChildren
-  '/oauth-login': typeof OauthLoginRoute
-  '/onboard': typeof OnboardRoute
-  '/data': typeof RequireAuthDataRoute
-  '/permissions': typeof RequireAuthPermissionsRouteWithChildren
-  '/community/create': typeof CommunityCreateRoute
-  '/login/habitat': typeof LoginHabitatRoute
-  '/org/create': typeof OrgCreateRoute
-  '/org/join': typeof OrgJoinRoute
-  '/collections/$collection': typeof RequireAuthCollectionsCollectionRoute
-  '/groups/$group': typeof RequireAuthGroupsGroupRoute
-  '/pear-test/view': typeof RequireAuthPearTestViewRoute
-  '/permissions/lexicons': typeof RequireAuthPermissionsLexiconsRouteWithChildren
-  '/permissions/people': typeof RequireAuthPermissionsPeopleRouteWithChildren
-  '/spaces/$space': typeof RequireAuthSpacesSpaceRoute
-  '/blob-test/': typeof RequireAuthBlobTestIndexRoute
-  '/collections/': typeof RequireAuthCollectionsIndexRoute
-  '/groups/': typeof RequireAuthGroupsIndexRoute
-  '/org/': typeof RequireAuthOrgIndexRoute
-  '/pear-test/': typeof RequireAuthPearTestIndexRoute
-  '/permissions/': typeof RequireAuthPermissionsIndexRoute
-  '/spaces/': typeof RequireAuthSpacesIndexRoute
-  '/permissions/lexicons/$collection': typeof RequireAuthPermissionsLexiconsCollectionRoute
-  '/permissions/people/$did': typeof RequireAuthPermissionsPeopleDidRoute
-  '/permissions/lexicons/': typeof RequireAuthPermissionsLexiconsIndexRoute
+  "/": typeof RequireAuthIndexRoute;
+  "/devtools": typeof DevtoolsRoute;
+  "/explore": typeof ExploreRoute;
+  "/login": typeof LoginRouteWithChildren;
+  "/oauth-login": typeof OauthLoginRoute;
+  "/onboard": typeof OnboardRoute;
+  "/data": typeof RequireAuthDataRoute;
+  "/permissions": typeof RequireAuthPermissionsRouteWithChildren;
+  "/community/create": typeof CommunityCreateRoute;
+  "/login/habitat": typeof LoginHabitatRoute;
+  "/org/create": typeof OrgCreateRoute;
+  "/org/join": typeof OrgJoinRoute;
+  "/collections/$collection": typeof RequireAuthCollectionsCollectionRoute;
+  "/groups/$group": typeof RequireAuthGroupsGroupRoute;
+  "/pear-test/view": typeof RequireAuthPearTestViewRoute;
+  "/permissions/lexicons": typeof RequireAuthPermissionsLexiconsRouteWithChildren;
+  "/permissions/people": typeof RequireAuthPermissionsPeopleRouteWithChildren;
+  "/spaces/$space": typeof RequireAuthSpacesSpaceRoute;
+  "/blob-test/": typeof RequireAuthBlobTestIndexRoute;
+  "/collections/": typeof RequireAuthCollectionsIndexRoute;
+  "/groups/": typeof RequireAuthGroupsIndexRoute;
+  "/org/": typeof RequireAuthOrgIndexRoute;
+  "/pear-test/": typeof RequireAuthPearTestIndexRoute;
+  "/permissions/": typeof RequireAuthPermissionsIndexRoute;
+  "/spaces/": typeof RequireAuthSpacesIndexRoute;
+  "/permissions/lexicons/$collection": typeof RequireAuthPermissionsLexiconsCollectionRoute;
+  "/permissions/people/$did": typeof RequireAuthPermissionsPeopleDidRoute;
+  "/permissions/lexicons/": typeof RequireAuthPermissionsLexiconsIndexRoute;
 }
 export interface FileRoutesByTo {
-  '/devtools': typeof DevtoolsRoute
-  '/explore': typeof ExploreRoute
-  '/login': typeof LoginRouteWithChildren
-  '/oauth-login': typeof OauthLoginRoute
-  '/onboard': typeof OnboardRoute
-  '/data': typeof RequireAuthDataRoute
-  '/community/create': typeof CommunityCreateRoute
-  '/login/habitat': typeof LoginHabitatRoute
-  '/org/create': typeof OrgCreateRoute
-  '/org/join': typeof OrgJoinRoute
-  '/': typeof RequireAuthIndexRoute
-  '/collections/$collection': typeof RequireAuthCollectionsCollectionRoute
-  '/groups/$group': typeof RequireAuthGroupsGroupRoute
-  '/pear-test/view': typeof RequireAuthPearTestViewRoute
-  '/permissions/people': typeof RequireAuthPermissionsPeopleRouteWithChildren
-  '/spaces/$space': typeof RequireAuthSpacesSpaceRoute
-  '/blob-test': typeof RequireAuthBlobTestIndexRoute
-  '/collections': typeof RequireAuthCollectionsIndexRoute
-  '/groups': typeof RequireAuthGroupsIndexRoute
-  '/org': typeof RequireAuthOrgIndexRoute
-  '/pear-test': typeof RequireAuthPearTestIndexRoute
-  '/permissions': typeof RequireAuthPermissionsIndexRoute
-  '/spaces': typeof RequireAuthSpacesIndexRoute
-  '/permissions/lexicons/$collection': typeof RequireAuthPermissionsLexiconsCollectionRoute
-  '/permissions/people/$did': typeof RequireAuthPermissionsPeopleDidRoute
-  '/permissions/lexicons': typeof RequireAuthPermissionsLexiconsIndexRoute
+  "/devtools": typeof DevtoolsRoute;
+  "/explore": typeof ExploreRoute;
+  "/login": typeof LoginRouteWithChildren;
+  "/oauth-login": typeof OauthLoginRoute;
+  "/onboard": typeof OnboardRoute;
+  "/data": typeof RequireAuthDataRoute;
+  "/community/create": typeof CommunityCreateRoute;
+  "/login/habitat": typeof LoginHabitatRoute;
+  "/org/create": typeof OrgCreateRoute;
+  "/org/join": typeof OrgJoinRoute;
+  "/": typeof RequireAuthIndexRoute;
+  "/collections/$collection": typeof RequireAuthCollectionsCollectionRoute;
+  "/groups/$group": typeof RequireAuthGroupsGroupRoute;
+  "/pear-test/view": typeof RequireAuthPearTestViewRoute;
+  "/permissions/people": typeof RequireAuthPermissionsPeopleRouteWithChildren;
+  "/spaces/$space": typeof RequireAuthSpacesSpaceRoute;
+  "/blob-test": typeof RequireAuthBlobTestIndexRoute;
+  "/collections": typeof RequireAuthCollectionsIndexRoute;
+  "/groups": typeof RequireAuthGroupsIndexRoute;
+  "/org": typeof RequireAuthOrgIndexRoute;
+  "/pear-test": typeof RequireAuthPearTestIndexRoute;
+  "/permissions": typeof RequireAuthPermissionsIndexRoute;
+  "/spaces": typeof RequireAuthSpacesIndexRoute;
+  "/permissions/lexicons/$collection": typeof RequireAuthPermissionsLexiconsCollectionRoute;
+  "/permissions/people/$did": typeof RequireAuthPermissionsPeopleDidRoute;
+  "/permissions/lexicons": typeof RequireAuthPermissionsLexiconsIndexRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/_requireAuth': typeof RequireAuthRouteWithChildren
-  '/devtools': typeof DevtoolsRoute
-  '/explore': typeof ExploreRoute
-  '/login': typeof LoginRouteWithChildren
-  '/oauth-login': typeof OauthLoginRoute
-  '/onboard': typeof OnboardRoute
-  '/_requireAuth/data': typeof RequireAuthDataRoute
-  '/_requireAuth/permissions': typeof RequireAuthPermissionsRouteWithChildren
-  '/community/create': typeof CommunityCreateRoute
-  '/login/habitat': typeof LoginHabitatRoute
-  '/org/create': typeof OrgCreateRoute
-  '/org/join': typeof OrgJoinRoute
-  '/_requireAuth/': typeof RequireAuthIndexRoute
-  '/_requireAuth/collections/$collection': typeof RequireAuthCollectionsCollectionRoute
-  '/_requireAuth/groups/$group': typeof RequireAuthGroupsGroupRoute
-  '/_requireAuth/pear-test/view': typeof RequireAuthPearTestViewRoute
-  '/_requireAuth/permissions/lexicons': typeof RequireAuthPermissionsLexiconsRouteWithChildren
-  '/_requireAuth/permissions/people': typeof RequireAuthPermissionsPeopleRouteWithChildren
-  '/_requireAuth/spaces/$space': typeof RequireAuthSpacesSpaceRoute
-  '/_requireAuth/blob-test/': typeof RequireAuthBlobTestIndexRoute
-  '/_requireAuth/collections/': typeof RequireAuthCollectionsIndexRoute
-  '/_requireAuth/groups/': typeof RequireAuthGroupsIndexRoute
-  '/_requireAuth/org/': typeof RequireAuthOrgIndexRoute
-  '/_requireAuth/pear-test/': typeof RequireAuthPearTestIndexRoute
-  '/_requireAuth/permissions/': typeof RequireAuthPermissionsIndexRoute
-  '/_requireAuth/spaces/': typeof RequireAuthSpacesIndexRoute
-  '/_requireAuth/permissions/lexicons/$collection': typeof RequireAuthPermissionsLexiconsCollectionRoute
-  '/_requireAuth/permissions/people/$did': typeof RequireAuthPermissionsPeopleDidRoute
-  '/_requireAuth/permissions/lexicons/': typeof RequireAuthPermissionsLexiconsIndexRoute
+  __root__: typeof rootRouteImport;
+  "/_requireAuth": typeof RequireAuthRouteWithChildren;
+  "/devtools": typeof DevtoolsRoute;
+  "/explore": typeof ExploreRoute;
+  "/login": typeof LoginRouteWithChildren;
+  "/oauth-login": typeof OauthLoginRoute;
+  "/onboard": typeof OnboardRoute;
+  "/_requireAuth/data": typeof RequireAuthDataRoute;
+  "/_requireAuth/permissions": typeof RequireAuthPermissionsRouteWithChildren;
+  "/community/create": typeof CommunityCreateRoute;
+  "/login/habitat": typeof LoginHabitatRoute;
+  "/org/create": typeof OrgCreateRoute;
+  "/org/join": typeof OrgJoinRoute;
+  "/_requireAuth/": typeof RequireAuthIndexRoute;
+  "/_requireAuth/collections/$collection": typeof RequireAuthCollectionsCollectionRoute;
+  "/_requireAuth/groups/$group": typeof RequireAuthGroupsGroupRoute;
+  "/_requireAuth/pear-test/view": typeof RequireAuthPearTestViewRoute;
+  "/_requireAuth/permissions/lexicons": typeof RequireAuthPermissionsLexiconsRouteWithChildren;
+  "/_requireAuth/permissions/people": typeof RequireAuthPermissionsPeopleRouteWithChildren;
+  "/_requireAuth/spaces/$space": typeof RequireAuthSpacesSpaceRoute;
+  "/_requireAuth/blob-test/": typeof RequireAuthBlobTestIndexRoute;
+  "/_requireAuth/collections/": typeof RequireAuthCollectionsIndexRoute;
+  "/_requireAuth/groups/": typeof RequireAuthGroupsIndexRoute;
+  "/_requireAuth/org/": typeof RequireAuthOrgIndexRoute;
+  "/_requireAuth/pear-test/": typeof RequireAuthPearTestIndexRoute;
+  "/_requireAuth/permissions/": typeof RequireAuthPermissionsIndexRoute;
+  "/_requireAuth/spaces/": typeof RequireAuthSpacesIndexRoute;
+  "/_requireAuth/permissions/lexicons/$collection": typeof RequireAuthPermissionsLexiconsCollectionRoute;
+  "/_requireAuth/permissions/people/$did": typeof RequireAuthPermissionsPeopleDidRoute;
+  "/_requireAuth/permissions/lexicons/": typeof RequireAuthPermissionsLexiconsIndexRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
-    | '/'
-    | '/devtools'
-    | '/explore'
-    | '/login'
-    | '/oauth-login'
-    | '/onboard'
-    | '/data'
-    | '/permissions'
-    | '/community/create'
-    | '/login/habitat'
-    | '/org/create'
-    | '/org/join'
-    | '/collections/$collection'
-    | '/groups/$group'
-    | '/pear-test/view'
-    | '/permissions/lexicons'
-    | '/permissions/people'
-    | '/spaces/$space'
-    | '/blob-test/'
-    | '/collections/'
-    | '/groups/'
-    | '/org/'
-    | '/pear-test/'
-    | '/permissions/'
-    | '/spaces/'
-    | '/permissions/lexicons/$collection'
-    | '/permissions/people/$did'
-    | '/permissions/lexicons/'
-  fileRoutesByTo: FileRoutesByTo
+    | "/"
+    | "/devtools"
+    | "/explore"
+    | "/login"
+    | "/oauth-login"
+    | "/onboard"
+    | "/data"
+    | "/permissions"
+    | "/community/create"
+    | "/login/habitat"
+    | "/org/create"
+    | "/org/join"
+    | "/collections/$collection"
+    | "/groups/$group"
+    | "/pear-test/view"
+    | "/permissions/lexicons"
+    | "/permissions/people"
+    | "/spaces/$space"
+    | "/blob-test/"
+    | "/collections/"
+    | "/groups/"
+    | "/org/"
+    | "/pear-test/"
+    | "/permissions/"
+    | "/spaces/"
+    | "/permissions/lexicons/$collection"
+    | "/permissions/people/$did"
+    | "/permissions/lexicons/";
+  fileRoutesByTo: FileRoutesByTo;
   to:
-    | '/devtools'
-    | '/explore'
-    | '/login'
-    | '/oauth-login'
-    | '/onboard'
-    | '/data'
-    | '/community/create'
-    | '/login/habitat'
-    | '/org/create'
-    | '/org/join'
-    | '/'
-    | '/collections/$collection'
-    | '/groups/$group'
-    | '/pear-test/view'
-    | '/permissions/people'
-    | '/spaces/$space'
-    | '/blob-test'
-    | '/collections'
-    | '/groups'
-    | '/org'
-    | '/pear-test'
-    | '/permissions'
-    | '/spaces'
-    | '/permissions/lexicons/$collection'
-    | '/permissions/people/$did'
-    | '/permissions/lexicons'
+    | "/devtools"
+    | "/explore"
+    | "/login"
+    | "/oauth-login"
+    | "/onboard"
+    | "/data"
+    | "/community/create"
+    | "/login/habitat"
+    | "/org/create"
+    | "/org/join"
+    | "/"
+    | "/collections/$collection"
+    | "/groups/$group"
+    | "/pear-test/view"
+    | "/permissions/people"
+    | "/spaces/$space"
+    | "/blob-test"
+    | "/collections"
+    | "/groups"
+    | "/org"
+    | "/pear-test"
+    | "/permissions"
+    | "/spaces"
+    | "/permissions/lexicons/$collection"
+    | "/permissions/people/$did"
+    | "/permissions/lexicons";
   id:
-    | '__root__'
-    | '/_requireAuth'
-    | '/devtools'
-    | '/explore'
-    | '/login'
-    | '/oauth-login'
-    | '/onboard'
-    | '/_requireAuth/data'
-    | '/_requireAuth/permissions'
-    | '/community/create'
-    | '/login/habitat'
-    | '/org/create'
-    | '/org/join'
-    | '/_requireAuth/'
-    | '/_requireAuth/collections/$collection'
-    | '/_requireAuth/groups/$group'
-    | '/_requireAuth/pear-test/view'
-    | '/_requireAuth/permissions/lexicons'
-    | '/_requireAuth/permissions/people'
-    | '/_requireAuth/spaces/$space'
-    | '/_requireAuth/blob-test/'
-    | '/_requireAuth/collections/'
-    | '/_requireAuth/groups/'
-    | '/_requireAuth/org/'
-    | '/_requireAuth/pear-test/'
-    | '/_requireAuth/permissions/'
-    | '/_requireAuth/spaces/'
-    | '/_requireAuth/permissions/lexicons/$collection'
-    | '/_requireAuth/permissions/people/$did'
-    | '/_requireAuth/permissions/lexicons/'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/_requireAuth"
+    | "/devtools"
+    | "/explore"
+    | "/login"
+    | "/oauth-login"
+    | "/onboard"
+    | "/_requireAuth/data"
+    | "/_requireAuth/permissions"
+    | "/community/create"
+    | "/login/habitat"
+    | "/org/create"
+    | "/org/join"
+    | "/_requireAuth/"
+    | "/_requireAuth/collections/$collection"
+    | "/_requireAuth/groups/$group"
+    | "/_requireAuth/pear-test/view"
+    | "/_requireAuth/permissions/lexicons"
+    | "/_requireAuth/permissions/people"
+    | "/_requireAuth/spaces/$space"
+    | "/_requireAuth/blob-test/"
+    | "/_requireAuth/collections/"
+    | "/_requireAuth/groups/"
+    | "/_requireAuth/org/"
+    | "/_requireAuth/pear-test/"
+    | "/_requireAuth/permissions/"
+    | "/_requireAuth/spaces/"
+    | "/_requireAuth/permissions/lexicons/$collection"
+    | "/_requireAuth/permissions/people/$did"
+    | "/_requireAuth/permissions/lexicons/";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  RequireAuthRoute: typeof RequireAuthRouteWithChildren
-  DevtoolsRoute: typeof DevtoolsRoute
-  ExploreRoute: typeof ExploreRoute
-  LoginRoute: typeof LoginRouteWithChildren
-  OauthLoginRoute: typeof OauthLoginRoute
-  OnboardRoute: typeof OnboardRoute
-  CommunityCreateRoute: typeof CommunityCreateRoute
-  OrgCreateRoute: typeof OrgCreateRoute
-  OrgJoinRoute: typeof OrgJoinRoute
+  RequireAuthRoute: typeof RequireAuthRouteWithChildren;
+  DevtoolsRoute: typeof DevtoolsRoute;
+  ExploreRoute: typeof ExploreRoute;
+  LoginRoute: typeof LoginRouteWithChildren;
+  OauthLoginRoute: typeof OauthLoginRoute;
+  OnboardRoute: typeof OnboardRoute;
+  CommunityCreateRoute: typeof CommunityCreateRoute;
+  OrgCreateRoute: typeof OrgCreateRoute;
+  OrgJoinRoute: typeof OrgJoinRoute;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/_requireAuth': {
-      id: '/_requireAuth'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof RequireAuthRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/devtools': {
-      id: '/devtools'
-      path: '/devtools'
-      fullPath: '/devtools'
-      preLoaderRoute: typeof DevtoolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/explore': {
-      id: '/explore'
-      path: '/explore'
-      fullPath: '/explore'
-      preLoaderRoute: typeof ExploreRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/oauth-login': {
-      id: '/oauth-login'
-      path: '/oauth-login'
-      fullPath: '/oauth-login'
-      preLoaderRoute: typeof OauthLoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/onboard': {
-      id: '/onboard'
-      path: '/onboard'
-      fullPath: '/onboard'
-      preLoaderRoute: typeof OnboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_requireAuth/': {
-      id: '/_requireAuth/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof RequireAuthIndexRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/data': {
-      id: '/_requireAuth/data'
-      path: '/data'
-      fullPath: '/data'
-      preLoaderRoute: typeof RequireAuthDataRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/permissions': {
-      id: '/_requireAuth/permissions'
-      path: '/permissions'
-      fullPath: '/permissions'
-      preLoaderRoute: typeof RequireAuthPermissionsRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/community/create': {
-      id: '/community/create'
-      path: '/community/create'
-      fullPath: '/community/create'
-      preLoaderRoute: typeof CommunityCreateRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login/habitat': {
-      id: '/login/habitat'
-      path: '/habitat'
-      fullPath: '/login/habitat'
-      preLoaderRoute: typeof LoginHabitatRouteImport
-      parentRoute: typeof LoginRoute
-    }
-    '/org/create': {
-      id: '/org/create'
-      path: '/org/create'
-      fullPath: '/org/create'
-      preLoaderRoute: typeof OrgCreateRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/org/join': {
-      id: '/org/join'
-      path: '/org/join'
-      fullPath: '/org/join'
-      preLoaderRoute: typeof OrgJoinRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_requireAuth/blob-test/': {
-      id: '/_requireAuth/blob-test/'
-      path: '/blob-test'
-      fullPath: '/blob-test/'
-      preLoaderRoute: typeof RequireAuthBlobTestIndexRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/collections/': {
-      id: '/_requireAuth/collections/'
-      path: '/collections'
-      fullPath: '/collections/'
-      preLoaderRoute: typeof RequireAuthCollectionsIndexRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/collections/$collection': {
-      id: '/_requireAuth/collections/$collection'
-      path: '/collections/$collection'
-      fullPath: '/collections/$collection'
-      preLoaderRoute: typeof RequireAuthCollectionsCollectionRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/groups/': {
-      id: '/_requireAuth/groups/'
-      path: '/groups'
-      fullPath: '/groups/'
-      preLoaderRoute: typeof RequireAuthGroupsIndexRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/groups/$group': {
-      id: '/_requireAuth/groups/$group'
-      path: '/groups/$group'
-      fullPath: '/groups/$group'
-      preLoaderRoute: typeof RequireAuthGroupsGroupRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/org/': {
-      id: '/_requireAuth/org/'
-      path: '/org'
-      fullPath: '/org/'
-      preLoaderRoute: typeof RequireAuthOrgIndexRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/pear-test/': {
-      id: '/_requireAuth/pear-test/'
-      path: '/pear-test'
-      fullPath: '/pear-test/'
-      preLoaderRoute: typeof RequireAuthPearTestIndexRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/pear-test/view': {
-      id: '/_requireAuth/pear-test/view'
-      path: '/pear-test/view'
-      fullPath: '/pear-test/view'
-      preLoaderRoute: typeof RequireAuthPearTestViewRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/permissions/': {
-      id: '/_requireAuth/permissions/'
-      path: '/'
-      fullPath: '/permissions/'
-      preLoaderRoute: typeof RequireAuthPermissionsIndexRouteImport
-      parentRoute: typeof RequireAuthPermissionsRoute
-    }
-    '/_requireAuth/permissions/lexicons': {
-      id: '/_requireAuth/permissions/lexicons'
-      path: '/lexicons'
-      fullPath: '/permissions/lexicons'
-      preLoaderRoute: typeof RequireAuthPermissionsLexiconsRouteImport
-      parentRoute: typeof RequireAuthPermissionsRoute
-    }
-    '/_requireAuth/permissions/people': {
-      id: '/_requireAuth/permissions/people'
-      path: '/people'
-      fullPath: '/permissions/people'
-      preLoaderRoute: typeof RequireAuthPermissionsPeopleRouteImport
-      parentRoute: typeof RequireAuthPermissionsRoute
-    }
-    '/_requireAuth/spaces/': {
-      id: '/_requireAuth/spaces/'
-      path: '/spaces'
-      fullPath: '/spaces/'
-      preLoaderRoute: typeof RequireAuthSpacesIndexRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/spaces/$space': {
-      id: '/_requireAuth/spaces/$space'
-      path: '/spaces/$space'
-      fullPath: '/spaces/$space'
-      preLoaderRoute: typeof RequireAuthSpacesSpaceRouteImport
-      parentRoute: typeof RequireAuthRoute
-    }
-    '/_requireAuth/permissions/lexicons/': {
-      id: '/_requireAuth/permissions/lexicons/'
-      path: '/'
-      fullPath: '/permissions/lexicons/'
-      preLoaderRoute: typeof RequireAuthPermissionsLexiconsIndexRouteImport
-      parentRoute: typeof RequireAuthPermissionsLexiconsRoute
-    }
-    '/_requireAuth/permissions/lexicons/$collection': {
-      id: '/_requireAuth/permissions/lexicons/$collection'
-      path: '/$collection'
-      fullPath: '/permissions/lexicons/$collection'
-      preLoaderRoute: typeof RequireAuthPermissionsLexiconsCollectionRouteImport
-      parentRoute: typeof RequireAuthPermissionsLexiconsRoute
-    }
-    '/_requireAuth/permissions/people/$did': {
-      id: '/_requireAuth/permissions/people/$did'
-      path: '/$did'
-      fullPath: '/permissions/people/$did'
-      preLoaderRoute: typeof RequireAuthPermissionsPeopleDidRouteImport
-      parentRoute: typeof RequireAuthPermissionsPeopleRoute
-    }
+    "/_requireAuth": {
+      id: "/_requireAuth";
+      path: "";
+      fullPath: "/";
+      preLoaderRoute: typeof RequireAuthRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/devtools": {
+      id: "/devtools";
+      path: "/devtools";
+      fullPath: "/devtools";
+      preLoaderRoute: typeof DevtoolsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/explore": {
+      id: "/explore";
+      path: "/explore";
+      fullPath: "/explore";
+      preLoaderRoute: typeof ExploreRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/login": {
+      id: "/login";
+      path: "/login";
+      fullPath: "/login";
+      preLoaderRoute: typeof LoginRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/oauth-login": {
+      id: "/oauth-login";
+      path: "/oauth-login";
+      fullPath: "/oauth-login";
+      preLoaderRoute: typeof OauthLoginRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/onboard": {
+      id: "/onboard";
+      path: "/onboard";
+      fullPath: "/onboard";
+      preLoaderRoute: typeof OnboardRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/_requireAuth/": {
+      id: "/_requireAuth/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof RequireAuthIndexRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/data": {
+      id: "/_requireAuth/data";
+      path: "/data";
+      fullPath: "/data";
+      preLoaderRoute: typeof RequireAuthDataRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/permissions": {
+      id: "/_requireAuth/permissions";
+      path: "/permissions";
+      fullPath: "/permissions";
+      preLoaderRoute: typeof RequireAuthPermissionsRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/community/create": {
+      id: "/community/create";
+      path: "/community/create";
+      fullPath: "/community/create";
+      preLoaderRoute: typeof CommunityCreateRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/login/habitat": {
+      id: "/login/habitat";
+      path: "/habitat";
+      fullPath: "/login/habitat";
+      preLoaderRoute: typeof LoginHabitatRouteImport;
+      parentRoute: typeof LoginRoute;
+    };
+    "/org/create": {
+      id: "/org/create";
+      path: "/org/create";
+      fullPath: "/org/create";
+      preLoaderRoute: typeof OrgCreateRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/org/join": {
+      id: "/org/join";
+      path: "/org/join";
+      fullPath: "/org/join";
+      preLoaderRoute: typeof OrgJoinRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/_requireAuth/blob-test/": {
+      id: "/_requireAuth/blob-test/";
+      path: "/blob-test";
+      fullPath: "/blob-test/";
+      preLoaderRoute: typeof RequireAuthBlobTestIndexRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/collections/": {
+      id: "/_requireAuth/collections/";
+      path: "/collections";
+      fullPath: "/collections/";
+      preLoaderRoute: typeof RequireAuthCollectionsIndexRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/collections/$collection": {
+      id: "/_requireAuth/collections/$collection";
+      path: "/collections/$collection";
+      fullPath: "/collections/$collection";
+      preLoaderRoute: typeof RequireAuthCollectionsCollectionRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/groups/": {
+      id: "/_requireAuth/groups/";
+      path: "/groups";
+      fullPath: "/groups/";
+      preLoaderRoute: typeof RequireAuthGroupsIndexRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/groups/$group": {
+      id: "/_requireAuth/groups/$group";
+      path: "/groups/$group";
+      fullPath: "/groups/$group";
+      preLoaderRoute: typeof RequireAuthGroupsGroupRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/org/": {
+      id: "/_requireAuth/org/";
+      path: "/org";
+      fullPath: "/org/";
+      preLoaderRoute: typeof RequireAuthOrgIndexRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/pear-test/": {
+      id: "/_requireAuth/pear-test/";
+      path: "/pear-test";
+      fullPath: "/pear-test/";
+      preLoaderRoute: typeof RequireAuthPearTestIndexRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/pear-test/view": {
+      id: "/_requireAuth/pear-test/view";
+      path: "/pear-test/view";
+      fullPath: "/pear-test/view";
+      preLoaderRoute: typeof RequireAuthPearTestViewRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/permissions/": {
+      id: "/_requireAuth/permissions/";
+      path: "/";
+      fullPath: "/permissions/";
+      preLoaderRoute: typeof RequireAuthPermissionsIndexRouteImport;
+      parentRoute: typeof RequireAuthPermissionsRoute;
+    };
+    "/_requireAuth/permissions/lexicons": {
+      id: "/_requireAuth/permissions/lexicons";
+      path: "/lexicons";
+      fullPath: "/permissions/lexicons";
+      preLoaderRoute: typeof RequireAuthPermissionsLexiconsRouteImport;
+      parentRoute: typeof RequireAuthPermissionsRoute;
+    };
+    "/_requireAuth/permissions/people": {
+      id: "/_requireAuth/permissions/people";
+      path: "/people";
+      fullPath: "/permissions/people";
+      preLoaderRoute: typeof RequireAuthPermissionsPeopleRouteImport;
+      parentRoute: typeof RequireAuthPermissionsRoute;
+    };
+    "/_requireAuth/spaces/": {
+      id: "/_requireAuth/spaces/";
+      path: "/spaces";
+      fullPath: "/spaces/";
+      preLoaderRoute: typeof RequireAuthSpacesIndexRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/spaces/$space": {
+      id: "/_requireAuth/spaces/$space";
+      path: "/spaces/$space";
+      fullPath: "/spaces/$space";
+      preLoaderRoute: typeof RequireAuthSpacesSpaceRouteImport;
+      parentRoute: typeof RequireAuthRoute;
+    };
+    "/_requireAuth/permissions/lexicons/": {
+      id: "/_requireAuth/permissions/lexicons/";
+      path: "/";
+      fullPath: "/permissions/lexicons/";
+      preLoaderRoute: typeof RequireAuthPermissionsLexiconsIndexRouteImport;
+      parentRoute: typeof RequireAuthPermissionsLexiconsRoute;
+    };
+    "/_requireAuth/permissions/lexicons/$collection": {
+      id: "/_requireAuth/permissions/lexicons/$collection";
+      path: "/$collection";
+      fullPath: "/permissions/lexicons/$collection";
+      preLoaderRoute: typeof RequireAuthPermissionsLexiconsCollectionRouteImport;
+      parentRoute: typeof RequireAuthPermissionsLexiconsRoute;
+    };
+    "/_requireAuth/permissions/people/$did": {
+      id: "/_requireAuth/permissions/people/$did";
+      path: "/$did";
+      fullPath: "/permissions/people/$did";
+      preLoaderRoute: typeof RequireAuthPermissionsPeopleDidRouteImport;
+      parentRoute: typeof RequireAuthPermissionsPeopleRoute;
+    };
   }
 }
 
 interface RequireAuthPermissionsLexiconsRouteChildren {
-  RequireAuthPermissionsLexiconsCollectionRoute: typeof RequireAuthPermissionsLexiconsCollectionRoute
-  RequireAuthPermissionsLexiconsIndexRoute: typeof RequireAuthPermissionsLexiconsIndexRoute
+  RequireAuthPermissionsLexiconsCollectionRoute: typeof RequireAuthPermissionsLexiconsCollectionRoute;
+  RequireAuthPermissionsLexiconsIndexRoute: typeof RequireAuthPermissionsLexiconsIndexRoute;
 }
 
 const RequireAuthPermissionsLexiconsRouteChildren: RequireAuthPermissionsLexiconsRouteChildren =
@@ -607,31 +607,31 @@ const RequireAuthPermissionsLexiconsRouteChildren: RequireAuthPermissionsLexicon
       RequireAuthPermissionsLexiconsCollectionRoute,
     RequireAuthPermissionsLexiconsIndexRoute:
       RequireAuthPermissionsLexiconsIndexRoute,
-  }
+  };
 
 const RequireAuthPermissionsLexiconsRouteWithChildren =
   RequireAuthPermissionsLexiconsRoute._addFileChildren(
     RequireAuthPermissionsLexiconsRouteChildren,
-  )
+  );
 
 interface RequireAuthPermissionsPeopleRouteChildren {
-  RequireAuthPermissionsPeopleDidRoute: typeof RequireAuthPermissionsPeopleDidRoute
+  RequireAuthPermissionsPeopleDidRoute: typeof RequireAuthPermissionsPeopleDidRoute;
 }
 
 const RequireAuthPermissionsPeopleRouteChildren: RequireAuthPermissionsPeopleRouteChildren =
   {
     RequireAuthPermissionsPeopleDidRoute: RequireAuthPermissionsPeopleDidRoute,
-  }
+  };
 
 const RequireAuthPermissionsPeopleRouteWithChildren =
   RequireAuthPermissionsPeopleRoute._addFileChildren(
     RequireAuthPermissionsPeopleRouteChildren,
-  )
+  );
 
 interface RequireAuthPermissionsRouteChildren {
-  RequireAuthPermissionsLexiconsRoute: typeof RequireAuthPermissionsLexiconsRouteWithChildren
-  RequireAuthPermissionsPeopleRoute: typeof RequireAuthPermissionsPeopleRouteWithChildren
-  RequireAuthPermissionsIndexRoute: typeof RequireAuthPermissionsIndexRoute
+  RequireAuthPermissionsLexiconsRoute: typeof RequireAuthPermissionsLexiconsRouteWithChildren;
+  RequireAuthPermissionsPeopleRoute: typeof RequireAuthPermissionsPeopleRouteWithChildren;
+  RequireAuthPermissionsIndexRoute: typeof RequireAuthPermissionsIndexRoute;
 }
 
 const RequireAuthPermissionsRouteChildren: RequireAuthPermissionsRouteChildren =
@@ -641,27 +641,27 @@ const RequireAuthPermissionsRouteChildren: RequireAuthPermissionsRouteChildren =
     RequireAuthPermissionsPeopleRoute:
       RequireAuthPermissionsPeopleRouteWithChildren,
     RequireAuthPermissionsIndexRoute: RequireAuthPermissionsIndexRoute,
-  }
+  };
 
 const RequireAuthPermissionsRouteWithChildren =
   RequireAuthPermissionsRoute._addFileChildren(
     RequireAuthPermissionsRouteChildren,
-  )
+  );
 
 interface RequireAuthRouteChildren {
-  RequireAuthDataRoute: typeof RequireAuthDataRoute
-  RequireAuthPermissionsRoute: typeof RequireAuthPermissionsRouteWithChildren
-  RequireAuthIndexRoute: typeof RequireAuthIndexRoute
-  RequireAuthCollectionsCollectionRoute: typeof RequireAuthCollectionsCollectionRoute
-  RequireAuthGroupsGroupRoute: typeof RequireAuthGroupsGroupRoute
-  RequireAuthPearTestViewRoute: typeof RequireAuthPearTestViewRoute
-  RequireAuthSpacesSpaceRoute: typeof RequireAuthSpacesSpaceRoute
-  RequireAuthBlobTestIndexRoute: typeof RequireAuthBlobTestIndexRoute
-  RequireAuthCollectionsIndexRoute: typeof RequireAuthCollectionsIndexRoute
-  RequireAuthGroupsIndexRoute: typeof RequireAuthGroupsIndexRoute
-  RequireAuthOrgIndexRoute: typeof RequireAuthOrgIndexRoute
-  RequireAuthPearTestIndexRoute: typeof RequireAuthPearTestIndexRoute
-  RequireAuthSpacesIndexRoute: typeof RequireAuthSpacesIndexRoute
+  RequireAuthDataRoute: typeof RequireAuthDataRoute;
+  RequireAuthPermissionsRoute: typeof RequireAuthPermissionsRouteWithChildren;
+  RequireAuthIndexRoute: typeof RequireAuthIndexRoute;
+  RequireAuthCollectionsCollectionRoute: typeof RequireAuthCollectionsCollectionRoute;
+  RequireAuthGroupsGroupRoute: typeof RequireAuthGroupsGroupRoute;
+  RequireAuthPearTestViewRoute: typeof RequireAuthPearTestViewRoute;
+  RequireAuthSpacesSpaceRoute: typeof RequireAuthSpacesSpaceRoute;
+  RequireAuthBlobTestIndexRoute: typeof RequireAuthBlobTestIndexRoute;
+  RequireAuthCollectionsIndexRoute: typeof RequireAuthCollectionsIndexRoute;
+  RequireAuthGroupsIndexRoute: typeof RequireAuthGroupsIndexRoute;
+  RequireAuthOrgIndexRoute: typeof RequireAuthOrgIndexRoute;
+  RequireAuthPearTestIndexRoute: typeof RequireAuthPearTestIndexRoute;
+  RequireAuthSpacesIndexRoute: typeof RequireAuthSpacesIndexRoute;
 }
 
 const RequireAuthRouteChildren: RequireAuthRouteChildren = {
@@ -678,21 +678,21 @@ const RequireAuthRouteChildren: RequireAuthRouteChildren = {
   RequireAuthOrgIndexRoute: RequireAuthOrgIndexRoute,
   RequireAuthPearTestIndexRoute: RequireAuthPearTestIndexRoute,
   RequireAuthSpacesIndexRoute: RequireAuthSpacesIndexRoute,
-}
+};
 
 const RequireAuthRouteWithChildren = RequireAuthRoute._addFileChildren(
   RequireAuthRouteChildren,
-)
+);
 
 interface LoginRouteChildren {
-  LoginHabitatRoute: typeof LoginHabitatRoute
+  LoginHabitatRoute: typeof LoginHabitatRoute;
 }
 
 const LoginRouteChildren: LoginRouteChildren = {
   LoginHabitatRoute: LoginHabitatRoute,
-}
+};
 
-const LoginRouteWithChildren = LoginRoute._addFileChildren(LoginRouteChildren)
+const LoginRouteWithChildren = LoginRoute._addFileChildren(LoginRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
   RequireAuthRoute: RequireAuthRouteWithChildren,
@@ -704,7 +704,7 @@ const rootRouteChildren: RootRouteChildren = {
   CommunityCreateRoute: CommunityCreateRoute,
   OrgCreateRoute: OrgCreateRoute,
   OrgJoinRoute: OrgJoinRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();

--- a/frontend/src/routes/_requireAuth/org/index.tsx
+++ b/frontend/src/routes/_requireAuth/org/index.tsx
@@ -88,8 +88,15 @@ function InviteSection({
           orgId: orgId,
         },
       }).publicHref;
-      const hash = import.meta.env.VITE_HASH_ROUTING ? "/#" : "";
-      setInviteUrl(`${window.location.origin}${hash}${location}`);
+      if (import.meta.env.VITE_HASH_ROUTING) {
+        const basePath = new URL(import.meta.env.VITE_BASE_URL).pathname.replace(
+          /\/$/,
+          "",
+        );
+        setInviteUrl(`${window.location.origin}${basePath}/#${location}`);
+      } else {
+        setInviteUrl(`${window.location.origin}${location}`);
+      }
     },
   });
 

--- a/frontend/src/routes/_requireAuth/org/index.tsx
+++ b/frontend/src/routes/_requireAuth/org/index.tsx
@@ -89,10 +89,9 @@ function InviteSection({
         },
       }).publicHref;
       if (import.meta.env.VITE_HASH_ROUTING) {
-        const basePath = new URL(import.meta.env.VITE_BASE_URL).pathname.replace(
-          /\/$/,
-          "",
-        );
+        const basePath = new URL(
+          import.meta.env.VITE_BASE_URL,
+        ).pathname.replace(/\/$/, "");
         setInviteUrl(`${window.location.origin}${basePath}/#${location}`);
       } else {
         setInviteUrl(`${window.location.origin}${location}`);

--- a/go.work.sum
+++ b/go.work.sum
@@ -593,6 +593,7 @@ github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AV
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
 github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc h1:lzi/5fg2EfinRlh3v//YyIhnc4tY7BTqazQGwb1ar+0=
 github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
 github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb h1:Ywfo8sUltxogBpFuMOFRrrSifO788kAFxmvVw31PtQQ=
@@ -663,6 +664,7 @@ go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0
 go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.45.0/go.mod h1:Px9kH7SJ+NhsgWRtD/eMcs15Tyt4uL3rM7X54qv6pfA=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 h1:0Qx7VGBacMm9ZENQ7TnNObTYI4ShC+lHI16seduaxZo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0/go.mod h1:Sje3i3MjSPKTSPvVWCaL8ugBzJwik3u4smCjUeuupqg=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0/go.mod h1:D7J12YRapIekYyPWgGPlA/23pRmpSEZC5xJC/TTLI9U=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0/go.mod h1:69uWxva0WgAA/4bu2Yy70SLDBwZXuQ6PbBpbsa5iZrQ=
 go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=

--- a/internal/org/models.go
+++ b/internal/org/models.go
@@ -14,7 +14,7 @@ type organization struct {
 	SigningSecret   string      // base64-encoded HMAC-SHA256 key for invite tokens
 	CreatedAt       time.Time
 	HandleSubdomain string `gorm:"unique"`
-	ContactEmail    string `gorm:"unique"` // email for reaching out to the org about its account
+	ContactEmail    string // email for reaching out to the org about its account
 }
 
 // Keep track of members in the org.


### PR DESCRIPTION
Three fixes from this morning:
- generate invite link does not have `/habitat` in prod
- drop google_credential_models table because it got out of sync with the gorm model and there was only one row from sashank (since no one can insert because it's broken)
- remove the uniqueness constraint (in prod DB and gorm model) on contact email for org create flow