### PR TITLE
[Spaces] Restore perm check for putRecord

### DIFF
--- a/internal/spaces/server.go
+++ b/internal/spaces/server.go
@@ -471,6 +471,24 @@ func (s *Server) PutRecord(w http.ResponseWriter, r *http.Request) {
 		httpx.WriteInvalidRequest(ctx, w, "record must be a JSON object", nil)
 		return
 	}
+	authorized, err := s.authorize(
+		ctx,
+		credInfo.Org.DID(),
+		credInfo.Subject,
+		spaceURI,
+		fgastore.RelationSpaceWriter,
+	)
+	if err != nil {
+		httpx.WriteServerError(ctx, w, fmt.Errorf("authorize: %w", err))
+		return
+	}
+	if !authorized {
+		// TODO: we don't know if they're not authorize because they're not a member or
+		// because they don't have the right role. assume worst case and return not found
+		// need to return a reason from authorize
+		httpx.WriteSpaceNotFound(r.Context(), w, fmt.Errorf("not authorized to manage members"))
+		return
+	}
 	recordURI, cid, err := s.store.PutRecord(
 		ctx,
 		spaceURI,


### PR DESCRIPTION
Restore the permission check for putRecord. While technically anyone can put a record into their repo under any space, we're blocking non-permitted writes for now. This way, listRepos can just check for all repos that exist instead of filtering the ones that have permissions

<!-- branch-stack-start -->

<!-- branch-stack-end -->
