### PR TITLE
[Sap] Add TrackSpace to track a space without a crawl

### DIFF
--- a/pkg/sap/crawl/crawl.go
+++ b/pkg/sap/crawl/crawl.go
@@ -286,19 +286,8 @@ func (c *Crawler) crawlSession(
 		}
 		for _, sp := range output.Spaces {
 			space := habitat_syntax.SpaceURI(sp.Uri)
-			if err := c.access.RecordSpaceAccess(ctx, space, did, sessionID); err != nil {
-				return fmt.Errorf("record space access %s: %w", space, err)
-			}
-			// Subscribe to the space's push notifications as soon as we know
-			// about it. Best-effort: the registrar's sweep retries misses.
-			if c.notify != nil {
-				if err := c.notify.EnsureRegistered(ctx, space); err != nil {
-					slog.WarnContext(ctx, "register notify during crawl",
-						"space", space, "err", err)
-				}
-			}
-			if err := c.enumerateRepos(ctx, space); err != nil {
-				return fmt.Errorf("enumerate repos for %s: %w", space, err)
+			if err := c.TrackSpace(ctx, space, did, sessionID); err != nil {
+				return err
 			}
 		}
 
@@ -312,6 +301,34 @@ func (c *Crawler) crawlSession(
 			return fmt.Errorf("save crawl cursor: %w", err)
 		}
 	}
+}
+
+// TrackSpace records that (did, sessionID) can access space and syncs the
+// space's repos, exactly as if a crawl's listSpaces had just returned it. It
+// is the entry point for a space the caller already knows about — say, one
+// named by an out-of-band notification or an invite — without waiting for the
+// session's next crawl.
+func (c *Crawler) TrackSpace(
+	ctx context.Context,
+	space habitat_syntax.SpaceURI,
+	did syntax.DID,
+	sessionID string,
+) error {
+	if err := c.access.RecordSpaceAccess(ctx, space, did, sessionID); err != nil {
+		return fmt.Errorf("record space access %s: %w", space, err)
+	}
+	// Subscribe to the space's push notifications as soon as we know about
+	// it. Best-effort: the registrar's sweep retries misses.
+	if c.notify != nil {
+		if err := c.notify.EnsureRegistered(ctx, space); err != nil {
+			slog.WarnContext(ctx, "register notify for space",
+				"space", space, "err", err)
+		}
+	}
+	if err := c.enumerateRepos(ctx, space); err != nil {
+		return fmt.Errorf("enumerate repos for %s: %w", space, err)
+	}
+	return nil
 }
 
 func (c *Crawler) enumerateRepos(

--- a/pkg/sap/crawl/crawl_test.go
+++ b/pkg/sap/crawl/crawl_test.go
@@ -75,21 +75,25 @@ func newOAuthApp(t *testing.T, base *url.URL, did syntax.DID, sessionID string) 
 
 // recorder collects space access records and tracked repos.
 type recorder struct {
-	mu      sync.Mutex
-	access  []habitat_syntax.SpaceURI
-	tracked []syntax.DID
-	checks  []syntax.DID
+	mu             sync.Mutex
+	access         []habitat_syntax.SpaceURI
+	accessDIDs     []syntax.DID
+	accessSessions []string
+	tracked        []syntax.DID
+	checks         []syntax.DID
 }
 
 func (r *recorder) RecordSpaceAccess(
 	_ context.Context,
 	space habitat_syntax.SpaceURI,
-	_ syntax.DID,
-	_ string,
+	did syntax.DID,
+	sessionID string,
 ) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.access = append(r.access, space)
+	r.accessDIDs = append(r.accessDIDs, did)
+	r.accessSessions = append(r.accessSessions, sessionID)
 	return nil
 }
 
@@ -351,4 +355,43 @@ func TestCrawlerChecksRepoRevAndHash(t *testing.T) {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 	require.Contains(t, rec.checks, repoDID)
+}
+
+// TestCrawlerTrackSpace verifies that TrackSpace records access for the
+// (did, sessionID) pair, registers the space for notifications, and
+// enumerates/checks its repos — the same steps a listSpaces discovery takes.
+func TestCrawlerTrackSpace(t *testing.T) {
+	t.Parallel()
+
+	space := habitat_syntax.SpaceURI("ats://did:web:owner/network.habitat.space/s1")
+	repoDID := syntax.DID("did:web:alice")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/xrpc/network.habitat.space.listRepos":
+			_ = json.NewEncoder(w).Encode(habitat.NetworkHabitatSpaceListReposOutput{
+				Repos: []habitat.NetworkHabitatSpaceListReposRepo{
+					{Did: repoDID.String(), Rev: "3lrev2", Hash: "aGFzaA=="},
+				},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	rec := &recorder{}
+	nr := &fakeNotifyRegistrar{}
+	base := mustParseURL(t, srv.URL)
+	c, err := New(db_testutil.NewDB(t), nil, rec, fakeClients{base: base}, rec, nr, nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, c.TrackSpace(t.Context(), space, "did:web:bob", "sess1"))
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	require.Equal(t, []habitat_syntax.SpaceURI{space}, rec.access)
+	require.Equal(t, []syntax.DID{"did:web:bob"}, rec.accessDIDs)
+	require.Equal(t, []string{"sess1"}, rec.accessSessions)
+	require.Contains(t, rec.checks, repoDID)
+	require.True(t, nr.called)
 }

--- a/pkg/sap/sap.go
+++ b/pkg/sap/sap.go
@@ -249,6 +249,20 @@ func (s *Sap) NotifyWrite(
 	return s.engine.NotifyWrite(ctx, space, repo, rev, hash)
 }
 
+// TrackSpace tracks a space sap wouldn't discover through a session's crawl —
+// e.g. one the caller learned about out of band (an invite, an external
+// notification). It records that (did, sessionID) can access the space,
+// registers the space for notifications, and syncs its repos, exactly as if
+// the session's listSpaces had returned it.
+func (s *Sap) TrackSpace(
+	ctx context.Context,
+	space habitat_syntax.SpaceURI,
+	did syntax.DID,
+	sessionID string,
+) error {
+	return s.crawler.TrackSpace(ctx, space, did, sessionID)
+}
+
 // NotifySpaceDeleted reacts to a host's notifySpaceDeleted: all local tracking
 // state for the space is dropped.
 func (s *Sap) NotifySpaceDeleted(

--- a/pkg/sap/sap_test.go
+++ b/pkg/sap/sap_test.go
@@ -253,6 +253,99 @@ func TestSap(t *testing.T) {
 	}
 }
 
+// TestSapTrackSpace verifies that TrackSpace tracks a space the same way the
+// crawl would if its listSpaces discovered it — recording space access,
+// registering for notifications, and syncing the space's repos — without the
+// session ever being crawled. The session is never added, so only TrackSpace
+// can discover the space.
+func TestSapTrackSpace(t *testing.T) {
+	// Configure default transport to skip TLS verification for the test
+	// servers (sap's credential exchange and repo-host reads).
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	pear := setupPear(t)
+	t.Cleanup(func() {
+		pear.server.CloseClientConnections()
+		pear.server.Close()
+	})
+	author := pear.author.DID
+
+	groupType := syntax.NSID("network.habitat.group")
+	collection := syntax.NSID("network.habitat.test")
+	space, err := pear.store.CreateSpace(
+		t.Context(), author, author, groupType, habitat_syntax.SpaceKey("tracked-space"),
+	)
+	require.NoError(t, err)
+	recURI, _, err := pear.store.PutRecord(
+		t.Context(), space, author, collection,
+		syntax.RecordKey("rkey-0"), map[string]any{"data": "tracked"},
+	)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	sapServer := httptest.NewTLSServer(mux)
+	t.Cleanup(sapServer.Close)
+
+	db := db_testutil.NewDB(t)
+	store, err := oauthclient.NewGormStore(db)
+	require.NoError(t, err)
+	cfg := oauth.NewPublicConfig(
+		sapServer.URL+"/client-metadata.json",
+		sapServer.URL+"/oauth-callback",
+		[]string{},
+	)
+	oauthApp := oauth.NewClientApp(&cfg, store)
+
+	s, err := New(Config{
+		DB:          db,
+		OAuthClient: oauthApp,
+		Directory:   pear.hive,
+		Endpoint:    sapServer.URL,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go func() {
+		require.NoError(t, s.Start(ctx))
+	}()
+
+	// The session is resumable for TrackSpace's space-credential delegation,
+	// but is never added, so no crawl discovers the space.
+	require.NoError(t, store.SaveSession(t.Context(), oauth.ClientSessionData{
+		AccountDID:              author,
+		SessionID:               "sess1",
+		HostURL:                 pear.server.URL,
+		AccessToken:             futureJWT(t),
+		DPoPPrivateKeyMultibase: testDPoPKey(t),
+	}))
+
+	require.NoError(t, s.TrackSpace(t.Context(), space, author, "sess1"))
+
+	// The space's record lands in the outbox, as it would after a crawl.
+	var got []outbox.Message
+	require.Eventually(t, func() bool {
+		var err error
+		got, err = s.Outbox().Poll(t.Context(), 10)
+		require.NoError(t, err)
+		return len(got) >= 1
+	}, 15*time.Second, 100*time.Millisecond)
+	for _, msg := range got {
+		require.Equal(t, recURI.String(), string(msg.URI))
+	}
+
+	// The space is registered for notifications and its repo is tracked.
+	var regCount int64
+	require.NoError(t, db.Table("registrations").Count(&regCount).Error)
+	require.Equal(t, int64(1), regCount)
+
+	var repoCount int64
+	require.NoError(t, db.Table("repos").Count(&repoCount).Error)
+	require.Equal(t, int64(1), repoCount)
+}
+
 // pearHost bundles the host-side pieces the test drives.
 type pearHost struct {
 	server *httptest.Server


### PR DESCRIPTION
## Summary
- Add `Sap.TrackSpace(space, did, sessionID)` so a space can be tracked without waiting for a session crawl — useful for spaces learned out of band (invites, external notifications).
- Extract the crawler's per-space listSpaces discovery (record space access, best-effort notify registration, listRepos → Check) into `Crawler.TrackSpace`, reused by the crawl loop so both paths are identical.
- Tests: `TestCrawlerTrackSpace` (unit) and `TestSapTrackSpace` (integration, space synced to the outbox + registered without a crawl).

## Test Plan
- [x] `go test ./pkg/sap/...`
- [x] `golangci-lint run ./pkg/sap/...`