### PR TITLE
[Spaces] Limit blob uploads to 500kb

### DIFF
--- a/internal/spaces/server.go
+++ b/internal/spaces/server.go
@@ -554,15 +554,6 @@ func (s *Server) GetRecord(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// blobRef is the atproto blob reference returned by uploadBlob. It matches the
-// "blob" lexicon type: https://atproto.com/specs/data-model#blob-type
-type blobRef struct {
-	Type     string         `json:"$type"`
-	Ref      atdata.CIDLink `json:"ref"`
-	MimeType string         `json:"mimeType"`
-	Size     int64          `json:"size"`
-}
-
 // UploadBlob stores an uploaded blob content-addressed by its CID and returns
 // the blob reference. Implements network.habitat.repo.uploadBlob.
 func (s *Server) UploadBlob(w http.ResponseWriter, r *http.Request) {
@@ -577,8 +568,12 @@ func (s *Server) UploadBlob(w http.ResponseWriter, r *http.Request) {
 	if mimeType == "" {
 		mimeType = "application/octet-stream"
 	}
-	data, err := io.ReadAll(r.Body)
-	if err != nil {
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 500*1024))
+	var tooLarge *http.MaxBytesError
+	if errors.As(err, &tooLarge) {
+		httpx.WriteError(ctx, w, "BlobTooLarge", "max 500kb", http.StatusRequestEntityTooLarge)
+		return
+	} else if err != nil {
 		httpx.WriteInvalidRequest(ctx, w, "failed to read request body", err)
 		return
 	}
@@ -587,16 +582,14 @@ func (s *Server) UploadBlob(w http.ResponseWriter, r *http.Request) {
 		httpx.WriteServerError(ctx, w, fmt.Errorf("store blob: %w", err))
 		return
 	}
-	output := habitat.NetworkHabitatRepoUploadBlobOutput{
+	httpx.WriteJSON(ctx, w, habitat.NetworkHabitatRepoUploadBlobOutput{
 		Cid: c.String(),
-		Blob: blobRef{
-			Type:     "blob",
+		Blob: atdata.Blob{
 			Ref:      atdata.CIDLink(c),
 			MimeType: mimeType,
 			Size:     size,
 		},
-	}
-	httpx.WriteJSON(ctx, w, output)
+	})
 }
 
 // GetBlob streams a blob stored within a space back to a caller with read

--- a/internal/spaces/server_test.go
+++ b/internal/spaces/server_test.go
@@ -142,6 +142,28 @@ func TestServer_UploadAndGetBlob(t *testing.T) {
 	require.Equal(t, "hello blobs", string(body))
 }
 
+func TestServer_UploadBlob_RejectsOversized(t *testing.T) {
+	s := newTestServerWithOpts(t,
+		testServerOptions{
+			oauth:       authntest.NewSuccessMethodWithOrg(owner, orgId),
+			serviceAuth: authntest.NewSuccessMethodWithOrg(owner, orgId),
+		},
+	)
+
+	// 500 KiB upload limit + 1 byte must be rejected.
+	oversized := make([]byte, 500*1024+1)
+	upReq := httptest.NewRequest(
+		http.MethodPost,
+		"/xrpc/network.habitat.repo.uploadBlob",
+		bytes.NewReader(oversized),
+	)
+	upReq.Header.Set("Content-Type", "application/octet-stream")
+	upW := httptest.NewRecorder()
+	s.UploadBlob(upW, upReq)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, upW.Code)
+}
+
 func TestServer_ListSpaces(t *testing.T) {
 	s := newTestServerWithOpts(t,
 		testServerOptions{


### PR DESCRIPTION
## Summary
- Reject blob uploads over 500kb in `spaces.Server.UploadBlob` with HTTP 413 `BlobTooLarge`
- Uses `http.MaxBytesReader` so oversized bodies are rejected while streaming
- Added `TestServer_UploadBlob_RejectsOversized` covering the limit

## Test Plan
- [ ] `go test ./internal/spaces/`