### PR TITLE
Update Space URI scheme from `ats://` to `at://` with path restructuring

### DIFF
--- a/pkg/sap/crawl/crawl_test.go
+++ b/pkg/sap/crawl/crawl_test.go
@@ -126,7 +126,7 @@ func (r *recorder) Check(
 func TestCrawlerBackfillsSession(t *testing.T) {
 	t.Parallel()
 
-	space := "ats://did:plc:owner/network.habitat.space/s1"
+	space := "at://did:plc:owner/space/network.habitat.space/s1"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/xrpc/network.habitat.space.listSpaces":
@@ -257,7 +257,7 @@ func TestDetachCancel(t *testing.T) {
 func TestCrawlerEnumerateReposError(t *testing.T) {
 	t.Parallel()
 
-	space := "ats://did:plc:owner/network.habitat.space/s1"
+	space := "at://did:plc:owner/space/network.habitat.space/s1"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/xrpc/network.habitat.space.listSpaces":
@@ -289,7 +289,7 @@ func TestCrawlerEnumerateReposError(t *testing.T) {
 func TestCrawlerNotifyRegistration(t *testing.T) {
 	t.Parallel()
 
-	space := "ats://did:plc:owner/network.habitat.space/s1"
+	space := "at://did:plc:owner/space/network.habitat.space/s1"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/xrpc/network.habitat.space.listSpaces":
@@ -334,7 +334,7 @@ func mustParseURL(t *testing.T, raw string) *url.URL {
 // listRepos rev/hash against the tracker (so drift requeues) instead of only
 // tracking newly-seen repos.
 func TestCrawlerChecksRepoRevAndHash(t *testing.T) {
-	space := habitat_syntax.SpaceURI("ats://did:web:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:web:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:web:alice")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -373,7 +373,7 @@ func TestCrawlerChecksRepoRevAndHash(t *testing.T) {
 func TestCrawlerTrackSpace(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:web:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:web:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:web:alice")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/pkg/sap/outbox/outbox_test.go
+++ b/pkg/sap/outbox/outbox_test.go
@@ -17,7 +17,7 @@ func TestStoreEmitPollAck(t *testing.T) {
 	require.NoError(t, err)
 
 	uri := habitat_syntax.SpaceRecordURI(
-		"ats://did:plc:o/network.habitat.space/s1/did:plc:a/network.habitat.test/k1",
+		"at://did:plc:o/space/network.habitat.space/s1/did:plc:a/network.habitat.test/k1",
 	)
 	require.NoError(t, s.Emit(t.Context(), uri, []byte(`{"n":1}`)))
 	require.NoError(t, s.Emit(t.Context(), uri, []byte(`{"n":2}`)))

--- a/pkg/sap/register/register_test.go
+++ b/pkg/sap/register/register_test.go
@@ -54,7 +54,7 @@ func TestRegistrarRegistersDueSpaces(t *testing.T) {
 	require.NoError(t, err)
 
 	db := db_testutil.NewDB(t)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	reg, err := New(db, fakeClients{base: base}, fakeSpaces{space}, "https://sap.example")
 	require.NoError(t, err)
 
@@ -86,7 +86,7 @@ func TestRegistrarEnsureRegisteredAlreadyTracked(t *testing.T) {
 	base, _ := url.Parse(srv.URL)
 
 	db := db_testutil.NewDB(t)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	reg, err := New(db, fakeClients{base: base}, fakeSpaces{space}, "https://sap.example")
 	require.NoError(t, err)
 
@@ -111,7 +111,7 @@ func TestRegistrarDropSpace(t *testing.T) {
 	base, _ := url.Parse(srv.URL)
 
 	db := db_testutil.NewDB(t)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	reg, err := New(db, fakeClients{base: base}, fakeSpaces{space}, "https://sap.example")
 	require.NoError(t, err)
 
@@ -154,8 +154,8 @@ func TestRegistrarDueSpacesFiltersFresh(t *testing.T) {
 	base, _ := url.Parse(srv.URL)
 
 	db := db_testutil.NewDB(t)
-	space1 := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
-	space2 := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s2")
+	space1 := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
+	space2 := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s2")
 	reg, err := New(db, fakeClients{base: base}, fakeSpaces{space1, space2}, "https://sap.example")
 	require.NoError(t, err)
 

--- a/pkg/sap/session/session_test.go
+++ b/pkg/sap/session/session_test.go
@@ -88,7 +88,7 @@ func TestStoreSessionsAndSpaceAccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []Session{{DID: "did:plc:alice", SessionID: "sess1"}}, sessions)
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	require.NoError(t, s.RecordSpaceAccess(t.Context(), space, "did:plc:alice", "sess1"))
 	require.NoError(
 		t,

--- a/pkg/sap/syncer/syncer_test.go
+++ b/pkg/sap/syncer/syncer_test.go
@@ -83,7 +83,7 @@ func newTestEngine(t *testing.T, hostURL string) (*Engine, *memEmitter, *gorm.DB
 func TestEngineSyncRepoVerifiesAndSettles(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	clock := syntax.NewTIDClock(0)
 	rev1, rev2 := clock.Next().String(), clock.Next().String()
@@ -135,7 +135,7 @@ func TestEngineSyncRepoVerifiesAndSettles(t *testing.T) {
 func TestEngineNotifyWriteRequeues(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 
 	require.NoError(t, e.NotifyWrite(t.Context(), space, "did:plc:new", "aaa", nil))
@@ -157,7 +157,7 @@ func TestEngineNotifyWriteRequeues(t *testing.T) {
 func TestEngineSyncRepoSinceAheadMarksDesynced(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -220,7 +220,7 @@ func TestEngineWithTx(t *testing.T) {
 func TestEngineDropSpace(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:bob"))
@@ -240,7 +240,7 @@ func TestEngineDropSpace(t *testing.T) {
 func TestEngineNotifyWriteSyncingMarksDirty(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
@@ -259,7 +259,7 @@ func TestEngineNotifyWriteSyncingMarksDirty(t *testing.T) {
 func TestEngineNotifyWriteAlreadyBehindHash(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
@@ -278,7 +278,7 @@ func TestEngineNotifyWriteAlreadyBehindHash(t *testing.T) {
 func TestVerifierNilDir(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	var lt spacecommit.LtHash
 	lt.Add(spacecommit.RecordElement("net.test", "r1", "cid1"))
 	commit := spacecommit.SignedCommit{
@@ -296,7 +296,7 @@ func TestVerifierNilDir(t *testing.T) {
 func TestVerifierNilDirMismatch(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	var lt spacecommit.LtHash
 	lt.Add(spacecommit.RecordElement("net.test", "r1", "cid1"))
 	commit := spacecommit.SignedCommit{
@@ -315,7 +315,7 @@ func TestVerifierNilDirMismatch(t *testing.T) {
 func TestVerifierNilPointer(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	var lt spacecommit.LtHash
 	lt.Add(spacecommit.RecordElement("net.test", "r1", "cid1"))
 	commit := spacecommit.SignedCommit{
@@ -370,7 +370,7 @@ func TestDecodeCommitBadBase64(t *testing.T) {
 func TestEngineScheduleRetry(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
@@ -398,7 +398,7 @@ func TestEngineScheduleRetry(t *testing.T) {
 func TestEngineSettleDirtyRepo(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
@@ -427,7 +427,7 @@ func TestEngineRecoverRepoClientError(t *testing.T) {
 	e, err := New(db, failClient, &memEmitter{}, NewVerifier(nil), 1, m)
 	require.NoError(t, err)
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
 		Update("state", stateDesynced).Error)
@@ -459,7 +459,7 @@ func TestEngineRecoverRepoNonOK(t *testing.T) {
 	e, err := New(db, fakeClients{base: base}, &memEmitter{}, NewVerifier(nil), 1, m)
 	require.NoError(t, err)
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
 		Update("state", stateDesynced).Error)
@@ -491,7 +491,7 @@ func TestEngineRecoverRepoInvalidCAR(t *testing.T) {
 	e, err := New(db, fakeClients{base: base}, &memEmitter{}, NewVerifier(nil), 1, m)
 	require.NoError(t, err)
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
 		Update("state", stateDesynced).Error)
@@ -528,7 +528,7 @@ func TestVerifierSignerWebAuthor(t *testing.T) {
 	dir := identity.NewMockDirectory()
 	dir.Insert(*ident)
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	var lt spacecommit.LtHash
 	_ = spacecommit.SignedCommit{
 		Ver:  spacecommit.Version,
@@ -560,7 +560,7 @@ func TestVerifierSignerExternalAuthor(t *testing.T) {
 	dir.Insert(*ownerIdent)
 	dir.Insert(*hostIdent)
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 
 	got, err := v.signer(t.Context(), space, "did:plc:external")
 	require.NoError(t, err)
@@ -587,7 +587,7 @@ func TestVerifierSignerExternalAuthorFallsBackToAtproto(t *testing.T) {
 	dir.Insert(*ownerIdent)
 	dir.Insert(*hostIdent)
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 
 	got, err := v.signer(t.Context(), space, "did:plc:external")
 	require.NoError(t, err)
@@ -601,7 +601,7 @@ func TestVerifierSignerAuthorLookupError(t *testing.T) {
 
 	dir := identity.NewMockDirectory()
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 
 	_, err := v.signer(t.Context(), space, "did:web:missing.example.com")
 	require.Error(t, err)
@@ -619,7 +619,7 @@ func TestVerifierSignerAuthorNoKey(t *testing.T) {
 	dir := identity.NewMockDirectory()
 	dir.Insert(*ident)
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 
 	_, err := v.signer(t.Context(), space, authorDID)
 	require.Error(t, err)
@@ -633,7 +633,7 @@ func TestVerifierSignerExternalOwnerLookupError(t *testing.T) {
 
 	dir := identity.NewMockDirectory()
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 
 	_, err := v.signer(t.Context(), space, "did:plc:external")
 	require.Error(t, err)
@@ -651,7 +651,7 @@ func TestVerifierSignerExternalNoHabitatService(t *testing.T) {
 	dir := identity.NewMockDirectory()
 	dir.Insert(*ownerIdent)
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 
 	_, err := v.signer(t.Context(), space, "did:plc:external")
 	require.Error(t, err)
@@ -669,7 +669,7 @@ func TestVerifierSignerExternalHostLookupError(t *testing.T) {
 	dir := identity.NewMockDirectory()
 	dir.Insert(*ownerIdent)
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 
 	_, err := v.signer(t.Context(), space, "did:plc:external")
 	require.Error(t, err)
@@ -690,7 +690,7 @@ func TestVerifierSignerExternalHostNoKey(t *testing.T) {
 	dir.Insert(*ownerIdent)
 	dir.Insert(*hostIdent)
 	v := NewVerifier(dir)
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 
 	_, err := v.signer(t.Context(), space, "did:plc:external")
 	require.Error(t, err)
@@ -702,7 +702,7 @@ func TestVerifierSignerExternalHostNoKey(t *testing.T) {
 func TestEngineDispatchClaimsPendingAndErrorRepos(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 
 	require.NoError(
@@ -730,7 +730,7 @@ func TestEngineDispatchClaimsPendingAndErrorRepos(t *testing.T) {
 func TestEngineDispatchClaimsDesyncedRepos(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 
 	require.NoError(
@@ -756,7 +756,7 @@ func TestEngineDispatchClaimsDesyncedRepos(t *testing.T) {
 func TestEngineSettleCleanRepo(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
@@ -781,7 +781,7 @@ func TestEngineSettleCleanRepo(t *testing.T) {
 func TestEngineScheduleRetryBackoff(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 
@@ -843,7 +843,7 @@ func TestEngineRunJobDispatchesToRecover(t *testing.T) {
 	e, err := New(db, failClient, &memEmitter{}, NewVerifier(nil), 1, m)
 	require.NoError(t, err)
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 
 	j := job{Space: space, DID: "did:plc:alice", Recover: true}
@@ -858,7 +858,7 @@ func TestEngineRunJobDispatchesToRecover(t *testing.T) {
 func TestEngineRunJobDispatchesToSync(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(habitat.NetworkHabitatSpaceListRepoOpsOutput{
 			Commit: habitat.NetworkHabitatSpaceDefsSignedCommit{Ver: 0},
@@ -884,7 +884,7 @@ func TestEngineRunJobDispatchesToSync(t *testing.T) {
 func TestEngineRunProcessesPendingRepo(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	commit := habitat.NetworkHabitatSpaceDefsSignedCommit{Ver: 0}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -913,7 +913,7 @@ func TestEngineRecoverRepoVerifyError(t *testing.T) {
 
 	carBytes := buildMinimalCAR(t)
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -951,7 +951,7 @@ func TestEngineRecoverRepoSuccess(t *testing.T) {
 
 	carBytes := buildMinimalCAR(t)
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -985,7 +985,7 @@ func TestEngineRecoverRepoSuccess(t *testing.T) {
 func TestEngineNotifyWriteBehindHashSameRev(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
@@ -1003,7 +1003,7 @@ func TestEngineNotifyWriteBehindHashSameRev(t *testing.T) {
 func TestEngineNotifyWriteAlreadyCurrent(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 	require.NoError(t, db.Model(&repo{}).Where("did = ?", "did:plc:alice").
@@ -1024,7 +1024,7 @@ func TestEngineNotifyWriteAlreadyCurrent(t *testing.T) {
 func TestEngineNotifyWriteConcurrentUnknownRepo(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 
 	const concurrency = 8
@@ -1054,7 +1054,7 @@ func TestEngineNotifyWriteConcurrentUnknownRepo(t *testing.T) {
 func TestEngineScheduleRetryDesyncRecoversPromptly(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	e, _, db := newTestEngine(t, "http://unused.example")
 	require.NoError(t, e.Track(t.Context(), space, "did:plc:alice"))
 
@@ -1081,7 +1081,7 @@ func TestEngineScheduleRetryDesyncRecoversPromptly(t *testing.T) {
 func TestEngineRecoverByDiffRefetchesOnlyChangedRecords(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	coll := syntax.NSID("network.habitat.test")
 	rev := syntax.NewTIDClock(0).Next().String()
@@ -1174,7 +1174,7 @@ func TestEngineRecoverByDiffRefetchesOnlyChangedRecords(t *testing.T) {
 func TestEngineRecoverByDiffEmitsDeleteTombstone(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	coll := syntax.NSID("network.habitat.test")
 	rev := syntax.NewTIDClock(0).Next().String()
@@ -1222,7 +1222,7 @@ func TestEngineRecoverByDiffEmitsDeleteTombstone(t *testing.T) {
 	require.Equal(
 		t,
 		[]byte("null"),
-		emitter.values["ats://did:plc:owner/network.habitat.space/s1/did:plc:alice/network.habitat.test/k2"],
+		emitter.values["at://did:plc:owner/space/network.habitat.space/s1/did:plc:alice/network.habitat.test/k2"],
 	)
 
 	index, err := recordIndex(t.Context(), db, space, repoDID)
@@ -1238,7 +1238,7 @@ func TestEngineRecoverByDiffEmitsDeleteTombstone(t *testing.T) {
 func TestEngineRecoverFromCAREmitsDeleteTombstone(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	car := buildMinimalCAR(t) // holds exactly network.habitat.test/rec1
 
@@ -1268,7 +1268,7 @@ func TestEngineRecoverFromCAREmitsDeleteTombstone(t *testing.T) {
 	require.Equal(
 		t,
 		[]byte("null"),
-		emitter.values["ats://did:plc:owner/network.habitat.space/s1/did:plc:alice/network.habitat.test/rec2"],
+		emitter.values["at://did:plc:owner/space/network.habitat.space/s1/did:plc:alice/network.habitat.test/rec2"],
 	)
 
 	index, err := recordIndex(t.Context(), db, space, repoDID)
@@ -1284,7 +1284,7 @@ func TestEngineRecoverFromCAREmitsDeleteTombstone(t *testing.T) {
 func TestEngineRecoverRepoUsesHabitatNsid(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 
 	var requestedPath string
@@ -1312,7 +1312,7 @@ func TestEngineRecoverRepoUsesHabitatNsid(t *testing.T) {
 func TestEngineSyncRepoEmitsDeleteTombstone(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	clock := syntax.NewTIDClock(0)
 	rev1, rev2 := clock.Next().String(), clock.Next().String()
@@ -1351,7 +1351,7 @@ func TestEngineSyncRepoEmitsDeleteTombstone(t *testing.T) {
 	require.Equal(
 		t,
 		[]byte("null"),
-		emitter.values["ats://did:plc:owner/network.habitat.space/s1/did:plc:alice/network.habitat.test/k1"],
+		emitter.values["at://did:plc:owner/space/network.habitat.space/s1/did:plc:alice/network.habitat.test/k1"],
 	)
 }
 
@@ -1361,7 +1361,7 @@ func TestEngineSyncRepoEmitsDeleteTombstone(t *testing.T) {
 func TestEngineCheckRequeuesDriftedRepo(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	clock := syntax.NewTIDClock(0)
 	rev1, rev2 := clock.Next().String(), clock.Next().String()
@@ -1400,7 +1400,7 @@ func TestEngineCheckRequeuesDriftedRepo(t *testing.T) {
 func TestEngineCheckLeavesCurrentReposActive(t *testing.T) {
 	t.Parallel()
 
-	space := habitat_syntax.SpaceURI("ats://did:plc:owner/network.habitat.space/s1")
+	space := habitat_syntax.SpaceURI("at://did:plc:owner/space/network.habitat.space/s1")
 	repoDID := syntax.DID("did:plc:alice")
 	rev := syntax.NewTIDClock(0).Next().String()
 


### PR DESCRIPTION
## Summary
Updates all test fixtures to use the new Space URI scheme format, changing from `ats://did:plc:owner/network.habitat.space/s1` to `at://did:plc:owner/space/network.habitat.space/s1`. This reflects a breaking change in the Space URI syntax where the scheme changes from `ats://` to `at://` and the path structure is reorganized to include an explicit `/space/` segment.

## Changes
- Updated 50+ Space URI test fixtures across syncer, crawler, register, outbox, and session test files
- Changed scheme prefix from `ats://` to `at://`
- Restructured path to insert `/space/` segment after the DID component
- Updated corresponding emitter value keys that include the full Space Record URI path

## Implementation Details
This is a comprehensive test fixture update ensuring all test cases use the new Space URI format. The change appears to be part of a broader URI scheme standardization effort, moving away from the AT Protocol-specific `ats://` scheme to a more generic `at://` scheme with explicit path segmentation for clarity.

https://claude.ai/code/session_01VBh1kAALCpJXQWYtmMFzQ5