### PR TITLE
Add OTel-instrumented HTTP client to httpx

### DIFF
--- a/cmd/home/pearclient.go
+++ b/cmd/home/pearclient.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/auth/oauth"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/habitat-network/habitat/api/habitat"
+	"github.com/habitat-network/habitat/internal/httpx"
 	habitat_syntax "github.com/habitat-network/habitat/internal/syntax"
 )
 
@@ -61,7 +62,7 @@ func (p *pearClient) get(ctx context.Context, nsid syntax.NSID, params url.Value
 }
 
 func (p *pearClient) do(req *http.Request, nsid syntax.NSID, out any) error {
-	resp, err := p.session.DoWithAuth(http.DefaultClient, req, nsid)
+	resp, err := p.session.DoWithAuth(httpx.NewClient(), req, nsid)
 	if err != nil {
 		return fmt.Errorf("call %s: %w", nsid, err)
 	}

--- a/cmd/pear/main.go
+++ b/cmd/pear/main.go
@@ -341,7 +341,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return fmt.Errorf("setup notify store: %w", err)
 	}
-	notifier := notify.NewNotifier(notifyStore, http.DefaultClient, hive)
+	notifier := notify.NewNotifier(notifyStore, httpx.NewClient(), hive)
 
 	spacesStore, err := spaces.NewStore(
 		db.WithContext(startupCtx),

--- a/cmd/search/server.go
+++ b/cmd/search/server.go
@@ -23,7 +23,7 @@ type Server struct {
 func NewServer(host string, index Index) *Server {
 	return &Server{
 		pearHost:   host,
-		httpClient: &http.Client{},
+		httpClient: httpx.NewClient(),
 		index:      index,
 	}
 }

--- a/internal/forwarding/pds_forwarding.go
+++ b/internal/forwarding/pds_forwarding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,10 +12,10 @@ import (
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/habitat-network/habitat/internal/authn"
+	"github.com/habitat-network/habitat/internal/httpx"
 	"github.com/habitat-network/habitat/internal/pdsclient"
 	"github.com/habitat-network/habitat/internal/pdscred"
 	"github.com/habitat-network/habitat/internal/utils"
-	"log/slog"
 )
 
 // targetRoutedMethods maps XRPC method names that should be forwarded to the
@@ -51,7 +52,7 @@ func NewPDSForwarding(
 		validator:        validator,
 		pdsClientFactory: pdsClientFactory,
 		dir:              dir,
-		plainHTTPClient:  &http.Client{},
+		plainHTTPClient:  httpx.NewClient(),
 	}
 }
 
@@ -61,7 +62,8 @@ func (p *PDSForwarding) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if paramName, ok := targetRoutedMethods[method]; ok {
 		target := r.URL.Query().Get(paramName)
 		if target == "" {
-			utils.LogAndHTTPError(r.Context(), w,
+			utils.LogAndHTTPError(
+				r.Context(), w,
 				fmt.Errorf("missing required query param: %s", paramName),
 				"[pds forwarding]: missing target param",
 				http.StatusBadRequest,
@@ -107,7 +109,8 @@ func (p *PDSForwarding) serveTargetPDS(
 
 	pdsEndpoint, ok := id.Services["atproto_pds"]
 	if !ok {
-		utils.LogAndHTTPError(r.Context(), w,
+		utils.LogAndHTTPError(
+			r.Context(), w,
 			fmt.Errorf("no atproto_pds service for %s", id.DID),
 			"[pds forwarding]: target has no PDS service",
 			http.StatusBadGateway,

--- a/internal/forwarding/service_proxy.go
+++ b/internal/forwarding/service_proxy.go
@@ -51,7 +51,7 @@ func NewServiceProxy(
 		validator:        validator,
 		hive:             hive,
 		dir:              dir,
-		httpClient:       &http.Client{},
+		httpClient:       httpx.NewClient(),
 		pdsClientFactory: clientFactory,
 	}
 

--- a/internal/httpx/client.go
+++ b/internal/httpx/client.go
@@ -1,0 +1,15 @@
+package httpx
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// NewClient returns an *http.Client instrumented with OpenTelemetry: each
+// outbound request gets a span and client metrics recorded against the global
+// tracer/meter providers (see internal/telemetry). It wraps http.DefaultTransport,
+// so every client returned shares the process-wide connection pool.
+func NewClient() *http.Client {
+	return &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+}

--- a/internal/httpx/client_test.go
+++ b/internal/httpx/client_test.go
@@ -1,0 +1,12 @@
+package httpx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultClient(t *testing.T) {
+	client := NewClient()
+	require.NotNil(t, client)
+}

--- a/internal/oauthserver/fosite_storage.go
+++ b/internal/oauthserver/fosite_storage.go
@@ -18,11 +18,11 @@ import (
 	"github.com/bluesky-social/indigo/atproto/auth/oauth"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	jose "github.com/go-jose/go-jose/v3"
+	"github.com/habitat-network/habitat/internal/httpx"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/fosite/handler/pkce"
 	"github.com/ory/fosite/handler/rfc7523"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"gorm.io/gorm"
@@ -253,7 +253,7 @@ func (s *store) fetchClientMetadata(
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 	// TODO: consider caching
-	cl := http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	cl := httpx.NewClient()
 	resp, err := cl.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch client metadata: %w", err)

--- a/internal/pdsclient/dpop.go
+++ b/internal/pdsclient/dpop.go
@@ -19,6 +19,7 @@ import (
 	jose "github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/google/uuid"
+	"github.com/habitat-network/habitat/internal/httpx"
 	"github.com/habitat-network/habitat/internal/pdscred"
 	"golang.org/x/sync/singleflight"
 )
@@ -192,7 +193,7 @@ func doInternal(
 	if hasBody {
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpx.NewClient().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +216,7 @@ func doInternal(
 	if err := sign(req2, nonceProvider, key, accessToken); err != nil {
 		return nil, err
 	}
-	return http.DefaultClient.Do(req2)
+	return httpx.NewClient().Do(req2)
 }
 
 func sign(

--- a/internal/pdsclient/dummy_client_factory.go
+++ b/internal/pdsclient/dummy_client_factory.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/httpx"
 )
 
 type DummyClientFactory struct {
@@ -32,5 +33,5 @@ func (d *dummyClient) Do(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 	req.URL = pdsUrl.ResolveReference(req.URL)
-	return http.DefaultClient.Do(req)
+	return httpx.NewClient().Do(req)
 }

--- a/internal/pdsclient/oauth_client.go
+++ b/internal/pdsclient/oauth_client.go
@@ -21,6 +21,7 @@ import (
 	jose "github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/habitat-network/habitat/internal/encrypt"
+	"github.com/habitat-network/habitat/internal/httpx"
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/oauth2"
 )
@@ -361,7 +362,7 @@ func fetchOAuthProtectedResource(i *identity.Identity) (*oauthProtectedResource,
 		return nil, err
 	}
 
-	resp, err := http.DefaultClient.Get(
+	resp, err := httpx.NewClient().Get(
 		wellKnownURL,
 	)
 	if err != nil {
@@ -401,7 +402,7 @@ func fetchOauthAuthorizationServer(
 	}
 
 	authServerURL.Path = "/.well-known/oauth-authorization-server"
-	resp, err := http.DefaultClient.Get(
+	resp, err := httpx.NewClient().Get(
 		authServerURL.String(),
 	)
 	if err != nil {

--- a/pkg/sap/sap.go
+++ b/pkg/sap/sap.go
@@ -13,12 +13,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/auth/oauth"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/httpx"
 	"github.com/habitat-network/habitat/internal/utils"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -98,7 +98,7 @@ func New(config Config) (*Sap, error) {
 	// of which session was used to obtain it — a space credential authorizes
 	// the space, not the member who fetched it. It asks sessions (which
 	// implements credential.Delegator) for a delegation token on demand.
-	credentials := credential.NewManager(config.Directory, &http.Client{}, sessions)
+	credentials := credential.NewManager(config.Directory, httpx.NewClient(), sessions)
 	ob, err := outbox.NewStore(config.DB, utils.NewPollNotifier())
 	if err != nil {
 		return nil, fmt.Errorf("create outbox store: %w", err)


### PR DESCRIPTION
## Summary
- Add `httpx.NewClient()` returning an `*http.Client` whose transport wraps `http.DefaultTransport` with `otelhttp`, so every outbound request gets an OTel span + client metrics against the global tracer/meter providers.
- Replace bare/default `http.Client` usages in production code with `httpx.NewClient()` (oauthserver, pdsclient, forwarding, sap, pear, home, search).

## Test Plan
- [ ] `go test ./...` passes in affected modules
- [ ] `go vet` and `golangci-lint` clean