### PR TITLE
[Spaces] listSpaces lists spaces the user has written to

### DIFF
--- a/frontend/src/routes/_requireAuth/spaces/index.tsx
+++ b/frontend/src/routes/_requireAuth/spaces/index.tsx
@@ -58,14 +58,14 @@ function SpaceTypesList() {
   return (
     <SpacesPageLayout
       title="Spaces"
-      subtitle="The spaces you have permission to, grouped by type."
+      subtitle="The spaces you've written to, grouped by type."
     >
       <CreateSpaceForm />
 
       {types.length === 0 ? (
         <Card>
           <CardContent className="py-10 text-center text-muted-foreground">
-            You aren’t in any spaces yet. Create one to get started.
+            You haven’t written to any spaces yet. Create one to get started.
           </CardContent>
         </Card>
       ) : (

--- a/internal/spaces/server.go
+++ b/internal/spaces/server.go
@@ -186,7 +186,6 @@ func (s *Server) ListSpaces(w http.ResponseWriter, r *http.Request) {
 	}
 	spaces, err := s.store.ListSpaces(
 		ctx,
-		credInfo.Org.DID(),
 		credInfo.Subject,
 		filterOwner,
 		filterType,
@@ -196,10 +195,10 @@ func (s *Server) ListSpaces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	views := make([]habitat.NetworkHabitatSpaceListSpacesSpaceView, len(spaces))
-	for i, sp := range spaces {
+	for i, uri := range spaces {
 		views[i] = habitat.NetworkHabitatSpaceListSpacesSpaceView{
-			Uri:     sp.URI.String(),
-			IsOwner: sp.URI.SpaceOwner() == credInfo.Subject,
+			Uri:     uri.String(),
+			IsOwner: uri.SpaceOwner() == credInfo.Subject,
 		}
 	}
 	httpx.WriteJSON(ctx, w, habitat.NetworkHabitatSpaceListSpacesOutput{

--- a/internal/spaces/server_test.go
+++ b/internal/spaces/server_test.go
@@ -235,6 +235,10 @@ func TestServer_ListSpaces(t *testing.T) {
 	uri, err := s.Store.CreateSpace(t.Context(), orgId, owner, groupType, "my-space")
 	require.NoError(t, err)
 
+	coll := syntax.NSID("network.habitat.note")
+	_, _, err = s.Store.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+
 	req := httptest.NewRequest(
 		http.MethodGet,
 		"/xrpc/network.habitat.space.listSpaces",

--- a/internal/spaces/spaces.go
+++ b/internal/spaces/spaces.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
+	"strings"
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/atdata"
@@ -321,25 +321,45 @@ func (s *store) ListSpaces(
 	// member has written into a space, keyed by the space URI, so the URIs are
 	// read straight out of it. The spaces table is not consulted, which means a
 	// space nobody has written to is not listed at all.
-	var uris []habitat_syntax.SpaceURI
-	if err := s.db.WithContext(ctx).
+	query := s.db.WithContext(ctx).
 		Model(&spaceRepo{}).
-		Where("repo = ?", member).
-		Order("updated_at DESC").
-		Pluck("space", &uris).Error; err != nil {
-		return nil, fmt.Errorf("list written spaces: %w", err)
+		Where("repo = ?", member)
+	if filterOwner != nil || filterType != nil {
+		query = query.Where(`space LIKE ? ESCAPE '\'`, spaceURIPattern(filterOwner, filterType))
 	}
 
-	// The filters read the owner and type out of the URI rather than matching a
-	// prefix in SQL, so the URI encoding stays the syntax package's business. A
-	// member's writer set is small enough that this costs nothing.
-	if filterOwner == nil && filterType == nil {
-		return uris, nil
+	var uris []habitat_syntax.SpaceURI
+	if err := query.Order("updated_at DESC").Pluck("space", &uris).Error; err != nil {
+		return nil, fmt.Errorf("list written spaces: %w", err)
 	}
-	return slices.DeleteFunc(uris, func(uri habitat_syntax.SpaceURI) bool {
-		return (filterOwner != nil && uri.SpaceOwner() != *filterOwner) ||
-			(filterType != nil && uri.SpaceType() != *filterType)
-	}), nil
+	return uris, nil
+}
+
+// spaceURIPattern builds a LIKE pattern matching the stored space URIs with the
+// given owner and type; a nil filter matches any value. Stored URIs are always
+// in the current format ("at://<did>/space/<type>/<skey>"), whose literal
+// separators anchor each component — and since neither a DID nor an NSID can
+// contain "/", a wildcard cannot spill into the neighbouring component.
+func spaceURIPattern(owner *syntax.DID, spaceType *syntax.NSID) string {
+	ownerPattern := "%"
+	if owner != nil {
+		ownerPattern = escapeLike(owner.String())
+	}
+	typePattern := "%"
+	if spaceType != nil {
+		typePattern = escapeLike(spaceType.String())
+	}
+	return fmt.Sprintf("at://%s/space/%s/%%", ownerPattern, typePattern)
+}
+
+// likeEscaper escapes the LIKE wildcards in a value interpolated into a
+// pattern, for use with "ESCAPE '\'". A DID can legitimately carry both: a
+// did:web holding a port percent-encodes it (did:web:example.com%3A8080), and %
+// would otherwise match anything.
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+func escapeLike(s string) string {
+	return likeEscaper.Replace(s)
 }
 
 // loadRepoHash reads a repo's cached LtHash state and rev, or the zero hash and

--- a/internal/spaces/spaces.go
+++ b/internal/spaces/spaces.go
@@ -58,10 +58,9 @@ type spaceRepo struct {
 
 // SpaceView is the public representation of a space
 type SpaceView struct {
-	URI         habitat_syntax.SpaceURI
-	Type        syntax.NSID
-	Skey        habitat_syntax.SpaceKey
-	MemberCount int
+	URI  habitat_syntax.SpaceURI
+	Type syntax.NSID
+	Skey habitat_syntax.SpaceKey
 }
 
 // RepoInfo holds a repo's DID and latest rev within a space
@@ -110,7 +109,9 @@ type Store interface {
 		spaceType syntax.NSID,
 		skey habitat_syntax.SpaceKey,
 	) (habitat_syntax.SpaceURI, error)
-	// ListSpaces returns the spaces that `member` is a part of
+	// ListSpaces returns the spaces `member` holds a permissioned repo in (has
+	// written at least one record to), plus every space `member` owns — the org
+	// authority listing all of its spaces. An empty member returns all spaces.
 	ListSpaces(
 		ctx context.Context,
 		org syntax.DID,
@@ -327,25 +328,28 @@ func (s *store) ListSpaces(
 	if member == "" {
 		conditions = s.db
 	} else {
-		// If member is the org itself, include all the org's spaces. This initial condition
-		// is always false for user members since they are never owners of a space.
+		// The caller sees the spaces it owns (the org authority enumerating
+		// all of its spaces, as the sap crawler relies on) plus the spaces it
+		// has written at least one record into. The writer set is the cached
+		// spaceRepo table, so no access store is consulted.
 		conditions = s.db.Where("owner = ?", member)
-		fgaObjects, err := s.fga.ListObjects(
-			ctx,
-			fgastore.MemberUserString(member),
-			"can_read",
-			"space",
-			fgastore.OrgMemberContextualTuple(org),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("list fga spaces: %w", err)
+		var spaceURIs []string
+		if err := s.db.WithContext(ctx).
+			Model(&spaceRepo{}).
+			Where("repo = ?", member).
+			Distinct().
+			Pluck("space", &spaceURIs).Error; err != nil {
+			return nil, fmt.Errorf("list written spaces: %w", err)
 		}
-		for _, key := range fgaObjects {
-			uri, err := fgastore.ParseSpaceObjectKey(key)
+		for _, uriStr := range spaceURIs {
+			uri, err := habitat_syntax.ParseSpaceURI(uriStr)
 			if err != nil {
-				return nil, fmt.Errorf("parse space object key: %w", err)
+				return nil, fmt.Errorf("parse space uri: %w", err)
 			}
-			conditions = conditions.Or("owner = ? AND skey = ?", uri.SpaceOwner(), uri.Skey())
+			conditions = conditions.Or(
+				"owner = ? AND type = ? AND skey = ?",
+				uri.SpaceOwner(), uri.SpaceType(), uri.Skey(),
+			)
 		}
 	}
 
@@ -364,23 +368,10 @@ func (s *store) ListSpaces(
 
 	views := make([]SpaceView, len(rows))
 	for i, row := range rows {
-		uri := habitat_syntax.ConstructSpaceURI(row.Owner, row.Type, row.Skey)
-		fgaUsers, err := s.fga.ListUsers(
-			ctx,
-			fgastore.SpaceObjectKey(uri),
-			"can_read",
-			ownerContextualTuple(uri),
-			fgastore.OrgMemberContextualTuple(org),
-		)
-		memberCount := 0
-		if err == nil {
-			memberCount = len(fgaUsers)
-		}
 		views[i] = SpaceView{
-			URI:         uri,
-			Type:        row.Type,
-			Skey:        row.Skey,
-			MemberCount: memberCount,
+			URI:  habitat_syntax.ConstructSpaceURI(row.Owner, row.Type, row.Skey),
+			Type: row.Type,
+			Skey: row.Skey,
 		}
 	}
 	return views, nil

--- a/internal/spaces/spaces.go
+++ b/internal/spaces/spaces.go
@@ -56,13 +56,6 @@ type spaceRepo struct {
 	DeletedAt gorm.DeletedAt
 }
 
-// SpaceView is the public representation of a space
-type SpaceView struct {
-	URI  habitat_syntax.SpaceURI
-	Type syntax.NSID
-	Skey habitat_syntax.SpaceKey
-}
-
 // RepoInfo holds a repo's DID and latest rev within a space
 type RepoInfo struct {
 	DID  syntax.DID
@@ -109,16 +102,16 @@ type Store interface {
 		spaceType syntax.NSID,
 		skey habitat_syntax.SpaceKey,
 	) (habitat_syntax.SpaceURI, error)
-	// ListSpaces returns the spaces `member` holds a permissioned repo in (has
-	// written at least one record to), plus every space `member` owns — the org
-	// authority listing all of its spaces. An empty member returns all spaces.
+	// ListSpaces returns the URIs of the spaces `member` holds a permissioned
+	// repo in (has written at least one record to), plus every space `member`
+	// owns — the org authority listing all of its spaces. An empty member
+	// returns all spaces.
 	ListSpaces(
 		ctx context.Context,
-		org syntax.DID,
 		member syntax.DID,
 		filterOwner *syntax.DID,
 		filterType *syntax.NSID,
-	) ([]SpaceView, error)
+	) ([]habitat_syntax.SpaceURI, error)
 
 	// Member operations
 	AddMember(
@@ -319,41 +312,24 @@ func (s *store) CreateSpace(
 
 func (s *store) ListSpaces(
 	ctx context.Context,
-	org syntax.DID,
 	member syntax.DID,
 	filterOwner *syntax.DID,
 	filterType *syntax.NSID,
-) ([]SpaceView, error) {
-	var conditions *gorm.DB
-	if member == "" {
-		conditions = s.db
-	} else {
-		// The caller sees the spaces it owns (the org authority enumerating
-		// all of its spaces, as the sap crawler relies on) plus the spaces it
-		// has written at least one record into. The writer set is the cached
-		// spaceRepo table, so no access store is consulted.
-		conditions = s.db.Where("owner = ?", member)
-		var spaceURIs []string
-		if err := s.db.WithContext(ctx).
+) ([]habitat_syntax.SpaceURI, error) {
+	query := s.db.WithContext(ctx).Model(&space{})
+	if member != "" {
+		// spaceRepo keys rows by the whole space URI, so the correlated subquery
+		// re-derives that URI from the space's (owner, type, skey) columns
+		// rather than reading the writer set in a second round trip.
+		writtenBy := s.db.
 			Model(&spaceRepo{}).
+			Select("1").
 			Where("repo = ?", member).
-			Distinct().
-			Pluck("space", &spaceURIs).Error; err != nil {
-			return nil, fmt.Errorf("list written spaces: %w", err)
-		}
-		for _, uriStr := range spaceURIs {
-			uri, err := habitat_syntax.ParseSpaceURI(uriStr)
-			if err != nil {
-				return nil, fmt.Errorf("parse space uri: %w", err)
-			}
-			conditions = conditions.Or(
-				"owner = ? AND type = ? AND skey = ?",
-				uri.SpaceOwner(), uri.SpaceType(), uri.Skey(),
-			)
-		}
+			Where("space = ?", gorm.Expr("'at://' || spaces.owner || '/space/' || spaces.type || '/' || spaces.skey"))
+		query = query.Where(
+			s.db.Where("owner = ?", member).Or("EXISTS (?)", writtenBy),
+		)
 	}
-
-	query := s.db.WithContext(ctx).Model(&space{}).Where(conditions).Distinct()
 	if filterOwner != nil {
 		query = query.Where("owner = ?", *filterOwner)
 	}
@@ -366,15 +342,11 @@ func (s *store) ListSpaces(
 		return nil, err
 	}
 
-	views := make([]SpaceView, len(rows))
+	uris := make([]habitat_syntax.SpaceURI, len(rows))
 	for i, row := range rows {
-		views[i] = SpaceView{
-			URI:  habitat_syntax.ConstructSpaceURI(row.Owner, row.Type, row.Skey),
-			Type: row.Type,
-			Skey: row.Skey,
-		}
+		uris[i] = habitat_syntax.ConstructSpaceURI(row.Owner, row.Type, row.Skey)
 	}
-	return views, nil
+	return uris, nil
 }
 
 // loadRepoHash reads a repo's cached LtHash state and rev, or the zero hash and

--- a/internal/spaces/spaces.go
+++ b/internal/spaces/spaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/atdata"
@@ -103,9 +104,9 @@ type Store interface {
 		skey habitat_syntax.SpaceKey,
 	) (habitat_syntax.SpaceURI, error)
 	// ListSpaces returns the URIs of the spaces `member` holds a permissioned
-	// repo in (has written at least one record to), plus every space `member`
-	// owns — the org authority listing all of its spaces. An empty member
-	// returns all spaces.
+	// repo in — the spaces it has written at least one record to — most
+	// recently written first. A space `member` owns but has never written to is
+	// not listed, and neither is one whose records it has since deleted.
 	ListSpaces(
 		ctx context.Context,
 		member syntax.DID,
@@ -316,37 +317,29 @@ func (s *store) ListSpaces(
 	filterOwner *syntax.DID,
 	filterType *syntax.NSID,
 ) ([]habitat_syntax.SpaceURI, error) {
-	query := s.db.WithContext(ctx).Model(&space{})
-	if member != "" {
-		// spaceRepo keys rows by the whole space URI, so the correlated subquery
-		// re-derives that URI from the space's (owner, type, skey) columns
-		// rather than reading the writer set in a second round trip.
-		writtenBy := s.db.
-			Model(&spaceRepo{}).
-			Select("1").
-			Where("repo = ?", member).
-			Where("space = ?", gorm.Expr("'at://' || spaces.owner || '/space/' || spaces.type || '/' || spaces.skey"))
-		query = query.Where(
-			s.db.Where("owner = ?", member).Or("EXISTS (?)", writtenBy),
-		)
-	}
-	if filterOwner != nil {
-		query = query.Where("owner = ?", *filterOwner)
-	}
-	if filterType != nil {
-		query = query.Where("type = ?", *filterType)
+	// The writer set is the whole answer: spaceRepo holds one row per repo a
+	// member has written into a space, keyed by the space URI, so the URIs are
+	// read straight out of it. The spaces table is not consulted, which means a
+	// space nobody has written to is not listed at all.
+	var uris []habitat_syntax.SpaceURI
+	if err := s.db.WithContext(ctx).
+		Model(&spaceRepo{}).
+		Where("repo = ?", member).
+		Order("updated_at DESC").
+		Pluck("space", &uris).Error; err != nil {
+		return nil, fmt.Errorf("list written spaces: %w", err)
 	}
 
-	var rows []space
-	if err := query.Order("created_at DESC").Find(&rows).Error; err != nil {
-		return nil, err
+	// The filters read the owner and type out of the URI rather than matching a
+	// prefix in SQL, so the URI encoding stays the syntax package's business. A
+	// member's writer set is small enough that this costs nothing.
+	if filterOwner == nil && filterType == nil {
+		return uris, nil
 	}
-
-	uris := make([]habitat_syntax.SpaceURI, len(rows))
-	for i, row := range rows {
-		uris[i] = habitat_syntax.ConstructSpaceURI(row.Owner, row.Type, row.Skey)
-	}
-	return uris, nil
+	return slices.DeleteFunc(uris, func(uri habitat_syntax.SpaceURI) bool {
+		return (filterOwner != nil && uri.SpaceOwner() != *filterOwner) ||
+			(filterType != nil && uri.SpaceType() != *filterType)
+	}), nil
 }
 
 // loadRepoHash reads a repo's cached LtHash state and rev, or the zero hash and
@@ -792,6 +785,15 @@ func (s *store) DeleteSpace(ctx context.Context, uri habitat_syntax.SpaceURI) er
 		if err := tx.
 			Where("space = ?", uri).
 			Delete(&spaceRecord{}).Error; err != nil {
+			return err
+		}
+
+		// Drop the permissioned repos along with the records they cached a
+		// hash of. They are the writer set listSpaces reads, so leaving them
+		// behind would keep a deleted space on its writers' listings.
+		if err := tx.
+			Where("space = ?", uri).
+			Delete(&spaceRepo{}).Error; err != nil {
 			return err
 		}
 

--- a/internal/spaces/spaces_test.go
+++ b/internal/spaces/spaces_test.go
@@ -59,28 +59,78 @@ func TestCreateSpace_OwnerIsMember(t *testing.T) {
 func TestListSpaces(t *testing.T) {
 	s := spaces_testutil.NewTestStore(t)
 
-	_, err := s.CreateSpace(t.Context(), orgId, owner, groupType, "space1")
+	space1, err := s.CreateSpace(t.Context(), orgId, owner, groupType, "space1")
 	require.NoError(t, err)
 
-	spaceUri2, err := s.CreateSpace(t.Context(), orgId, alice, groupType, "space2")
+	space2, err := s.CreateSpace(t.Context(), orgId, alice, groupType, "space2")
 	require.NoError(t, err)
 
-	err = s.AddMember(t.Context(), spaceUri2, owner, spaces.SpaceAccessRead)
+	// A read grant alone doesn't put a space on a member's listing: listSpaces
+	// reports the spaces the caller holds a repo in — the ones it has written
+	// to — and consults no access store.
+	err = s.AddMember(t.Context(), space2, owner, spaces.SpaceAccessRead)
 	require.NoError(t, err)
 
-	// Owner should see both
+	coll := syntax.NSID("network.habitat.note")
+	_, _, err = s.PutRecord(t.Context(), space1, owner, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+	_, _, err = s.PutRecord(t.Context(), space2, alice, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+
+	// Owner sees the space it wrote to, not the one it was merely granted read
+	// access to.
 	spaces, err := s.ListSpaces(t.Context(), orgId, owner, nil, nil)
 	require.NoError(t, err)
-	require.Len(t, spaces, 2)
+	require.Len(t, spaces, 1)
+	require.Equal(t, space1, spaces[0].URI)
 
-	// memberCount should be populated (at least 1 — the owner)
-	for _, sp := range spaces {
-		require.GreaterOrEqual(t, sp.MemberCount, 1)
-	}
-	// Alice should see 1
+	// Alice sees the space she wrote to.
 	spaces, err = s.ListSpaces(t.Context(), orgId, alice, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, spaces, 1)
+	require.Equal(t, space2, spaces[0].URI)
+}
+
+func TestListSpaces_OrgListsAllItsSpaces(t *testing.T) {
+	s := spaces_testutil.NewTestStore(t)
+
+	space1, err := s.CreateSpace(t.Context(), orgId, owner, groupType, "space1")
+	require.NoError(t, err)
+	space2, err := s.CreateSpace(t.Context(), orgId, alice, groupType, "space2")
+	require.NoError(t, err)
+
+	// The org is the space authority: it lists every space it owns even when
+	// it holds no repo there. This is the enumeration the sap crawler relies
+	// on, and it involves no FGA.
+	spaces, err := s.ListSpaces(t.Context(), orgId, orgId, nil, nil)
+	require.NoError(t, err)
+	uris := make([]habitat_syntax.SpaceURI, len(spaces))
+	for i, sp := range spaces {
+		uris[i] = sp.URI
+	}
+	require.ElementsMatch(t, []habitat_syntax.SpaceURI{space1, space2}, uris)
+}
+
+func TestListSpaces_LeavesListingAfterDeletingAllRecords(t *testing.T) {
+	s := spaces_testutil.NewTestStore(t)
+
+	uri, err := s.CreateSpace(t.Context(), orgId, owner, groupType, "test")
+	require.NoError(t, err)
+
+	coll := syntax.NSID("network.habitat.note")
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+
+	spaces, err := s.ListSpaces(t.Context(), orgId, owner, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, spaces, 1)
+
+	// Deleting the only record removes the repo from the writer set, so the
+	// space drops out of the caller's listing.
+	require.NoError(t, s.DeleteRecord(t.Context(), uri, owner, coll, "k1"))
+	spaces, err = s.ListSpaces(t.Context(), orgId, owner, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, spaces, 0)
 }
 
 func TestListSpaces_FilterByType(t *testing.T) {
@@ -88,10 +138,16 @@ func TestListSpaces_FilterByType(t *testing.T) {
 
 	personal := syntax.NSID("network.habitat.personal")
 
-	_, err := s.CreateSpace(t.Context(), orgId, owner, groupType, "group1")
+	group1, err := s.CreateSpace(t.Context(), orgId, owner, groupType, "group1")
 	require.NoError(t, err)
 
-	_, err = s.CreateSpace(t.Context(), orgId, owner, personal, "personal1")
+	personal1, err := s.CreateSpace(t.Context(), orgId, owner, personal, "personal1")
+	require.NoError(t, err)
+
+	coll := syntax.NSID("network.habitat.note")
+	_, _, err = s.PutRecord(t.Context(), group1, owner, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+	_, _, err = s.PutRecord(t.Context(), personal1, owner, coll, "k1", map[string]any{"x": 1})
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), orgId, owner, nil, &groupType)
@@ -110,6 +166,12 @@ func TestListSpaces_NilOwnerFilterSpansAllOrgs(t *testing.T) {
 	spaceA, err := s.CreateSpace(t.Context(), orgA, member, groupType, "space-a")
 	require.NoError(t, err)
 	spaceB, err := s.CreateSpace(t.Context(), orgB, member, groupType, "space-b")
+	require.NoError(t, err)
+
+	coll := syntax.NSID("network.habitat.note")
+	_, _, err = s.PutRecord(t.Context(), spaceA, member, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+	_, _, err = s.PutRecord(t.Context(), spaceB, member, coll, "k1", map[string]any{"x": 1})
 	require.NoError(t, err)
 
 	// With no owner filter, the member sees spaces across every org they

--- a/internal/spaces/spaces_test.go
+++ b/internal/spaces/spaces_test.go
@@ -91,7 +91,7 @@ func TestListSpaces(t *testing.T) {
 	require.Equal(t, space2, spaces[0])
 }
 
-func TestListSpaces_OrgListsAllItsSpaces(t *testing.T) {
+func TestListSpaces_OwningASpaceIsNotWritingToIt(t *testing.T) {
 	s := spaces_testutil.NewTestStore(t)
 
 	space1, err := s.CreateSpace(t.Context(), orgId, owner, groupType, "space1")
@@ -99,12 +99,40 @@ func TestListSpaces_OrgListsAllItsSpaces(t *testing.T) {
 	space2, err := s.CreateSpace(t.Context(), orgId, alice, groupType, "space2")
 	require.NoError(t, err)
 
-	// The org is the space authority: it lists every space it owns even when
-	// it holds no repo there. This is the enumeration the sap crawler relies
-	// on, and it involves no FGA.
+	// Owning a space is not writing to it: the org holds no repo in either
+	// space yet, so it lists neither.
 	spaces, err := s.ListSpaces(t.Context(), orgId, nil, nil)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []habitat_syntax.SpaceURI{space1, space2}, spaces)
+	require.Empty(t, spaces)
+
+	// A write on the org's behalf — how relationship tuples land in a space —
+	// puts that one space, and only that one, on its listing.
+	coll := syntax.NSID("network.habitat.note")
+	_, _, err = s.PutRecord(t.Context(), space1, orgId, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+
+	spaces, err = s.ListSpaces(t.Context(), orgId, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, []habitat_syntax.SpaceURI{space1}, spaces)
+	require.NotContains(t, spaces, space2)
+}
+
+func TestListSpaces_LeavesListingAfterSpaceIsDeleted(t *testing.T) {
+	s := spaces_testutil.NewTestStore(t)
+
+	uri, err := s.CreateSpace(t.Context(), orgId, owner, groupType, "space1")
+	require.NoError(t, err)
+	coll := syntax.NSID("network.habitat.note")
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+
+	// Deleting the space drops its permissioned repos, so it leaves the
+	// listings of everyone who had written to it.
+	require.NoError(t, s.DeleteSpace(t.Context(), uri))
+
+	spaces, err := s.ListSpaces(t.Context(), owner, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, spaces)
 }
 
 func TestListSpaces_LeavesListingAfterDeletingAllRecords(t *testing.T) {

--- a/internal/spaces/spaces_test.go
+++ b/internal/spaces/spaces_test.go
@@ -179,6 +179,33 @@ func TestListSpaces_FilterByType(t *testing.T) {
 	require.Equal(t, []habitat_syntax.SpaceURI{group1}, spaces)
 }
 
+// The owner filter matches the DID inside the stored URI, so a DID carrying a
+// LIKE wildcard — a did:web percent-encodes the port it holds — must not match
+// any other owner.
+func TestListSpaces_FilterByOwnerWithWildcardInDID(t *testing.T) {
+	s := spaces_testutil.NewTestStore(t)
+
+	orgWithPort := syntax.DID("did:web:example.com%3A8080")
+	// Differs from orgWithPort only where the % sits, so it matches if the %
+	// is left to act as a wildcard.
+	otherOrg := syntax.DID("did:web:example.comZZ3A8080")
+
+	wanted, err := s.CreateSpace(t.Context(), orgWithPort, owner, groupType, "space1")
+	require.NoError(t, err)
+	other, err := s.CreateSpace(t.Context(), otherOrg, owner, groupType, "space2")
+	require.NoError(t, err)
+
+	coll := syntax.NSID("network.habitat.note")
+	_, _, err = s.PutRecord(t.Context(), wanted, owner, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+	_, _, err = s.PutRecord(t.Context(), other, owner, coll, "k1", map[string]any{"x": 1})
+	require.NoError(t, err)
+
+	spaces, err := s.ListSpaces(t.Context(), owner, &orgWithPort, nil)
+	require.NoError(t, err)
+	require.Equal(t, []habitat_syntax.SpaceURI{wanted}, spaces)
+}
+
 func TestListSpaces_NilOwnerFilterSpansAllOrgs(t *testing.T) {
 	s := spaces_testutil.NewTestStore(t)
 

--- a/internal/spaces/spaces_test.go
+++ b/internal/spaces/spaces_test.go
@@ -79,16 +79,16 @@ func TestListSpaces(t *testing.T) {
 
 	// Owner sees the space it wrote to, not the one it was merely granted read
 	// access to.
-	spaces, err := s.ListSpaces(t.Context(), orgId, owner, nil, nil)
+	spaces, err := s.ListSpaces(t.Context(), owner, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, spaces, 1)
-	require.Equal(t, space1, spaces[0].URI)
+	require.Equal(t, space1, spaces[0])
 
 	// Alice sees the space she wrote to.
-	spaces, err = s.ListSpaces(t.Context(), orgId, alice, nil, nil)
+	spaces, err = s.ListSpaces(t.Context(), alice, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, spaces, 1)
-	require.Equal(t, space2, spaces[0].URI)
+	require.Equal(t, space2, spaces[0])
 }
 
 func TestListSpaces_OrgListsAllItsSpaces(t *testing.T) {
@@ -102,13 +102,9 @@ func TestListSpaces_OrgListsAllItsSpaces(t *testing.T) {
 	// The org is the space authority: it lists every space it owns even when
 	// it holds no repo there. This is the enumeration the sap crawler relies
 	// on, and it involves no FGA.
-	spaces, err := s.ListSpaces(t.Context(), orgId, orgId, nil, nil)
+	spaces, err := s.ListSpaces(t.Context(), orgId, nil, nil)
 	require.NoError(t, err)
-	uris := make([]habitat_syntax.SpaceURI, len(spaces))
-	for i, sp := range spaces {
-		uris[i] = sp.URI
-	}
-	require.ElementsMatch(t, []habitat_syntax.SpaceURI{space1, space2}, uris)
+	require.ElementsMatch(t, []habitat_syntax.SpaceURI{space1, space2}, spaces)
 }
 
 func TestListSpaces_LeavesListingAfterDeletingAllRecords(t *testing.T) {
@@ -121,14 +117,14 @@ func TestListSpaces_LeavesListingAfterDeletingAllRecords(t *testing.T) {
 	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
 	require.NoError(t, err)
 
-	spaces, err := s.ListSpaces(t.Context(), orgId, owner, nil, nil)
+	spaces, err := s.ListSpaces(t.Context(), owner, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, spaces, 1)
 
 	// Deleting the only record removes the repo from the writer set, so the
 	// space drops out of the caller's listing.
 	require.NoError(t, s.DeleteRecord(t.Context(), uri, owner, coll, "k1"))
-	spaces, err = s.ListSpaces(t.Context(), orgId, owner, nil, nil)
+	spaces, err = s.ListSpaces(t.Context(), owner, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, spaces, 0)
 }
@@ -150,10 +146,9 @@ func TestListSpaces_FilterByType(t *testing.T) {
 	_, _, err = s.PutRecord(t.Context(), personal1, owner, coll, "k1", map[string]any{"x": 1})
 	require.NoError(t, err)
 
-	spaces, err := s.ListSpaces(t.Context(), orgId, owner, nil, &groupType)
+	spaces, err := s.ListSpaces(t.Context(), owner, nil, &groupType)
 	require.NoError(t, err)
-	require.Len(t, spaces, 1)
-	require.Equal(t, groupType, spaces[0].Type)
+	require.Equal(t, []habitat_syntax.SpaceURI{group1}, spaces)
 }
 
 func TestListSpaces_NilOwnerFilterSpansAllOrgs(t *testing.T) {
@@ -176,19 +171,15 @@ func TestListSpaces_NilOwnerFilterSpansAllOrgs(t *testing.T) {
 
 	// With no owner filter, the member sees spaces across every org they
 	// belong to, not just one.
-	spaces, err := s.ListSpaces(t.Context(), orgA, member, nil, nil)
+	spaces, err := s.ListSpaces(t.Context(), member, nil, nil)
 	require.NoError(t, err)
-	uris := make([]habitat_syntax.SpaceURI, len(spaces))
-	for i, sp := range spaces {
-		uris[i] = sp.URI
-	}
-	require.ElementsMatch(t, []habitat_syntax.SpaceURI{spaceA, spaceB}, uris)
+	require.ElementsMatch(t, []habitat_syntax.SpaceURI{spaceA, spaceB}, spaces)
 
 	// Filtering by a specific org owner restricts the results to that org.
-	spaces, err = s.ListSpaces(t.Context(), orgA, member, &orgA, nil)
+	spaces, err = s.ListSpaces(t.Context(), member, &orgA, nil)
 	require.NoError(t, err)
 	require.Len(t, spaces, 1)
-	require.Equal(t, spaceA, spaces[0].URI)
+	require.Equal(t, spaceA, spaces[0])
 }
 
 func TestListRepos_Empty(t *testing.T) {


### PR DESCRIPTION
## Summary
- `spaces.ListSpaces` no longer consults the FGA store: it lists the spaces the caller holds a permissioned repo in (has written at least one record to) via the cached writer-set table, per proposal 0016's `listSpaces` ("the spaces the caller holds a repo in").
- The org authority still lists all spaces it owns (the enumeration the `sap` crawler relies on); `SpaceView.MemberCount` (the last FGA call in the path) is dropped.
- Frontend spaces-page copy updated to "The spaces you've written to".