### PR TITLE
[db] Route gorm test logger through t.Logf

### DIFF
--- a/cmd/pear/go.mod
+++ b/cmd/pear/go.mod
@@ -14,13 +14,9 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0
 	gocloud.dev v0.46.0
 	golang.org/x/sync v0.22.0
-	google.golang.org/api v0.291.0
 )
 
 require (
-	cloud.google.com/go/auth v0.22.0 // indirect
-	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
-	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -35,8 +31,6 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.3.19 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
@@ -64,11 +58,11 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
+	google.golang.org/api v0.291.0 // indirect
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bradenaw/juniper v0.15.3
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/earthboundkid/versioninfo/v2 v2.24.1 // indirect
@@ -94,9 +88,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260718201538-764159d718ef // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/cmd/pear/go.sum
+++ b/cmd/pear/go.sum
@@ -45,8 +45,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bluesky-social/indigo v0.0.0-20260730171912-8b43a326dbbb h1:OYUfO21BK5iO60+ij0L3ugCeawRqD/CbhoWDCpBw6tg=
 github.com/bluesky-social/indigo v0.0.0-20260730171912-8b43a326dbbb/go.mod h1:JqQkz8lrOI6YZivP38GHmtVOTtzsNToITKj1gMpU5Jo=
-github.com/bradenaw/juniper v0.15.3 h1:RHIAMEDTpvmzV1wg1jMAHGOoI2oJUSPx3lxRldXnFGo=
-github.com/bradenaw/juniper v0.15.3/go.mod h1:UX4FX57kVSaDp4TPqvSjkAAewmRFAfXf27BOs5z9dq8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -244,8 +242,6 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
-golang.org/x/exp v0.0.0-20260718201538-764159d718ef h1:LkZ48HFgy/TvhTI0bcWkjgFkgLyKUwcTbDjS0DUjw+A=
-golang.org/x/exp v0.0.0-20260718201538-764159d718ef/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/db/testutil/testutil.go
+++ b/internal/db/testutil/testutil.go
@@ -8,6 +8,7 @@ import (
 	"github.com/habitat-network/habitat/internal/db"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 // NewDB returns a gorm DB backed by a temporary SQLite file living in the
@@ -17,12 +18,30 @@ import (
 // use gorm's connection pool for concurrent reads and writes without hitting
 // "database is locked" errors — unlike a ":memory:" database, where each pooled
 // connection would see a separate, empty database.
+//
+// gorm logs are routed through t.Logf so they only appear when the test runs
+// verbosely or fails.
 func NewDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "test.db")
-	db, err := db.New(
+	d, err := db.New(
 		"sqlite://" + path,
 	)
 	require.NoError(t, err)
-	return db
+	d.Logger = logger.New(testLog{t: t}, logger.Config{
+		LogLevel:                  logger.Info,
+		IgnoreRecordNotFoundError: true,
+		ParameterizedQueries:      false,
+		Colorful:                  true,
+	})
+	return d
+}
+
+// testLog routes gorm's log output through t.Logf.
+type testLog struct {
+	t *testing.T
+}
+
+func (w testLog) Printf(format string, args ...any) {
+	w.t.Logf(format, args...)
 }


### PR DESCRIPTION
Route gorm SQL logs in test databases through `t.Logf` instead of stdout, so they only surface with verbose/failing test output.

- Add a `logger.Writer` adapter in `internal/db/testutil` that forwards to `t.Logf` (Info level, record-not-found ignored, colorful).
- Drop now-unused dependencies from `cmd/pear` (`go mod tidy`).

Verified: `go build ./...` and `go test ./internal/db/...` pass.