### PR TITLE
[oauthclient] Add single-session-per-user option to gorm store

### DIFF
--- a/pkg/oauthclient/gormstore.go
+++ b/pkg/oauthclient/gormstore.go
@@ -32,17 +32,50 @@ type authRequestRow struct {
 func (authRequestRow) TableName() string { return "client_auth_requests" }
 
 type gormStore struct {
-	db *gorm.DB
+	db                *gorm.DB
+	singleSessionUser bool
+}
+
+// singleSessionID is the session ID used to key sessions when
+// WithSingleSessionPerUser is enabled. It is deliberately non-empty so GORM's
+// Save() still upserts on the composite primary key; the real session ID lives
+// in the session data JSON.
+const singleSessionID = "single-session"
+
+// Option configures the GORM-backed ClientAuthStore.
+type Option func(*gormStore)
+
+// WithSingleSessionPerUser keeps at most one session per DID by ignoring the
+// session ID: all sessions are stored and looked up under a fixed session ID,
+// so the most recently saved session replaces any earlier one for the DID.
+func WithSingleSessionPerUser() Option {
+	return func(s *gormStore) {
+		s.singleSessionUser = true
+	}
 }
 
 var _ oauth.ClientAuthStore = (*gormStore)(nil)
 
 // NewGormStore creates a ClientAuthStore backed by GORM.
-func NewGormStore(db *gorm.DB) (oauth.ClientAuthStore, error) {
+func NewGormStore(db *gorm.DB, opts ...Option) (oauth.ClientAuthStore, error) {
 	if err := db.AutoMigrate(&sessionRow{}, &authRequestRow{}); err != nil {
 		return nil, fmt.Errorf("migrate gormstore: %w", err)
 	}
-	return &gormStore{db: db}, nil
+	s := &gormStore{db: db}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s, nil
+}
+
+// sessionID returns the session ID to use for storage and lookups. With
+// single-session-per-user enabled the ID is ignored so only one row exists per
+// DID.
+func (s *gormStore) sessionID(id string) string {
+	if s.singleSessionUser {
+		return singleSessionID
+	}
+	return id
 }
 
 // GetSession implements oauth.ClientAuthStore.
@@ -53,7 +86,7 @@ func (s *gormStore) GetSession(
 ) (*oauth.ClientSessionData, error) {
 	var row sessionRow
 	if err := s.db.WithContext(ctx).
-		Where("did = ? AND session_id = ?", did.String(), sessionID).
+		Where("did = ? AND session_id = ?", did.String(), s.sessionID(sessionID)).
 		First(&row).Error; err != nil {
 		return nil, err
 	}
@@ -74,17 +107,18 @@ func (s *gormStore) SaveSession(ctx context.Context, sess oauth.ClientSessionDat
 	if err != nil {
 		return fmt.Errorf("extract session key: %w", err)
 	}
-	return s.db.WithContext(ctx).Save(&sessionRow{
+	row := &sessionRow{
 		DID:       key.DID,
-		SessionID: key.SessionID,
+		SessionID: s.sessionID(key.SessionID),
 		Data:      data,
-	}).Error
+	}
+	return s.db.WithContext(ctx).Save(row).Error
 }
 
 // DeleteSession implements oauth.ClientAuthStore.
 func (s *gormStore) DeleteSession(ctx context.Context, did syntax.DID, sessionID string) error {
 	return s.db.WithContext(ctx).
-		Where("did = ? AND session_id = ?", did.String(), sessionID).
+		Where("did = ? AND session_id = ?", did.String(), s.sessionID(sessionID)).
 		Delete(&sessionRow{}).Error
 }
 

--- a/pkg/oauthclient/gormstore.go
+++ b/pkg/oauthclient/gormstore.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/auth/oauth"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/utils"
 	"gorm.io/gorm"
 )
 
@@ -42,13 +43,10 @@ type gormStore struct {
 // in the session data JSON.
 const singleSessionID = "single-session"
 
-// Option configures the GORM-backed ClientAuthStore.
-type Option func(*gormStore)
-
 // WithSingleSessionPerUser keeps at most one session per DID by ignoring the
 // session ID: all sessions are stored and looked up under a fixed session ID,
 // so the most recently saved session replaces any earlier one for the DID.
-func WithSingleSessionPerUser() Option {
+func WithSingleSessionPerUser() utils.Opt[gormStore] {
 	return func(s *gormStore) {
 		s.singleSessionUser = true
 	}
@@ -57,15 +55,13 @@ func WithSingleSessionPerUser() Option {
 var _ oauth.ClientAuthStore = (*gormStore)(nil)
 
 // NewGormStore creates a ClientAuthStore backed by GORM.
-func NewGormStore(db *gorm.DB, opts ...Option) (oauth.ClientAuthStore, error) {
+func NewGormStore(db *gorm.DB, opts ...utils.Opt[gormStore]) (oauth.ClientAuthStore, error) {
 	if err := db.AutoMigrate(&sessionRow{}, &authRequestRow{}); err != nil {
 		return nil, fmt.Errorf("migrate gormstore: %w", err)
 	}
-	s := &gormStore{db: db}
-	for _, opt := range opts {
-		opt(s)
-	}
-	return s, nil
+	s := utils.ResolveOptions(opts...)
+	s.db = db
+	return &s, nil
 }
 
 // sessionID returns the session ID to use for storage and lookups. With

--- a/pkg/oauthclient/gormstore_test.go
+++ b/pkg/oauthclient/gormstore_test.go
@@ -88,3 +88,60 @@ func TestStore_UpdateExistingSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"read", "write"}, got.Scopes)
 }
+
+func TestStore_SingleSessionPerUser(t *testing.T) {
+	store, err := NewGormStore(testutil.NewDB(t), WithSingleSessionPerUser())
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveSession(context.Background(), oauth.ClientSessionData{
+		AccountDID: "did:plc:test",
+		SessionID:  "sess1",
+		Scopes:     []string{"read"},
+	}))
+	require.NoError(t, store.SaveSession(context.Background(), oauth.ClientSessionData{
+		AccountDID: "did:plc:test",
+		SessionID:  "sess2",
+		Scopes:     []string{"read", "write"},
+	}))
+
+	got, err := store.GetSession(context.Background(), "did:plc:test", "sess1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"read", "write"}, got.Scopes)
+	require.Equal(t, "sess2", got.SessionID)
+}
+
+func TestStore_SingleSessionPerUser_DeleteIgnoresSessionID(t *testing.T) {
+	store, err := NewGormStore(testutil.NewDB(t), WithSingleSessionPerUser())
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveSession(context.Background(), oauth.ClientSessionData{
+		AccountDID: "did:plc:test",
+		SessionID:  "sess1",
+	}))
+
+	require.NoError(t, store.DeleteSession(context.Background(), "did:plc:test", "some-other-id"))
+
+	_, err = store.GetSession(context.Background(), "did:plc:test", "any-id")
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestStore_SingleSessionPerUser_IsolatedPerDID(t *testing.T) {
+	store, err := NewGormStore(testutil.NewDB(t), WithSingleSessionPerUser())
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveSession(context.Background(), oauth.ClientSessionData{
+		AccountDID: "did:plc:test",
+		SessionID:  "sess1",
+		Scopes:     []string{"read"},
+	}))
+	require.NoError(t, store.SaveSession(context.Background(), oauth.ClientSessionData{
+		AccountDID: "did:plc:other",
+		SessionID:  "sess9",
+		Scopes:     []string{"write"},
+	}))
+
+	got, err := store.GetSession(context.Background(), "did:plc:test", "unrelated-id")
+	require.NoError(t, err)
+	require.Equal(t, []string{"read"}, got.Scopes)
+	require.Equal(t, "sess1", got.SessionID)
+}


### PR DESCRIPTION
## Summary
- Add a functional option `WithSingleSessionPerUser()` to `NewGormStore` (variadic, existing callers unaffected).
- When enabled, the session ID is ignored and all sessions are keyed under a fixed sentinel ID, so at most one session exists per DID; the most recent save replaces earlier ones.
- `GetSession`/`DeleteSession` also ignore the passed session ID in this mode.

## Test Plan
- Added 3 tests: latest-session-wins, delete-by-DID-only, per-DID isolation.
- `go test ./pkg/oauthclient/`, `golangci-lint`, and `go build ./...` pass.