### PR TITLE
Add HabitatKey verification method to did:web builder

### DIFF
--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -474,6 +474,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	mux.Handle("/.well-known/did.json", did.NewHandler(
 		did.Web(domain).
 			ATProtoSpaceKey(hostPublicKey.Multibase()).
+			HabitatKey(hostPublicKey.Multibase()).
 			Habitat("https://"+domain).
 			ATProtoSpaceHost("https://"+domain).
 			Build(),

--- a/internal/did/builder.go
+++ b/internal/did/builder.go
@@ -58,6 +58,12 @@ func (b *Builder) ATProtoSpaceKey(multibase string) *Builder {
 	return b.VerificationMethod("atproto_space", "Multikey", multibase)
 }
 
+// HabitatKey registers the Habitat host signing key as a Multikey verification
+// method at <did>#habitat.
+func (b *Builder) HabitatKey(multibase string) *Builder {
+	return b.VerificationMethod("habitat", "Multikey", multibase)
+}
+
 // Habitat adds the #habitat HabitatServer service.
 func (b *Builder) Habitat(endpoint string) *Builder {
 	return b.Service("habitat", "HabitatServer", endpoint)

--- a/internal/did/builder_test.go
+++ b/internal/did/builder_test.go
@@ -22,6 +22,20 @@ func TestBuilder_Atproto(t *testing.T) {
 	}, ident.Keys)
 }
 
+func TestBuilder_HabitatKey(t *testing.T) {
+	ident := New(syntax.DID("did:web:alice.example.com")).
+		HabitatKey("zhabitatkey").
+		Build()
+
+	require.Equal(t, syntax.DID("did:web:alice.example.com"), ident.DID)
+	require.Equal(t, map[string]identity.VerificationMethod{
+		"habitat": {
+			Type:               "Multikey",
+			PublicKeyMultibase: "zhabitatkey",
+		},
+	}, ident.Keys)
+}
+
 func TestBuilder_Services(t *testing.T) {
 	ident := New(syntax.DID("did:web:alice.example.com")).
 		Habitat("https://pear.example.com").


### PR DESCRIPTION
Adds a `#habitat` Multikey verification method to the DID builder.

- `internal/did/builder.go`: new `HabitatKey` builder method registering a `Multikey` key at `<did>#habitat`.
- `cmd/pear/main.go`: pear's `.well-known/did.json` now includes the `#habitat` key pointing at the host signing key, same key as `atproto_space`.
- `internal/did/builder_test.go`: test covering the new method.

Verified: `go test ./internal/did/...`, `go build ./cmd/pear/...`, `go vet ./internal/did/...`.