### PR TITLE
[DID] Build returns identity.Identity, handler takes it directly

### DIFF
--- a/cmd/didgen/main.go
+++ b/cmd/didgen/main.go
@@ -75,7 +75,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	doc := did.Web(didHost).
 		AtprotoKey(multibaseKey).
 		ATProtoPDS(pdsURL).
-		Build()
+		Build().DIDDocument()
 
 	// Marshal the DID document to JSON
 	didDocJSON, err := json.MarshalIndent(doc, "", "  ")

--- a/internal/did/builder.go
+++ b/internal/did/builder.go
@@ -50,61 +50,47 @@ func (b *Builder) AlsoKnownAs(uris ...string) *Builder {
 // AtprotoKey registers the atproto repo signing key as a Multikey verification
 // method at <did>#atproto.
 func (b *Builder) AtprotoKey(multibase string) *Builder {
-	return b.VerificationMethod(
-		fmt.Sprintf("%s#atproto", b.id),
-		"Multikey",
-		multibase,
-	)
+	return b.VerificationMethod("atproto", "Multikey", multibase)
 }
 
 func (b *Builder) ATProtoSpaceKey(multibase string) *Builder {
-	return b.VerificationMethod(
-		fmt.Sprintf("%s#atproto_space", b.id),
-		"Multikey",
-		multibase,
-	)
+	return b.VerificationMethod("atproto_space", "Multikey", multibase)
 }
 
 // Habitat adds the #habitat HabitatServer service.
 func (b *Builder) Habitat(endpoint string) *Builder {
-	return b.Service("#habitat", "HabitatServer", endpoint)
+	return b.Service("habitat", "HabitatServer", endpoint)
 }
 
 // ATProtoPDS adds the #atproto_pds AtprotoPersonalDataServer service.
 func (b *Builder) ATProtoPDS(endpoint string) *Builder {
-	return b.Service("#atproto_pds", "AtprotoPersonalDataServer", endpoint)
+	return b.Service("atproto_pds", "AtprotoPersonalDataServer", endpoint)
 }
 
 func (b *Builder) ATProtoSpaceHost(endpoint string) *Builder {
-	return b.Service("#atproto_space_host", "AtprotoSpaceHost", endpoint)
+	return b.Service("atproto_space_host", "AtprotoSpaceHost", endpoint)
 }
 
-// VerificationMethod adds a custom verification method keyed by the fragment of id.
-func (b *Builder) VerificationMethod(id, typ, multibase string) *Builder {
-	_, frag, ok := strings.Cut(id, "#")
-	if !ok {
-		return b
-	}
+// VerificationMethod adds a custom verification method under the given
+// fragment, without the leading '#'.
+func (b *Builder) VerificationMethod(fragment, typ, multibase string) *Builder {
 	if b.keys == nil {
 		b.keys = make(map[string]identity.VerificationMethod)
 	}
-	b.keys[frag] = identity.VerificationMethod{
+	b.keys[fragment] = identity.VerificationMethod{
 		Type:               typ,
 		PublicKeyMultibase: multibase,
 	}
 	return b
 }
 
-// Service adds a custom service keyed by the fragment of id.
-func (b *Builder) Service(id, typ, endpoint string) *Builder {
-	_, frag, ok := strings.Cut(id, "#")
-	if !ok {
-		return b
-	}
+// Service adds a custom service under the given fragment, without the
+// leading '#'.
+func (b *Builder) Service(fragment, typ, endpoint string) *Builder {
 	if b.services == nil {
 		b.services = make(map[string]identity.ServiceEndpoint)
 	}
-	b.services[frag] = identity.ServiceEndpoint{
+	b.services[fragment] = identity.ServiceEndpoint{
 		Type: typ,
 		URL:  endpoint,
 	}

--- a/internal/did/builder.go
+++ b/internal/did/builder.go
@@ -13,8 +13,8 @@ type Builder struct {
 	id       syntax.DID
 	handle   syntax.Handle
 	aka      []string
-	methods  []identity.DocVerificationMethod
-	services []identity.DocService
+	keys     map[string]identity.VerificationMethod
+	services map[string]identity.ServiceEndpoint
 }
 
 // New returns a builder for an arbitrary DID.
@@ -53,7 +53,6 @@ func (b *Builder) AtprotoKey(multibase string) *Builder {
 	return b.VerificationMethod(
 		fmt.Sprintf("%s#atproto", b.id),
 		"Multikey",
-		b.id.String(),
 		multibase,
 	)
 }
@@ -62,7 +61,6 @@ func (b *Builder) ATProtoSpaceKey(multibase string) *Builder {
 	return b.VerificationMethod(
 		fmt.Sprintf("%s#atproto_space", b.id),
 		"Multikey",
-		b.id.String(),
 		multibase,
 	)
 }
@@ -81,56 +79,45 @@ func (b *Builder) ATProtoSpaceHost(endpoint string) *Builder {
 	return b.Service("#atproto_space_host", "AtprotoSpaceHost", endpoint)
 }
 
-// VerificationMethod adds a custom verification method.
-func (b *Builder) VerificationMethod(id, typ, controller, multibase string) *Builder {
-	b.methods = append(b.methods, identity.DocVerificationMethod{
-		ID:                 id,
+// VerificationMethod adds a custom verification method keyed by the fragment of id.
+func (b *Builder) VerificationMethod(id, typ, multibase string) *Builder {
+	_, frag, ok := strings.Cut(id, "#")
+	if !ok {
+		return b
+	}
+	if b.keys == nil {
+		b.keys = make(map[string]identity.VerificationMethod)
+	}
+	b.keys[frag] = identity.VerificationMethod{
 		Type:               typ,
-		Controller:         controller,
 		PublicKeyMultibase: multibase,
-	})
+	}
 	return b
 }
 
-// Service adds a custom service.
+// Service adds a custom service keyed by the fragment of id.
 func (b *Builder) Service(id, typ, endpoint string) *Builder {
-	b.services = append(b.services, identity.DocService{
-		ID:              id,
-		Type:            typ,
-		ServiceEndpoint: endpoint,
-	})
+	_, frag, ok := strings.Cut(id, "#")
+	if !ok {
+		return b
+	}
+	if b.services == nil {
+		b.services = make(map[string]identity.ServiceEndpoint)
+	}
+	b.services[frag] = identity.ServiceEndpoint{
+		Type: typ,
+		URL:  endpoint,
+	}
 	return b
 }
 
 // Build assembles the identity.
 func (b *Builder) Build() *identity.Identity {
-	keys := make(map[string]identity.VerificationMethod, len(b.methods))
-	for _, m := range b.methods {
-		_, frag, ok := strings.Cut(m.ID, "#")
-		if !ok {
-			continue
-		}
-		keys[frag] = identity.VerificationMethod{
-			Type:               m.Type,
-			PublicKeyMultibase: m.PublicKeyMultibase,
-		}
-	}
-	services := make(map[string]identity.ServiceEndpoint, len(b.services))
-	for _, s := range b.services {
-		_, frag, ok := strings.Cut(s.ID, "#")
-		if !ok {
-			continue
-		}
-		services[frag] = identity.ServiceEndpoint{
-			Type: s.Type,
-			URL:  s.ServiceEndpoint,
-		}
-	}
 	return &identity.Identity{
 		DID:         b.id,
 		Handle:      b.handle,
 		AlsoKnownAs: b.aka,
-		Keys:        keys,
-		Services:    services,
+		Keys:        b.keys,
+		Services:    b.services,
 	}
 }

--- a/internal/did/builder.go
+++ b/internal/did/builder.go
@@ -11,6 +11,7 @@ import (
 // Builder accumulates verification methods and services for a DID document.
 type Builder struct {
 	id       syntax.DID
+	handle   syntax.Handle
 	aka      []string
 	methods  []identity.DocVerificationMethod
 	services []identity.DocService
@@ -32,6 +33,12 @@ func Web(host string) *Builder {
 		}
 	}
 	return New(syntax.DID(didStr))
+}
+
+// Handle sets the identity's handle.
+func (b *Builder) Handle(handle syntax.Handle) *Builder {
+	b.handle = handle
+	return b
 }
 
 // AlsoKnownAs appends alsoKnownAs URIs (e.g. "at://handle.example.com").
@@ -95,12 +102,35 @@ func (b *Builder) Service(id, typ, endpoint string) *Builder {
 	return b
 }
 
-// Build assembles the DID document.
-func (b *Builder) Build() identity.DIDDocument {
-	return identity.DIDDocument{
-		DID:                b.id,
-		AlsoKnownAs:        b.aka,
-		VerificationMethod: b.methods,
-		Service:            b.services,
+// Build assembles the identity.
+func (b *Builder) Build() *identity.Identity {
+	keys := make(map[string]identity.VerificationMethod, len(b.methods))
+	for _, m := range b.methods {
+		_, frag, ok := strings.Cut(m.ID, "#")
+		if !ok {
+			continue
+		}
+		keys[frag] = identity.VerificationMethod{
+			Type:               m.Type,
+			PublicKeyMultibase: m.PublicKeyMultibase,
+		}
+	}
+	services := make(map[string]identity.ServiceEndpoint, len(b.services))
+	for _, s := range b.services {
+		_, frag, ok := strings.Cut(s.ID, "#")
+		if !ok {
+			continue
+		}
+		services[frag] = identity.ServiceEndpoint{
+			Type: s.Type,
+			URL:  s.ServiceEndpoint,
+		}
+	}
+	return &identity.Identity{
+		DID:         b.id,
+		Handle:      b.handle,
+		AlsoKnownAs: b.aka,
+		Keys:        keys,
+		Services:    services,
 	}
 }

--- a/internal/did/builder.go
+++ b/internal/did/builder.go
@@ -35,10 +35,11 @@ func Web(host string) *Builder {
 	return New(syntax.DID(didStr))
 }
 
-// Handle sets the identity's handle.
+// Handle sets the identity's handle and adds the corresponding at:// URI to
+// alsoKnownAs.
 func (b *Builder) Handle(handle syntax.Handle) *Builder {
 	b.handle = handle
-	return b
+	return b.AlsoKnownAs("at://" + string(handle))
 }
 
 // AlsoKnownAs appends alsoKnownAs URIs (e.g. "at://handle.example.com").

--- a/internal/did/builder_test.go
+++ b/internal/did/builder_test.go
@@ -68,6 +68,7 @@ func TestBuilder_Handle(t *testing.T) {
 		Build()
 
 	require.Equal(t, syntax.Handle("alice.example.com"), ident.Handle)
+	require.Equal(t, []string{"at://alice.example.com"}, ident.AlsoKnownAs)
 }
 
 func TestBuilder_Web(t *testing.T) {

--- a/internal/did/builder_test.go
+++ b/internal/did/builder_test.go
@@ -43,7 +43,7 @@ func TestBuilder_Services(t *testing.T) {
 func TestBuilder_Custom(t *testing.T) {
 	ident := New(syntax.DID("did:web:alice.example.com")).
 		AlsoKnownAs("at://alice.example.com").
-		VerificationMethod("did:web:alice.example.com#custom", "CustomType", "did:web:alice.example.com", "zcust").
+		VerificationMethod("did:web:alice.example.com#custom", "CustomType", "zcust").
 		Service("#custom", "CustomServer", "https://custom.example.com").
 		Build()
 

--- a/internal/did/builder_test.go
+++ b/internal/did/builder_test.go
@@ -43,8 +43,8 @@ func TestBuilder_Services(t *testing.T) {
 func TestBuilder_Custom(t *testing.T) {
 	ident := New(syntax.DID("did:web:alice.example.com")).
 		AlsoKnownAs("at://alice.example.com").
-		VerificationMethod("did:web:alice.example.com#custom", "CustomType", "zcust").
-		Service("#custom", "CustomServer", "https://custom.example.com").
+		VerificationMethod("custom", "CustomType", "zcust").
+		Service("custom", "CustomServer", "https://custom.example.com").
 		Build()
 
 	require.Equal(t, []string{"at://alice.example.com"}, ident.AlsoKnownAs)

--- a/internal/did/builder_test.go
+++ b/internal/did/builder_test.go
@@ -9,54 +9,65 @@ import (
 )
 
 func TestBuilder_Atproto(t *testing.T) {
-	doc := New(syntax.DID("did:web:alice.example.com")).
+	ident := New(syntax.DID("did:web:alice.example.com")).
 		AtprotoKey("zpubkey").
 		Build()
 
-	require.Equal(t, syntax.DID("did:web:alice.example.com"), doc.DID)
-	require.Equal(t, []identity.DocVerificationMethod{{
-		ID:                 "did:web:alice.example.com#atproto",
-		Type:               "Multikey",
-		Controller:         "did:web:alice.example.com",
-		PublicKeyMultibase: "zpubkey",
-	}}, doc.VerificationMethod)
+	require.Equal(t, syntax.DID("did:web:alice.example.com"), ident.DID)
+	require.Equal(t, map[string]identity.VerificationMethod{
+		"atproto": {
+			Type:               "Multikey",
+			PublicKeyMultibase: "zpubkey",
+		},
+	}, ident.Keys)
 }
 
 func TestBuilder_Services(t *testing.T) {
-	doc := New(syntax.DID("did:web:alice.example.com")).
+	ident := New(syntax.DID("did:web:alice.example.com")).
 		Habitat("https://pear.example.com").
 		ATProtoPDS("https://pear.example.com").
 		Build()
 
-	require.Equal(t, []identity.DocService{
-		{ID: "#habitat", Type: "HabitatServer", ServiceEndpoint: "https://pear.example.com"},
-		{
-			ID:              "#atproto_pds",
-			Type:            "AtprotoPersonalDataServer",
-			ServiceEndpoint: "https://pear.example.com",
+	require.Equal(t, map[string]identity.ServiceEndpoint{
+		"habitat": {
+			Type: "HabitatServer",
+			URL:  "https://pear.example.com",
 		},
-	}, doc.Service)
+		"atproto_pds": {
+			Type: "AtprotoPersonalDataServer",
+			URL:  "https://pear.example.com",
+		},
+	}, ident.Services)
 }
 
 func TestBuilder_Custom(t *testing.T) {
-	doc := New(syntax.DID("did:web:alice.example.com")).
+	ident := New(syntax.DID("did:web:alice.example.com")).
 		AlsoKnownAs("at://alice.example.com").
 		VerificationMethod("did:web:alice.example.com#custom", "CustomType", "did:web:alice.example.com", "zcust").
 		Service("#custom", "CustomServer", "https://custom.example.com").
 		Build()
 
-	require.Equal(t, []string{"at://alice.example.com"}, doc.AlsoKnownAs)
-	require.Equal(t, []identity.DocVerificationMethod{{
-		ID:                 "did:web:alice.example.com#custom",
-		Type:               "CustomType",
-		Controller:         "did:web:alice.example.com",
-		PublicKeyMultibase: "zcust",
-	}}, doc.VerificationMethod)
-	require.Equal(t, []identity.DocService{{
-		ID:              "#custom",
-		Type:            "CustomServer",
-		ServiceEndpoint: "https://custom.example.com",
-	}}, doc.Service)
+	require.Equal(t, []string{"at://alice.example.com"}, ident.AlsoKnownAs)
+	require.Equal(t, map[string]identity.VerificationMethod{
+		"custom": {
+			Type:               "CustomType",
+			PublicKeyMultibase: "zcust",
+		},
+	}, ident.Keys)
+	require.Equal(t, map[string]identity.ServiceEndpoint{
+		"custom": {
+			Type: "CustomServer",
+			URL:  "https://custom.example.com",
+		},
+	}, ident.Services)
+}
+
+func TestBuilder_Handle(t *testing.T) {
+	ident := New(syntax.DID("did:web:alice.example.com")).
+		Handle(syntax.Handle("alice.example.com")).
+		Build()
+
+	require.Equal(t, syntax.Handle("alice.example.com"), ident.Handle)
 }
 
 func TestBuilder_Web(t *testing.T) {

--- a/internal/did/handler.go
+++ b/internal/did/handler.go
@@ -24,12 +24,12 @@ type docWithContext struct {
 
 // handler serves a DID document as application/did+ld+json.
 type handler struct {
-	// doc is the DID document to serve.
-	doc identity.DIDDocument
+	// ident is the identity whose DID document is served.
+	ident *identity.Identity
 }
 
-func NewHandler(doc identity.DIDDocument) *handler {
-	return &handler{doc: doc}
+func NewHandler(ident *identity.Identity) *handler {
+	return &handler{ident: ident}
 }
 
 // ServeHTTP implements http.Handler.
@@ -38,6 +38,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "max-age=3600")
 	httpx.WriteJSON(r.Context(), w, docWithContext{
 		Context:     didCtx,
-		DIDDocument: h.doc,
+		DIDDocument: h.ident.DIDDocument(),
 	})
 }

--- a/internal/hive/hive.go
+++ b/internal/hive/hive.go
@@ -57,16 +57,14 @@ var _ Hive = &hive{}
 func idTemplateBuilder(memberDomain, pearDomain string) idTemplate {
 	return func(handleInternal, opaqueID, signingPublicKey string) *identity.Identity {
 		handle := syntax.Handle(handleInternal + "." + memberDomain)
-		doc := did.Web(opaqueID + "." + memberDomain).
+		ident := did.Web(opaqueID + "." + memberDomain).
 			AlsoKnownAs("at://" + string(handle)).
 			AtprotoKey(signingPublicKey).
 			Habitat("https://" + pearDomain).
 			ATProtoPDS("https://" + pearDomain).
 			Build()
-		// ParseIdentity sets Handle to handle.invalid; overwrite with the real one.
-		ident := identity.ParseIdentity(&doc)
 		ident.Handle = handle
-		return &ident
+		return ident
 	}
 }
 

--- a/internal/hive/hive.go
+++ b/internal/hive/hive.go
@@ -57,14 +57,12 @@ var _ Hive = &hive{}
 func idTemplateBuilder(memberDomain, pearDomain string) idTemplate {
 	return func(handleInternal, opaqueID, signingPublicKey string) *identity.Identity {
 		handle := syntax.Handle(handleInternal + "." + memberDomain)
-		ident := did.Web(opaqueID + "." + memberDomain).
-			AlsoKnownAs("at://" + string(handle)).
+		return did.Web(opaqueID + "." + memberDomain).
+			Handle(handle).
 			AtprotoKey(signingPublicKey).
 			Habitat("https://" + pearDomain).
 			ATProtoPDS("https://" + pearDomain).
 			Build()
-		ident.Handle = handle
-		return ident
 	}
 }
 

--- a/internal/identity/server.go
+++ b/internal/identity/server.go
@@ -248,7 +248,7 @@ func (s *Server) overriddenDidDoc(ident *identity.Identity) identity.DIDDocument
 	b := did.New(ident.DID).AlsoKnownAs(ident.AlsoKnownAs...)
 	for k, vm := range ident.Keys {
 		b.VerificationMethod(
-			fmt.Sprintf("%s#%s", ident.DID, k),
+			k,
 			vm.Type,
 			vm.PublicKeyMultibase,
 		)

--- a/internal/identity/server.go
+++ b/internal/identity/server.go
@@ -250,7 +250,6 @@ func (s *Server) overriddenDidDoc(ident *identity.Identity) identity.DIDDocument
 		b.VerificationMethod(
 			fmt.Sprintf("%s#%s", ident.DID, k),
 			vm.Type,
-			ident.DID.String(),
 			vm.PublicKeyMultibase,
 		)
 	}

--- a/internal/identity/server.go
+++ b/internal/identity/server.go
@@ -137,7 +137,7 @@ func (s *Server) ServeDIDDoc(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	did.NewHandler(ident.DIDDocument()).ServeHTTP(w, r)
+	did.NewHandler(ident).ServeHTTP(w, r)
 }
 
 // Serve handle DID ( satisfy /{handle}/.well-known/atproto-did )
@@ -254,5 +254,5 @@ func (s *Server) overriddenDidDoc(ident *identity.Identity) identity.DIDDocument
 			vm.PublicKeyMultibase,
 		)
 	}
-	return b.ATProtoPDS("https://" + s.domain).Build()
+	return b.ATProtoPDS("https://" + s.domain).Build().DIDDocument()
 }


### PR DESCRIPTION
## Summary
- `did.Builder.Build()` now returns `*identity.Identity` (with a new `Handle()` helper) instead of a raw `DIDDocument`
- `did.NewHandler` takes an `*identity.Identity` and calls `.DIDDocument()` when serving
- Callers updated: `hive` drops the ParseIdentity round-trip, `didgen` marshals `.DIDDocument()`, identity server passes the identity through

## Test Plan
- [ ] `go build ./...`
- [ ] `go test ./internal/did/... ./internal/identity/... ./internal/hive/... ./cmd/home/... ./cmd/pear/...`