### PR TITLE
[Spaces] Build repo-head commits in the spaces store

### DIFF
--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/habitat-network/habitat/internal/relationship"
 	"github.com/habitat-network/habitat/internal/repo"
 	"github.com/habitat-network/habitat/internal/server"
+	"github.com/habitat-network/habitat/internal/spacecommit"
 	"github.com/habitat-network/habitat/internal/spaces"
 	"github.com/habitat-network/habitat/internal/telemetry"
 	"github.com/habitat-network/habitat/internal/webui"
@@ -342,7 +343,13 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 	notifier := notify.NewNotifier(notifyStore, http.DefaultClient, hive)
 
-	spacesStore, err := spaces.NewStore(db.WithContext(startupCtx), fgaStore, eventStore, notifier)
+	spacesStore, err := spaces.NewStore(
+		db.WithContext(startupCtx),
+		fgaStore,
+		eventStore,
+		notifier,
+		spacecommit.NewAuthority(hostKey, hive),
+	)
 	if err != nil {
 		return fmt.Errorf("setup spaces store: %w", err)
 	}

--- a/internal/relationship/store_test.go
+++ b/internal/relationship/store_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	db_testutil "github.com/habitat-network/habitat/internal/db/testutil"
-	"github.com/habitat-network/habitat/internal/events"
 	"github.com/habitat-network/habitat/internal/fgastore"
-	notify_testutil "github.com/habitat-network/habitat/internal/notify/testutil"
 	"github.com/habitat-network/habitat/internal/spaces"
 	space_testutil "github.com/habitat-network/habitat/internal/spaces/testutil"
 	habitat_syntax "github.com/habitat-network/habitat/internal/syntax"
@@ -460,16 +458,15 @@ func (f *flakyFGA) WriteRaw(ctx context.Context, req *openfgav1.WriteRequest) er
 }
 
 func TestWriteTuple_RollsBackRecordOnFGAFailure(t *testing.T) {
-	db := db_testutil.NewDB(t)
 	mem, err := fgastore.NewMemory(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = mem.Close() })
 	fga := &flakyFGA{Store: mem}
-	eventStore, err := events.NewStore(db)
 	require.NoError(t, err)
-	sp, err := spaces.NewStore(db, fga, eventStore, &notify_testutil.TestNotifier{})
-	require.NoError(t, err)
-	rel := NewStore(db, sp, fga)
+	// No commit-signing dependents: this test never calls a method that signs
+	// a repo-head commit.
+	sp := space_testutil.NewTestStore(t, space_testutil.Config{FgaStore: fga})
+	rel := NewStore(db_testutil.NewDB(t), sp, fga)
 
 	// CreateSpace uses fga.Write (not WriteRaw), so it succeeds.
 	space := newSpace(t, sp, docsType, "doc")

--- a/internal/spaces/server.go
+++ b/internal/spaces/server.go
@@ -1,7 +1,6 @@
 package spaces
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,28 +27,21 @@ import (
 	"github.com/habitat-network/habitat/internal/utils"
 )
 
-// errEmptyRepo signals that a repo holds no records, so there is nothing to
-// commit over. It is handled internally and never returned to clients.
-var errEmptyRepo = errors.New("repo has no records")
-
 type Server struct {
 	store     Store
 	fga       fgastore.Store
 	validator authn.RequestValidator
 	decoder   *schema.Decoder
 	orgStore  org.Store
-	commit    *spacecommit.Authority
 	hive      hive.Hive
 	blobs     BlobStore
 	hostKey   atcrypto.PrivateKey
 }
 
-// NewServer constructs the spaces server. host and member are the commit
-// signers: member signs commits for habitat-managed repo owners with their own
-// key (proposal spec), and host signs for owners on external PDSes with
-// Habitat's single host key. Either may be nil; when neither can sign an
-// author, listRepoOps omits the signed commit. blobs backs the uploadBlob and
-// getBlob endpoints.
+// NewServer constructs the spaces server. hostPrivateKey signs delegation
+// tokens and space credentials for authors hive does not manage (the store
+// holds its own commit-signing authority for repo-head commits). blobs backs
+// the uploadBlob and getBlob endpoints.
 func NewServer(
 	store Store,
 	fga fgastore.Store,
@@ -64,7 +56,6 @@ func NewServer(
 		fga:       fga,
 		decoder:   schema.NewDecoder(),
 		orgStore:  orgStore,
-		commit:    spacecommit.NewAuthority(hostPrivateKey, hive),
 		hive:      hive,
 		blobs:     blobs,
 		hostKey:   hostPrivateKey,
@@ -629,29 +620,25 @@ func (s *Server) GetRepo(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	// Sign the repo's current head; the signed commit is the CAR's first root. An
-	// empty repo has no state to recover, so it reports as not found.
-	commit, err := s.signRepoHead(ctx, spaceURI, repoDID)
-	switch {
-	case err == nil:
-	case errors.Is(err, errEmptyRepo):
-		httpx.WriteRepoNotFound(ctx, w, err)
-		return
-	default:
-		httpx.WriteServerError(ctx, w, fmt.Errorf("sign repo head: %w", err))
-		return
-	}
-
-	blocks, err := s.store.ListRecordBlocks(ctx, spaceURI, repoDID)
+	// Read the repo's signed head commit and its record blocks as of the same
+	// point (see RepoSnapshot), so the commit always agrees with the blocks
+	// the CAR actually carries. An empty repo has no state to recover, so it
+	// reports as not found.
+	commit, blocks, err := s.store.RepoSnapshot(ctx, spaceURI, repoDID)
 	if errors.Is(err, ErrSpaceNotFound) {
 		httpx.WriteSpaceNotFound(ctx, w, err)
 		return
 	} else if err != nil {
-		httpx.WriteServerError(ctx, w, fmt.Errorf("list blocks: %w", err))
+		httpx.WriteServerError(ctx, w, fmt.Errorf("repo snapshot: %w", err))
+		return
+	}
+	if commit == nil {
+		httpx.WriteRepoNotFound(ctx, w, ErrRepoNotFound)
 		return
 	}
 
-	carBytes, err := SerializeRepoCAR(commit, blocks)
+	// The signed commit is the CAR's first root.
+	carBytes, err := SerializeRepoCAR(*commit, blocks)
 	if err != nil {
 		httpx.WriteServerError(ctx, w, fmt.Errorf("serialize car: %w", err))
 		return
@@ -695,7 +682,7 @@ func (s *Server) ListRepoOps(w http.ResponseWriter, r *http.Request) {
 		limit = 100
 	}
 
-	records, err := s.store.ListRepoOps(ctx, spaceURI, repoDID, params.Since, limit)
+	records, commit, err := s.store.ListRepoOps(ctx, spaceURI, repoDID, params.Since, limit)
 	if errors.Is(err, ErrRevTooFar) {
 		httpx.WriteError(ctx, w, "RevNotFound",
 			"since revision is ahead of the repo head", http.StatusBadRequest)
@@ -725,59 +712,27 @@ func (s *Server) ListRepoOps(w http.ResponseWriter, r *http.Request) {
 		output.Cursor = records[len(records)-1].Rev
 	}
 
-	// When this page reaches the head of the oplog (fewer ops than the limit) and
-	// a signer is available for the repo owner, include the current signed commit
-	// so a syncer can authenticate the state it has folded up to this point.
-	if len(records) < limit {
-		commit, err := s.buildRepoCommit(ctx, spaceURI, repoDID)
-		switch err {
-		case nil:
-			output.Commit = commit
-		default:
-			httpx.WriteServerError(ctx, w, fmt.Errorf("build repo commit: %w", err))
-			return
-		}
+	// commit is only ever non-nil when the page reached the head of the
+	// oplog: the store reads the head and these ops inside the same locked
+	// transaction, so a syncer folding the ops and comparing its hash against
+	// this commit always sees the exact same state on both sides.
+	if commit != nil {
+		output.Commit = shapeSignedCommit(*commit)
 	}
 	httpx.WriteJSON(r.Context(), w, output)
 }
 
-// signRepoHead computes and signs the repo's current head commit over its cached
-// LtHash. It returns errEmptyRepo when the repo holds no records
-func (s *Server) signRepoHead(
-	ctx context.Context,
-	spaceURI habitat_syntax.SpaceURI,
-	repo syntax.DID,
-) (spacecommit.SignedCommit, error) {
-	rev, hash, found, err := s.store.RepoHead(ctx, spaceURI, repo)
-	if err != nil {
-		return spacecommit.SignedCommit{}, fmt.Errorf("repo head: %w", err)
-	}
-	if !found {
-		return spacecommit.SignedCommit{}, errEmptyRepo
-	}
-	return s.commit.Build(ctx, spaceURI, repo, rev, hash)
-}
-
-// buildRepoCommit signs the repo's current head and shapes it as the lexicon
-// signedCommit for JSON responses. It surfaces errEmptyRepo
-// from signRepoHead so callers can omit the commit.
-func (s *Server) buildRepoCommit(
-	ctx context.Context,
-	spaceURI habitat_syntax.SpaceURI,
-	repo syntax.DID,
-) (habitat.NetworkHabitatSpaceDefsSignedCommit, error) {
-	commit, err := s.signRepoHead(ctx, spaceURI, repo)
-	if err != nil {
-		return habitat.NetworkHabitatSpaceDefsSignedCommit{}, err
-	}
+// shapeSignedCommit shapes a domain signed commit as the lexicon signedCommit
+// for JSON responses.
+func shapeSignedCommit(c spacecommit.SignedCommit) habitat.NetworkHabitatSpaceDefsSignedCommit {
 	return habitat.NetworkHabitatSpaceDefsSignedCommit{
-		Ver:  int64(commit.Ver),
-		Hash: commit.Hash,
-		Ikm:  commit.Ikm,
-		Mac:  commit.Mac,
-		Sig:  commit.Sig,
-		Rev:  commit.Rev,
-	}, nil
+		Ver:  int64(c.Ver),
+		Hash: c.Hash,
+		Ikm:  c.Ikm,
+		Mac:  c.Mac,
+		Sig:  c.Sig,
+		Rev:  c.Rev,
+	}
 }
 
 // GetLatestCommit returns the current signed commit over a repo's head state
@@ -811,18 +766,19 @@ func (s *Server) GetLatestCommit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	commit, err := s.buildRepoCommit(ctx, spaceURI, repoDID)
-	switch {
-	case err == nil:
-	case errors.Is(err, errEmptyRepo):
-		httpx.WriteRepoNotFound(ctx, w, err)
+	commit, err := s.store.RepoHeadCommit(ctx, spaceURI, repoDID)
+	if err != nil {
+		httpx.WriteServerError(ctx, w, fmt.Errorf("repo head commit: %w", err))
 		return
-	default:
-		httpx.WriteServerError(ctx, w, fmt.Errorf("build repo commit: %w", err))
+	}
+	if commit == nil {
+		httpx.WriteRepoNotFound(ctx, w, ErrRepoNotFound)
 		return
 	}
 
-	httpx.WriteJSON(ctx, w, habitat.NetworkHabitatSpaceGetLatestCommitOutput{Commit: commit})
+	httpx.WriteJSON(ctx, w, habitat.NetworkHabitatSpaceGetLatestCommitOutput{
+		Commit: shapeSignedCommit(*commit),
+	})
 }
 
 func (s *Server) DeleteRecord(w http.ResponseWriter, r *http.Request) {

--- a/internal/spaces/server_test.go
+++ b/internal/spaces/server_test.go
@@ -57,7 +57,7 @@ func newTestServerWithOpts(t *testing.T, opts testServerOptions) *testServer {
 		opts.validator = authntest.NewSuccessValidatorWithOrg(owner, orgId)
 	}
 	if opts.store == nil {
-		opts.store = spaces_testutil.NewTestStore(t)
+		opts.store = spaces_testutil.NewTestStore(t, spaces_testutil.Config{HostKey: opts.hostKey})
 	}
 	h, err := hive.NewHive("example.com", "pear.example.com", db_testutil.NewDB(t))
 	require.NoError(t, err)

--- a/internal/spaces/spaces.go
+++ b/internal/spaces/spaces.go
@@ -157,11 +157,17 @@ type Store interface {
 		repo syntax.DID,
 		collection *syntax.NSID,
 	) ([]Record, error)
-	ListRecordBlocks(
+	// RepoSnapshot returns a repo's signed head commit together with its record
+	// blocks, read as of the same point: on Postgres both reads happen inside
+	// the same advisory-locked transaction PutRecord/DeleteRecord use, so a
+	// concurrent write cannot land between them, and the commit is built from
+	// that same frozen rev/hash. commit is nil when the repo holds no records
+	// in the space.
+	RepoSnapshot(
 		ctx context.Context,
 		space habitat_syntax.SpaceURI,
 		repo syntax.DID,
-	) ([]recordBlock, error)
+	) (commit *spacecommit.SignedCommit, blocks []recordBlock, err error)
 	DeleteRecord(
 		ctx context.Context,
 		space habitat_syntax.SpaceURI,
@@ -174,14 +180,19 @@ type Store interface {
 	// Oplog operations
 	//
 	// ListRepoOps returns a repo's operations within a space after a given
-	// revision, ordered by revision ascending, for incremental sync.
+	// revision, ordered by revision ascending, for incremental sync. When this
+	// page reaches the head of the oplog, commit is the signed commit over
+	// exactly the state these ops leave the caller at — the head is read inside
+	// the same locked transaction as the ops, so it can never describe a write
+	// that landed between the two reads. commit is nil when the page does not
+	// reach the head, or the repo has no records to sign a commit over.
 	ListRepoOps(
 		ctx context.Context,
 		space habitat_syntax.SpaceURI,
 		repo syntax.DID,
 		since string,
 		limit int,
-	) ([]Record, error)
+	) (ops []Record, commit *spacecommit.SignedCommit, err error)
 
 	// RepoHead returns a repo's current head revision and LtHash commit hash.
 	// found is false when the repo holds no records in the space.
@@ -190,6 +201,14 @@ type Store interface {
 		space habitat_syntax.SpaceURI,
 		repo syntax.DID,
 	) (rev string, hash []byte, found bool, err error)
+
+	// RepoHeadCommit returns the signed commit over a repo's current head
+	// state. commit is nil when the repo holds no records in the space.
+	RepoHeadCommit(
+		ctx context.Context,
+		space habitat_syntax.SpaceURI,
+		repo syntax.DID,
+	) (commit *spacecommit.SignedCommit, err error)
 
 	// WithTx returns a copy of the store scoped to the given transaction, so its
 	// DB writes participate in a caller-managed transaction. FGA writes are not
@@ -232,17 +251,20 @@ type store struct {
 	clock      *syntax.TIDClock
 	eventStore events.Store
 	notifier   Notifier
+	commit     *spacecommit.Authority
 }
 
 var _ Store = &store{}
 
 // NewStore creates a spaces store. notifier may be nil to disable notifyWrite
-// delivery.
+// delivery. commit signs the repo-head commits RepoSnapshot, ListRepoOps, and
+// RepoHeadCommit build.
 func NewStore(
 	db *gorm.DB,
 	fga fgastore.Store,
 	eventStore events.Store,
 	notifier Notifier,
+	commit *spacecommit.Authority,
 ) (*store, error) {
 	if err := db.AutoMigrate(&space{}, &spaceRecord{}, &spaceRepo{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate spaces tables: %w", err)
@@ -253,6 +275,7 @@ func NewStore(
 		clock:      syntax.NewTIDClock(0),
 		eventStore: eventStore,
 		notifier:   notifier,
+		commit:     commit,
 	}, nil
 }
 
@@ -264,6 +287,7 @@ func (s *store) WithTx(tx *gorm.DB) Store {
 		clock:      s.clock,
 		eventStore: s.eventStore,
 		notifier:   s.notifier,
+		commit:     s.commit,
 	}
 }
 
@@ -398,6 +422,23 @@ func saveRepoHash(
 		Hash:  h.State(),
 		Rev:   rev,
 	}).Error
+}
+
+// lockRepo acquires the per-repo advisory lock PutRecord/DeleteRecord hold for
+// their whole write, so a read inside the same transaction cannot race a
+// concurrent writer: it blocks until an in-flight write finishes and holds the
+// lock until the read commits. It is a no-op outside Postgres, where SQLite
+// serializes whole transactions already.
+func lockRepo(tx *gorm.DB, space habitat_syntax.SpaceURI, repo syntax.DID) error {
+	if tx.Name() != "postgres" {
+		return nil
+	}
+	if err := tx.Exec(
+		`SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))`, space, repo,
+	).Error; err != nil {
+		return fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	return nil
 }
 
 func (s *store) ListRepos(
@@ -593,15 +634,8 @@ func (s *store) PutRecord(
 	var newRev syntax.TID
 	var repoHash []byte
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if tx.Name() == "postgres" {
-			// acquire lock on permissioned repo within space
-			if err := tx.Exec(
-				`SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))`,
-				spaceUri,
-				repo,
-			).Error; err != nil {
-				return fmt.Errorf("failed to acquire lock: %w", err)
-			}
+		if err := lockRepo(tx, spaceUri, repo); err != nil {
+			return err
 		}
 		action := "update"
 		var prev spaceRecord
@@ -757,40 +791,75 @@ func (s *store) ListRecords(
 	return records, nil
 }
 
-func (s *store) ListRecordBlocks(
+func (s *store) RepoSnapshot(
 	ctx context.Context,
 	uri habitat_syntax.SpaceURI,
 	repo syntax.DID,
-) ([]recordBlock, error) {
-	var sp space
-	err := s.db.WithContext(ctx).
-		Where("owner = ? AND skey = ?", uri.SpaceOwner(), uri.Skey()).
-		First(&sp).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrSpaceNotFound
-	} else if err != nil {
-		return nil, err
-	}
-
-	var rows []spaceRecord
-	if err := s.db.WithContext(ctx).
-		Where("space = ?", uri).
-		Where("repo = ?", repo).
-		Order("collection ASC, rkey ASC").
-		Find(&rows).Error; err != nil {
-		return nil, err
-	}
-
-	blocks := make([]recordBlock, len(rows))
-	for i, row := range rows {
-		blocks[i] = recordBlock{
-			Collection: row.Collection,
-			Rkey:       row.Rkey,
-			Cid:        cid.MustParse(row.Cid),
-			Bytes:      row.Value,
+) (commit *spacecommit.SignedCommit, blocks []recordBlock, err error) {
+	var revision string
+	var hash []byte
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// The same per-repo lock PutRecord/DeleteRecord hold for their
+		// whole write blocks until this read finishes, and blocks any new
+		// writer from starting until it does: the head and the blocks
+		// below are read as of the same point, with nothing landing
+		// between them.
+		if err := lockRepo(tx, uri, repo); err != nil {
+			return err
 		}
+
+		var sp space
+		err := tx.
+			Where("owner = ? AND skey = ?", uri.SpaceOwner(), uri.Skey()).
+			First(&sp).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrSpaceNotFound
+		} else if err != nil {
+			return err
+		}
+
+		h, rev, ok, err := loadRepoHash(tx, uri, repo)
+		if err != nil {
+			return fmt.Errorf("repo head: %w", err)
+		}
+		if !ok {
+			return nil
+		}
+		revision, hash = rev.String(), h.Sum()
+
+		var rows []spaceRecord
+		if err := tx.
+			Where("space = ?", uri).
+			Where("repo = ?", repo).
+			Order("collection ASC, rkey ASC").
+			Find(&rows).Error; err != nil {
+			return err
+		}
+		blocks = make([]recordBlock, len(rows))
+		for i, row := range rows {
+			blocks[i] = recordBlock{
+				Collection: row.Collection,
+				Rkey:       row.Rkey,
+				Cid:        cid.MustParse(row.Cid),
+				Bytes:      row.Value,
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
 	}
-	return blocks, nil
+	if revision == "" {
+		return nil, nil, nil
+	}
+	// Signing only needs the already-frozen rev/hash above, not another DB
+	// read, so it happens outside the transaction rather than holding the
+	// repo's write lock while it runs.
+	signed, err := s.commit.Build(ctx, uri, repo, revision, hash)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build commit: %w", err)
+	}
+	return &signed, blocks, nil
 }
 
 func (s *store) DeleteSpace(ctx context.Context, uri habitat_syntax.SpaceURI) error {
@@ -859,50 +928,64 @@ func (s *store) ListRepoOps(
 	repo syntax.DID,
 	since string,
 	limit int,
-) ([]Record, error) {
-	// A since beyond the repo's head revision is a client error: nothing will
-	// ever be listed after it, and an empty page would be indistinguishable
-	// from the normal at-head case. Syncers use the RevNotFound error to detect
-	// they are ahead of the host and resync from scratch.
-	if since != "" {
-		var head spaceRepo
-		err := s.db.WithContext(ctx).
-			Where("space = ? AND repo = ?", uri, repo).
-			First(&head).Error
-		if err == nil && since > string(head.Rev) {
-			return nil, ErrRevTooFar
-		}
-	}
-	query := s.db.WithContext(ctx).
-		Unscoped().
-		Model(&spaceRecord{}).
-		Where("space = ? AND repo = ?", uri, repo)
-	if since != "" {
-		query = query.Where("rev > ?", since)
-	}
+) (records []Record, commit *spacecommit.SignedCommit, err error) {
 	if limit <= 0 {
 		limit = 100
 	}
+	var headRev syntax.TID
+	var headHash []byte
+	var headFound bool
 	var rows []spaceRecord
-	if err := query.Order("rev ASC").Limit(limit).Find(&rows).Error; err != nil {
-		return nil, fmt.Errorf("list repo ops: %w", err)
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Read the head and the ops behind the same per-repo lock
+		// PutRecord/DeleteRecord hold for their whole write, so a
+		// concurrent write cannot land between the two reads below: the
+		// head this transaction sees always describes exactly the ops it
+		// sees, letting the commit built from it (below, once the lock is
+		// released) name precisely where this page leaves the caller.
+		if err := lockRepo(tx, uri, repo); err != nil {
+			return err
+		}
+
+		h, rev, found, err := loadRepoHash(tx, uri, repo)
+		if err != nil {
+			return fmt.Errorf("repo head: %w", err)
+		}
+		headRev, headHash, headFound = rev, h.Sum(), found
+		// A since beyond the repo's head revision is a client error: nothing
+		// will ever be listed after it, and an empty page would be
+		// indistinguishable from the normal at-head case. Syncers use the
+		// RevNotFound error to detect they are ahead of the host and resync
+		// from scratch.
+		if since != "" && found && since > string(rev) {
+			return ErrRevTooFar
+		}
+
+		query := tx.Unscoped().Model(&spaceRecord{}).Where("space = ? AND repo = ?", uri, repo)
+		if since != "" {
+			query = query.Where("rev > ?", since)
+		}
+		return query.Order("rev ASC").Limit(limit).Find(&rows).Error
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list repo ops: %w", err)
 	}
-	records := make([]Record, len(rows))
+
+	records = make([]Record, len(rows))
 	for i, row := range rows {
 		value, err := atdata.UnmarshalCBOR(row.Value)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if row.DeletedAt.Valid {
 			records[i] = Record{
 				Owner:      row.Repo,
 				Collection: row.Collection,
 				Rkey:       row.Rkey,
-				Value:      nil,
 				Rev:        string(row.Rev),
 				Prev:       row.PrevCid,
 				UpdatedAt:  row.DeletedAt.Time,
-				// empty cid
+				// empty cid and value
 			}
 		} else {
 			records[i] = Record{
@@ -917,7 +1000,14 @@ func (s *store) ListRepoOps(
 			}
 		}
 	}
-	return records, nil
+	if len(rows) < limit && headFound {
+		signed, err := s.commit.Build(ctx, uri, repo, headRev.String(), headHash)
+		if err != nil {
+			return nil, nil, fmt.Errorf("build commit: %w", err)
+		}
+		commit = &signed
+	}
+	return records, commit, nil
 }
 
 func (s *store) RepoHead(
@@ -935,6 +1025,26 @@ func (s *store) RepoHead(
 	return rev.String(), h.Sum(), true, nil
 }
 
+// RepoHeadCommit implements [Store].
+func (s *store) RepoHeadCommit(
+	ctx context.Context,
+	uri habitat_syntax.SpaceURI,
+	repo syntax.DID,
+) (commit *spacecommit.SignedCommit, err error) {
+	rev, hash, found, err := s.RepoHead(ctx, uri, repo)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	signed, err := s.commit.Build(ctx, uri, repo, rev, hash)
+	if err != nil {
+		return nil, fmt.Errorf("build commit: %w", err)
+	}
+	return &signed, nil
+}
+
 func (s *store) DeleteRecord(
 	ctx context.Context,
 	uri habitat_syntax.SpaceURI,
@@ -943,14 +1053,8 @@ func (s *store) DeleteRecord(
 	rkey string,
 ) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if tx.Name() == "postgres" {
-			if err := tx.Exec(
-				`SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))`,
-				uri,
-				repo,
-			).Error; err != nil {
-				return err
-			}
+		if err := lockRepo(tx, uri, repo); err != nil {
+			return err
 		}
 		var rows []spaceRecord
 		if err := tx.

--- a/internal/spaces/spaces.go
+++ b/internal/spaces/spaces.go
@@ -799,11 +799,6 @@ func (s *store) RepoSnapshot(
 	var revision string
 	var hash []byte
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// The same per-repo lock PutRecord/DeleteRecord hold for their
-		// whole write blocks until this read finishes, and blocks any new
-		// writer from starting until it does: the head and the blocks
-		// below are read as of the same point, with nothing landing
-		// between them.
 		if err := lockRepo(tx, uri, repo); err != nil {
 			return err
 		}
@@ -852,9 +847,6 @@ func (s *store) RepoSnapshot(
 	if revision == "" {
 		return nil, nil, nil
 	}
-	// Signing only needs the already-frozen rev/hash above, not another DB
-	// read, so it happens outside the transaction rather than holding the
-	// repo's write lock while it runs.
 	signed, err := s.commit.Build(ctx, uri, repo, revision, hash)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build commit: %w", err)
@@ -937,12 +929,6 @@ func (s *store) ListRepoOps(
 	var headFound bool
 	var rows []spaceRecord
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Read the head and the ops behind the same per-repo lock
-		// PutRecord/DeleteRecord hold for their whole write, so a
-		// concurrent write cannot land between the two reads below: the
-		// head this transaction sees always describes exactly the ops it
-		// sees, letting the commit built from it (below, once the lock is
-		// released) name precisely where this page leaves the caller.
 		if err := lockRepo(tx, uri, repo); err != nil {
 			return err
 		}
@@ -952,11 +938,6 @@ func (s *store) ListRepoOps(
 			return fmt.Errorf("repo head: %w", err)
 		}
 		headRev, headHash, headFound = rev, h.Sum(), found
-		// A since beyond the repo's head revision is a client error: nothing
-		// will ever be listed after it, and an empty page would be
-		// indistinguishable from the normal at-head case. Syncers use the
-		// RevNotFound error to detect they are ahead of the host and resync
-		// from scratch.
 		if since != "" && found && since > string(rev) {
 			return ErrRevTooFar
 		}

--- a/internal/spaces/spaces_test.go
+++ b/internal/spaces/spaces_test.go
@@ -528,7 +528,7 @@ func TestDeleteRecord(t *testing.T) {
 	_, err = s.GetRecord(t.Context(), uri, owner, coll, "rkey")
 	require.ErrorIs(t, err, spaces.ErrRecordNotFound)
 
-	ops, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
+	ops, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
 	require.Empty(t, ops[0].Cid)
@@ -666,7 +666,7 @@ func TestListRepoOps(t *testing.T) {
 	coll := syntax.NSID("network.habitat.note")
 
 	t.Run("empty", func(t *testing.T) {
-		records, err := s.ListRepoOps(ctx, uri, "did:web:unknown", "", 100)
+		records, _, err := s.ListRepoOps(ctx, uri, "did:web:unknown", "", 100)
 		require.NoError(t, err)
 		require.Len(t, records, 0)
 	})
@@ -678,19 +678,19 @@ func TestListRepoOps(t *testing.T) {
 		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k3", map[string]any{"x": 3})
 		require.NoError(t, err)
 
-		records, err := s.ListRepoOps(ctx, uri, owner, "", 1)
+		records, _, err := s.ListRepoOps(ctx, uri, owner, "", 1)
 		require.NoError(t, err)
 		require.Len(t, records, 1)
 		require.Equal(t, syntax.RecordKey("k1"), records[0].Rkey)
 
-		records, err = s.ListRepoOps(ctx, uri, owner, records[0].Rev, 100)
+		records, _, err = s.ListRepoOps(ctx, uri, owner, records[0].Rev, 100)
 		require.NoError(t, err)
 		require.Len(t, records, 1)
 		require.Equal(t, syntax.RecordKey("k3"), records[0].Rkey)
 
 		ownerLastRev := records[0].Rev
 
-		records, err = s.ListRepoOps(ctx, uri, alice, "", 100)
+		records, _, err = s.ListRepoOps(ctx, uri, alice, "", 100)
 		require.NoError(t, err)
 		require.Len(t, records, 1)
 		require.Equal(t, syntax.RecordKey("k2"), records[0].Rkey)
@@ -700,13 +700,13 @@ func TestListRepoOps(t *testing.T) {
 		require.NoError(t, s.DeleteRecord(ctx, uri, owner, coll, "k1"))
 		require.NoError(t, s.DeleteRecord(ctx, uri, alice, coll, "k2"))
 
-		records, err = s.ListRepoOps(ctx, uri, owner, ownerLastRev, 100)
+		records, _, err = s.ListRepoOps(ctx, uri, owner, ownerLastRev, 100)
 		require.NoError(t, err)
 		require.Len(t, records, 1)
 		require.Equal(t, syntax.RecordKey("k1"), records[0].Rkey)
 		require.Empty(t, records[0].Cid)
 
-		records, err = s.ListRepoOps(ctx, uri, alice, aliceLastRev, 100)
+		records, _, err = s.ListRepoOps(ctx, uri, alice, aliceLastRev, 100)
 		require.NoError(t, err)
 		require.Len(t, records, 1)
 		require.Equal(t, syntax.RecordKey("k2"), records[0].Rkey)
@@ -718,7 +718,7 @@ func TestListRepoOps(t *testing.T) {
 		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", map[string]any{"text": "hello"})
 		require.NoError(t, err)
 
-		records, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
+		records, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
 		require.NoError(t, err)
 		require.Len(t, records, 1)
 		require.Equal(t, "hello", records[0].Value["text"])
@@ -767,7 +767,7 @@ func TestListRepoOpsPrev(t *testing.T) {
 	require.NoError(t, err)
 
 	// An update overwrites in place: one op whose prev is the old cid.
-	ops, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
+	ops, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
 	require.Equal(t, cid1.String(), ops[0].Prev)
@@ -777,7 +777,7 @@ func TestListRepoOpsPrev(t *testing.T) {
 	// A delete soft-removes the row: one op whose prev is the last cid, with no
 	// cid and no value.
 	require.NoError(t, s.DeleteRecord(t.Context(), uri, owner, coll, "k1"))
-	ops, err = s.ListRepoOps(t.Context(), uri, owner, "", 100)
+	ops, _, err = s.ListRepoOps(t.Context(), uri, owner, "", 100)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
 	require.Equal(t, cid2.String(), ops[0].Prev)
@@ -796,7 +796,7 @@ func TestListRepoOpsPrevCreateIsEmpty(t *testing.T) {
 	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 1})
 	require.NoError(t, err)
 
-	ops, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
+	ops, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
 	require.Empty(t, ops[0].Prev)

--- a/internal/spaces/testutil/store.go
+++ b/internal/spaces/testutil/store.go
@@ -1,20 +1,34 @@
 package testutil
 
 import (
+	"context"
 	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/atcrypto"
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	db_testutil "github.com/habitat-network/habitat/internal/db/testutil"
 	"github.com/habitat-network/habitat/internal/events"
 	"github.com/habitat-network/habitat/internal/fgastore"
 	"github.com/habitat-network/habitat/internal/notify/testutil"
+	"github.com/habitat-network/habitat/internal/spacecommit"
 	"github.com/habitat-network/habitat/internal/spaces"
-	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 )
 
 type Config struct {
 	FgaStore fgastore.Store
 	DB       *gorm.DB
+	// HostKey signs repo-head commits for authors MemberSigner does not
+	// resolve. Generated fresh when unset.
+	HostKey atcrypto.PrivateKey
+	// MemberSigner resolves habitat-managed authors' own signing keys.
+	// Defaults to one that resolves none, since callers' fixture DIDs are
+	// never actually hive-managed identities — every commit falls back to
+	// HostKey.
+	MemberSigner spacecommit.MemberSigner
 }
 
 type TestStore struct {
@@ -22,6 +36,7 @@ type TestStore struct {
 	Notifier   *testutil.TestNotifier
 	EventStore events.Store
 	FGA        fgastore.Store
+	HostKey    atcrypto.PrivateKey
 }
 
 func NewTestStore(t *testing.T, cfgs ...Config) *TestStore {
@@ -39,10 +54,44 @@ func NewTestStore(t *testing.T, cfgs ...Config) *TestStore {
 	if cfg.DB == nil {
 		cfg.DB = db_testutil.NewDB(t)
 	}
+	if cfg.HostKey == nil {
+		key, err := atcrypto.GeneratePrivateKeyK256()
+		require.NoError(t, err)
+		cfg.HostKey = key
+	}
+	if cfg.MemberSigner == nil {
+		cfg.MemberSigner = noMemberSigner{}
+	}
 	eventStore, err := events.NewStore(cfg.DB)
 	require.NoError(t, err)
 	notifier := &testutil.TestNotifier{}
-	s, err := spaces.NewStore(cfg.DB, cfg.FgaStore, eventStore, notifier)
+	s, err := spaces.NewStore(
+		cfg.DB,
+		cfg.FgaStore,
+		eventStore,
+		notifier,
+		spacecommit.NewAuthority(cfg.HostKey, cfg.MemberSigner),
+	)
 	require.NoError(t, err)
-	return &TestStore{Store: s, Notifier: notifier, EventStore: eventStore, FGA: cfg.FgaStore}
+	return &TestStore{
+		Store:      s,
+		Notifier:   notifier,
+		EventStore: eventStore,
+		FGA:        cfg.FgaStore,
+		HostKey:    cfg.HostKey,
+	}
+}
+
+// FGAStore exposes the underlying FGA store for tests that rebuild a Server
+// against an existing test store.
+func (t *TestStore) FGAStore() fgastore.Store { return t.FGA }
+
+// noMemberSigner never resolves a habitat-managed signer, so Authority.Build
+// always falls back to the host key.
+type noMemberSigner struct{}
+
+func (noMemberSigner) PrivateKeyForDID(
+	context.Context, syntax.DID,
+) (atcrypto.PrivateKey, error) {
+	return nil, identity.ErrDIDNotFound
 }


### PR DESCRIPTION
## Summary
- Move repo-head commit signing from the server into the spaces store: `RepoSnapshot` (formerly `ListRecordBlocks`), `ListRepoOps`, and new `RepoHeadCommit` return signed commits read atomically with their records under the same per-repo advisory lock writes use, so a commit always matches the state it accompanies.
- Return signed commits as pointers (`nil` = empty repo / page not at head), replacing separate `found`/`hasCommit` booleans, and extract advisory-lock acquisition into a shared `lockRepo` helper.
- `NewStore` now takes the commit-signing `spacecommit.Authority`; the server shapes store-built commits for JSON/CAR responses instead of signing itself.

## Test Plan
- `go test ./...` passes; `go vet`/`gofmt` clean.

<!-- branch-stack-start -->

<!-- branch-stack-end -->
