### PR TITLE
Support localhost client ids in the OAuth server

### DIFF
--- a/internal/oauthserver/fosite_storage.go
+++ b/internal/oauthserver/fosite_storage.go
@@ -228,10 +228,21 @@ func (s *store) GetClient(ctx context.Context, id string) (fosite.Client, error)
 // fetchClientMetadata fetches and decodes the client metadata document
 // published at id (the client's client_id URL). See
 // https://atproto.com/specs/oauth#client-id-metadata-document.
+//
+// Localhost client_ids are the exception: nothing is fetched, the metadata is
+// derived from the client_id itself.
 func (s *store) fetchClientMetadata(
 	ctx context.Context,
 	id string,
 ) (*pdsclient.ClientMetadata, error) {
+	parsed, err := url.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse client id: %w", err)
+	}
+	if isLocalhostClientId(parsed) {
+		return localhostClientMetadata(id, parsed)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, id, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)

--- a/internal/oauthserver/localhost.go
+++ b/internal/oauthserver/localhost.go
@@ -1,0 +1,107 @@
+package oauthserver
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/habitat-network/habitat/internal/pdsclient"
+)
+
+// Localhost development clients don't publish a metadata document; the
+// document is synthesized from the client_id URL instead. See
+// https://atproto.com/specs/oauth#localhost-client-development.
+var (
+	// defaultLocalhostRedirectUris are used when the client_id carries no
+	// redirect_uri query parameter.
+	defaultLocalhostRedirectUris = []string{"http://127.0.0.1/", "http://[::1]/"}
+	defaultLocalhostScope        = "atproto"
+	localhostClientName          = "Development client"
+)
+
+// isLocalhostClientId reports whether a client_id URL is a localhost
+// development client_id, i.e. one whose metadata is synthesized rather than
+// fetched. The hostname must be exactly `localhost`; loopback IP literals are
+// not localhost client_ids.
+func isLocalhostClientId(u *url.URL) bool {
+	return u.Scheme == "http" && u.Hostname() == "localhost"
+}
+
+// localhostClientMetadata builds the virtual client metadata document for a
+// localhost development client_id. The client_id origin must be exactly
+// `http://localhost` with no port and an empty path; redirect_uri (repeatable)
+// and scope (single) may be supplied as query parameters. Such a client is
+// always public: it authenticates with no secret.
+//
+// See https://atproto.com/specs/oauth#localhost-client-development.
+func localhostClientMetadata(id string, u *url.URL) (*pdsclient.ClientMetadata, error) {
+	if u.Port() != "" {
+		return nil, fmt.Errorf("localhost client id must not specify a port")
+	}
+	if u.Path != "" && u.Path != "/" {
+		return nil, fmt.Errorf("localhost client id must have an empty path")
+	}
+	if u.User != nil {
+		return nil, fmt.Errorf("localhost client id must not contain userinfo")
+	}
+	if u.Fragment != "" {
+		return nil, fmt.Errorf("localhost client id must not contain a fragment")
+	}
+
+	query, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse localhost client id query: %w", err)
+	}
+	for param := range query {
+		if param != "redirect_uri" && param != "scope" {
+			return nil, fmt.Errorf("unsupported localhost client id parameter %q", param)
+		}
+	}
+
+	scope := defaultLocalhostScope
+	if scopes := query["scope"]; len(scopes) > 1 {
+		return nil, fmt.Errorf("localhost client id must have at most one scope parameter")
+	} else if len(scopes) == 1 {
+		scope = scopes[0]
+	}
+
+	redirectUris := query["redirect_uri"]
+	if len(redirectUris) == 0 {
+		redirectUris = defaultLocalhostRedirectUris
+	}
+	for _, redirectUri := range redirectUris {
+		if err := validateLoopbackRedirectUri(redirectUri); err != nil {
+			return nil, err
+		}
+	}
+
+	return &pdsclient.ClientMetadata{
+		ClientId:                id,
+		ClientName:              localhostClientName,
+		ApplicationType:         "native",
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		RedirectUris:            redirectUris,
+		Scope:                   scope,
+		TokenEndpointAuthMethod: "none",
+		DpopBoundAccessTokens:   true,
+	}, nil
+}
+
+// validateLoopbackRedirectUri checks that a localhost client's declared
+// redirect URI points at the loopback interface by IP literal. The port is
+// deliberately unconstrained: the client is matched against these URIs ignoring
+// the port (see fosite's RFC 8252 §7.3 loopback matching), so a dev server on
+// any port works.
+func validateLoopbackRedirectUri(redirectUri string) error {
+	u, err := url.Parse(redirectUri)
+	if err != nil {
+		return fmt.Errorf("failed to parse localhost client redirect uri: %w", err)
+	}
+	if u.Scheme != "http" {
+		return fmt.Errorf("localhost client redirect uri must use the http scheme")
+	}
+	if u.Hostname() != "127.0.0.1" && u.Hostname() != "::1" {
+		return fmt.Errorf("localhost client redirect uri must use a loopback IP address")
+	}
+	return nil
+}

--- a/internal/oauthserver/oauth_server_test.go
+++ b/internal/oauthserver/oauth_server_test.go
@@ -968,7 +968,38 @@ func TestValidateWithScopeChecking(t *testing.T) {
 // oauth.ClientApp. Unlike the existing TestOAuthServerE2E which uses Go's
 // standard x/oauth2 library, this test drives the flow with indigo's DPoP-bound
 // SendInitialTokenRequest, ResumeSession, and ClientSession.DoWithAuth.
+//
+// The flow is run for both kinds of public client: one whose metadata is
+// fetched from a published client metadata document, and a localhost
+// development client whose metadata the server synthesizes from the client_id
+// itself (see localhost.go).
 func TestIndigoClientApp(t *testing.T) {
+	t.Run("client metadata document", func(t *testing.T) {
+		runIndigoClientAppFlow(t, func(clientAppURL string) oauth.ClientConfig {
+			return oauth.NewPublicConfig(
+				clientAppURL+"/client-metadata.json",
+				clientAppURL+"/oauth-callback",
+				[]string{"atproto"},
+			)
+		})
+	})
+
+	// The client app is served on a loopback address, so its callback URL is a
+	// valid localhost-client redirect_uri.
+	t.Run("localhost client id", func(t *testing.T) {
+		runIndigoClientAppFlow(t, func(clientAppURL string) oauth.ClientConfig {
+			return oauth.NewLocalhostConfig(
+				clientAppURL+"/oauth-callback",
+				[]string{"atproto"},
+			)
+		})
+	})
+}
+
+// runIndigoClientAppFlow drives one full indigo ClientApp authorization code
+// flow. config builds the client configuration from the URL the client app's
+// test server ends up listening on.
+func runIndigoClientAppFlow(t *testing.T, config func(clientAppURL string) oauth.ClientConfig) {
 	// The disambiguation page returns a handle, which the OAuth server resolves
 	// (via hive) to the member's hive-served DID; the org store then routes that
 	// DID's login to the atproto (passthrough) provider. The passthrough stands
@@ -1066,11 +1097,7 @@ func TestIndigoClientApp(t *testing.T) {
 	// TLS certificate and override the identity directory with our dummy so
 	// that ProcessCallback (not called here but kept for consistency) can
 	// resolve DIDs.
-	indigoApp := oauth.NewClientApp(new(oauth.NewPublicConfig(
-		clientApp.URL+"/client-metadata.json",
-		clientApp.URL+"/oauth-callback",
-		[]string{"atproto"},
-	)), oauth.NewMemStore())
+	indigoApp := oauth.NewClientApp(new(config(clientApp.URL)), oauth.NewMemStore())
 
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)

--- a/internal/oauthserver/storage_test.go
+++ b/internal/oauthserver/storage_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/habitat-network/habitat/internal/db/testutil"
+	"github.com/ory/fosite"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,4 +36,78 @@ func TestGetClient(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, clientId, client.GetID())
+}
+
+func TestGetClientLocalhost(t *testing.T) {
+	store, err := newStore(testutil.NewDB(t), nil)
+	require.NoError(t, err)
+
+	t.Run("defaults", func(t *testing.T) {
+		client, err := store.GetClient(context.Background(), "http://localhost")
+		require.NoError(t, err)
+
+		require.Equal(t, "http://localhost", client.GetID())
+		require.True(t, client.IsPublic())
+		require.Equal(t, []string{"http://127.0.0.1/", "http://[::1]/"}, client.GetRedirectURIs())
+		require.Equal(t, fosite.Arguments{"atproto"}, client.GetScopes())
+		require.Equal(t, fosite.Arguments{"code"}, client.GetResponseTypes())
+		require.Equal(
+			t,
+			fosite.Arguments{"authorization_code", "refresh_token"},
+			client.GetGrantTypes(),
+		)
+	})
+
+	t.Run("query parameters", func(t *testing.T) {
+		clientId := "http://localhost/?" + url.Values{
+			"redirect_uri": {"http://127.0.0.1/callback", "http://[::1]/callback"},
+			"scope":        {"atproto transition:generic"},
+		}.Encode()
+
+		client, err := store.GetClient(context.Background(), clientId)
+		require.NoError(t, err)
+
+		require.Equal(t, clientId, client.GetID())
+		require.Equal(
+			t,
+			[]string{"http://127.0.0.1/callback", "http://[::1]/callback"},
+			client.GetRedirectURIs(),
+		)
+		require.Equal(t, fosite.Arguments{"atproto", "transition:generic"}, client.GetScopes())
+	})
+
+	t.Run("redirect uri port is not matched", func(t *testing.T) {
+		client, err := store.GetClient(
+			context.Background(),
+			"http://localhost/?redirect_uri="+url.QueryEscape("http://127.0.0.1/callback"),
+		)
+		require.NoError(t, err)
+
+		matched, err := fosite.MatchRedirectURIWithClientRedirectURIs(
+			"http://127.0.0.1:5173/callback",
+			client,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "http://127.0.0.1:5173/callback", matched.String())
+	})
+
+	// Ids that are not localhost client ids at all (https scheme, or a
+	// loopback IP rather than the localhost hostname) are not listed here:
+	// those fall through to a regular client metadata document fetch.
+	t.Run("rejected client ids", func(t *testing.T) {
+		for _, clientId := range []string{
+			"http://localhost:8080",                 // explicit port
+			"http://localhost/client-metadata.json", // non-empty path
+			"http://user@localhost",                 // userinfo
+			"http://localhost/?scope=a&scope=b",     // multiple scope params
+			"http://localhost/?foo=bar",             // unsupported parameter
+			"http://localhost/?redirect_uri=" + url.QueryEscape("https://example.com/cb"),
+			"http://localhost/?redirect_uri=" + url.QueryEscape("http://localhost/cb"),
+		} {
+			t.Run(clientId, func(t *testing.T) {
+				_, err := store.GetClient(context.Background(), clientId)
+				require.Error(t, err)
+			})
+		}
+	})
 }


### PR DESCRIPTION
Adds support for localhost development `client_id`s, per [the atproto OAuth spec](https://atproto.com/specs/oauth#localhost-client-development): when a `client_id` is `http://localhost` (no port, empty path), the server synthesizes a virtual client metadata document from the URL's `redirect_uri` and `scope` query parameters instead of fetching a published metadata document, defaulting to `http://127.0.0.1/` + `http://[::1]/` and `atproto` respectively.

The new logic lives in `internal/oauthserver/localhost.go`; `fetchClientMetadata` only dispatches to it. Declared redirect URIs must be `http` on a loopback IP literal, and port-insensitive matching comes free from fosite's RFC 8252 §7.3 loopback handling, so a dev server on any port works. Such clients are public, as the spec requires.

Tests cover the synthesized metadata, query-param overrides, port-insensitive redirect matching, and rejected `client_id` shapes; `TestIndigoClientApp` now runs its full authorization code flow for both a metadata-document client and a localhost client built with indigo's `oauth.NewLocalhostConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)