### PR TITLE
[perms]: new interface

### DIFF
--- a/internal/fgastore/encoding.go
+++ b/internal/fgastore/encoding.go
@@ -44,6 +44,14 @@ func OrgMemberUsersetString(did syntax.DID) string {
 	return OrgObjectKey(did) + "#" + RelationMember
 }
 
+func OwnerContextualTuple(space habitat_syntax.SpaceURI) Tuple {
+	return Tuple{
+		User:     MemberUserString(space.SpaceOwner()),
+		Relation: RelationSpaceOwner,
+		Object:   SpaceObjectKey(space),
+	}
+}
+
 // OrgMemberContextualTuple returns a Tuple granting org members (via the
 // organization:#member userset) the can_read relation on the org's self space
 // (at://<org>/space/network.habitat.organization/self).  This lets org membership

--- a/internal/perms/store.go
+++ b/internal/perms/store.go
@@ -1,0 +1,328 @@
+package perms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/habitat-network/habitat/internal/fgastore"
+	habitat_syntax "github.com/habitat-network/habitat/internal/syntax"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/pkg/tuple"
+)
+
+// SpaceRole is an access-control role held on a space. The hierarchy
+// (owner ⇒ manager ⇒ writer ⇒ reader) is enforced by the OpenFGA model
+// (internal/fgastore's authModel), not by this package.
+type SpaceRole string
+
+const (
+	SpaceRoleOwner   SpaceRole = "owner"
+	SpaceRoleManager SpaceRole = "manager"
+	SpaceRoleWriter  SpaceRole = "writer"
+	SpaceRoleReader  SpaceRole = "reader"
+)
+
+var fgaRelationFromRole = map[SpaceRole]string{
+	SpaceRoleOwner:   fgastore.RelationSpaceOwner,
+	SpaceRoleManager: fgastore.RelationSpaceMemberManager,
+	SpaceRoleWriter:  fgastore.RelationSpaceWriter,
+	SpaceRoleReader:  fgastore.RelationSpaceReader,
+}
+
+var roleFromFGARelation = map[string]SpaceRole{
+	fgastore.RelationSpaceOwner:         SpaceRoleOwner,
+	fgastore.RelationSpaceMemberManager: SpaceRoleManager,
+	fgastore.RelationSpaceWriter:        SpaceRoleWriter,
+	fgastore.RelationSpaceReader:        SpaceRoleReader,
+}
+
+type SpaceRoleSubject struct {
+	Space habitat_syntax.SpaceURI
+	Role  SpaceRole
+}
+
+type Store interface {
+	// Additions
+	AddUserRelation(ctx context.Context, did syntax.DID, space habitat_syntax.SpaceURI, role SpaceRole) error
+	AddSpaceRoleRelation(ctx context.Context, subject habitat_syntax.SpaceURI, subjectRole SpaceRole, object habitat_syntax.SpaceURI, objectRole SpaceRole) error
+
+	// Revocations
+	RevokeUserRelation(ctx context.Context, did syntax.DID, space habitat_syntax.SpaceURI, role SpaceRole) error
+	RevokeSpaceRoleRelation(ctx context.Context, subjectSpace habitat_syntax.SpaceURI, subjectRole SpaceRole, objectSpace habitat_syntax.SpaceURI, objectRole SpaceRole) error
+	UnsafeRevokeAllSpaceRoles(ctx context.Context, space habitat_syntax.SpaceURI) error
+
+	// Permission checks
+	CheckUserHasSpaceRole(ctx context.Context, did syntax.DID, space habitat_syntax.SpaceURI, role SpaceRole) (bool, error)
+	CheckSpaceRelationHasSpaceRole(ctx context.Context, subjectSpace habitat_syntax.SpaceURI, subjectRole SpaceRole, objectSpace habitat_syntax.SpaceURI, objectRole SpaceRole) (bool, error)
+
+	// List various things using relations
+	ListSubjects(ctx context.Context, space habitat_syntax.SpaceURI) ([]syntax.DID, []SpaceRoleSubject, error)
+	ListSpaceRoleSubjects(ctx context.Context, space habitat_syntax.SpaceURI) ([]SpaceRoleSubject, error)
+	ListUserSubjects(ctx context.Context, space habitat_syntax.SpaceURI) ([]syntax.DID, error)
+	ListObjects(ctx context.Context, did syntax.DID) ([]habitat_syntax.SpaceURI, error)
+}
+
+type store struct {
+	fga fgastore.Store
+}
+
+func NewStore(fga fgastore.Store) *store {
+	return &store{fga: fga}
+}
+
+var _ Store = &store{}
+
+// AddUserRelation implements [Store].
+func (s *store) AddUserRelation(
+	ctx context.Context,
+	did syntax.DID,
+	space habitat_syntax.SpaceURI,
+	role SpaceRole,
+) error {
+	return s.fga.WriteRaw(ctx, &openfgav1.WriteRequest{
+		Writes: &openfgav1.WriteRequestWrites{
+			TupleKeys: []*openfgav1.TupleKey{
+				tuple.NewTupleKey(
+					fgastore.SpaceObjectKey(space),
+					fgaRelationFromRole[role],
+					fgastore.MemberUserString(did),
+				),
+			},
+			OnDuplicate: "ignore",
+		},
+	})
+}
+
+// AddSpaceRoleRelation implements [Store]. It grants every subject holding
+// subjectRole on subject (a userset) objectRole on object — this is what
+// powers groups-as-spaces and cross-space role inheritance.
+func (s *store) AddSpaceRoleRelation(
+	ctx context.Context,
+	subject habitat_syntax.SpaceURI,
+	subjectRole SpaceRole,
+	object habitat_syntax.SpaceURI,
+	objectRole SpaceRole,
+) error {
+	return s.fga.WriteRaw(ctx, &openfgav1.WriteRequest{
+		Writes: &openfgav1.WriteRequestWrites{
+			TupleKeys: []*openfgav1.TupleKey{
+				tuple.NewTupleKey(
+					fgastore.SpaceObjectKey(object),
+					fgaRelationFromRole[objectRole],
+					fgastore.SpaceUsersetString(subject, fgaRelationFromRole[subjectRole]),
+				),
+			},
+			OnDuplicate: "ignore",
+		},
+	})
+}
+
+// RevokeUserRelation implements [Store].
+func (s *store) RevokeUserRelation(
+	ctx context.Context,
+	did syntax.DID,
+	space habitat_syntax.SpaceURI,
+	role SpaceRole,
+) error {
+	return s.fga.WriteRaw(ctx, &openfgav1.WriteRequest{
+		Deletes: &openfgav1.WriteRequestDeletes{
+			TupleKeys: []*openfgav1.TupleKeyWithoutCondition{
+				tuple.TupleKeyToTupleKeyWithoutCondition(tuple.NewTupleKey(
+					fgastore.SpaceObjectKey(space),
+					fgaRelationFromRole[role],
+					fgastore.MemberUserString(did),
+				)),
+			},
+			OnMissing: "ignore",
+		},
+	})
+}
+
+// RevokeSpaceRoleRelation implements [Store].
+func (s *store) RevokeSpaceRoleRelation(
+	ctx context.Context,
+	subjectSpace habitat_syntax.SpaceURI,
+	subjectRole SpaceRole,
+	objectSpace habitat_syntax.SpaceURI,
+	objectRole SpaceRole,
+) error {
+	return s.fga.WriteRaw(ctx, &openfgav1.WriteRequest{
+		Deletes: &openfgav1.WriteRequestDeletes{
+			TupleKeys: []*openfgav1.TupleKeyWithoutCondition{
+				tuple.TupleKeyToTupleKeyWithoutCondition(tuple.NewTupleKey(
+					fgastore.SpaceObjectKey(objectSpace),
+					fgaRelationFromRole[objectRole],
+					fgastore.SpaceUsersetString(subjectSpace, fgaRelationFromRole[subjectRole]),
+				)),
+			},
+			OnMissing: "ignore",
+		},
+	})
+}
+
+// UnsafeRevokeAllSpaceRoles implements [Store]. It reads back every tuple stored
+// against space, so it doesn't need to know which roles/subjects exist, then
+// deletes them all — for use when a space is deleted.
+//
+// This is only meant to be used upon space deletion--if this is called on a space that is
+// still used, it will be in a broken state.
+func (s *store) UnsafeRevokeAllSpaceRoles(ctx context.Context, space habitat_syntax.SpaceURI) error {
+	tuples, err := s.fga.Read(ctx, fgastore.Tuple{Object: fgastore.SpaceObjectKey(space)})
+	if err != nil {
+		return err
+	}
+	if len(tuples) == 0 {
+		return nil
+	}
+
+	deletes := make([]*openfgav1.TupleKeyWithoutCondition, len(tuples))
+	for i, t := range tuples {
+		deletes[i] = tuple.TupleKeyToTupleKeyWithoutCondition(tuple.NewTupleKey(t.Object, t.Relation, t.User))
+	}
+	return s.fga.WriteRaw(ctx, &openfgav1.WriteRequest{
+		Deletes: &openfgav1.WriteRequestDeletes{
+			TupleKeys: deletes,
+			OnMissing: "ignore",
+		},
+	})
+}
+
+// CheckUserHasSpaceRole implements [Store]. The space's owner is treated as
+// an implicit SpaceRoleOwner, and the owning org's members as implicit
+// SpaceRoleReaders, without either needing a stored tuple.
+func (s *store) CheckUserHasSpaceRole(
+	ctx context.Context,
+	did syntax.DID,
+	space habitat_syntax.SpaceURI,
+	role SpaceRole,
+) (bool, error) {
+	return s.fga.Check(
+		ctx,
+		fgastore.MemberUserString(did),
+		fgaRelationFromRole[role],
+		fgastore.SpaceObjectKey(space),
+		fgastore.OwnerContextualTuple(space),
+		fgastore.OrgMemberContextualTuple(space.SpaceOwner()),
+	)
+}
+
+// CheckSpaceRelationHasSpaceRole implements [Store]: whether every subject
+// holding subjectRole on subjectSpace also holds objectRole on objectSpace.
+func (s *store) CheckSpaceRelationHasSpaceRole(
+	ctx context.Context,
+	subjectSpace habitat_syntax.SpaceURI,
+	subjectRole SpaceRole,
+	objectSpace habitat_syntax.SpaceURI,
+	objectRole SpaceRole,
+) (bool, error) {
+	return s.fga.Check(
+		ctx,
+		fgastore.SpaceUsersetString(subjectSpace, fgaRelationFromRole[subjectRole]),
+		fgaRelationFromRole[objectRole],
+		fgastore.SpaceObjectKey(objectSpace),
+		fgastore.OwnerContextualTuple(objectSpace),
+		fgastore.OrgMemberContextualTuple(objectSpace.SpaceOwner()),
+	)
+}
+
+// ListSubjects implements [Store]. It returns every direct grantee stored
+// against space, split into individual users and space-userset grantees.
+// Owner/org-member implications are not expanded, since those aren't stored
+// tuples.
+func (s *store) ListSubjects(
+	ctx context.Context,
+	space habitat_syntax.SpaceURI,
+) ([]syntax.DID, []SpaceRoleSubject, error) {
+	tuples, err := s.fga.Read(ctx, fgastore.Tuple{Object: fgastore.SpaceObjectKey(space)})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var dids []syntax.DID
+	var spaceSubjects []SpaceRoleSubject
+	for _, t := range tuples {
+		did, spaceSubject, isUser, err := parseSubjectUser(t.User)
+		if err != nil {
+			return nil, nil, fmt.Errorf("perms: list subjects: %w", err)
+		}
+		if isUser {
+			dids = append(dids, did)
+		} else {
+			spaceSubjects = append(spaceSubjects, spaceSubject)
+		}
+	}
+	return dids, spaceSubjects, nil
+}
+
+// ListSpaceRoleSubjects implements [Store].
+func (s *store) ListSpaceRoleSubjects(
+	ctx context.Context,
+	space habitat_syntax.SpaceURI,
+) ([]SpaceRoleSubject, error) {
+	_, spaceSubjects, err := s.ListSubjects(ctx, space)
+	return spaceSubjects, err
+}
+
+// ListUserSubjects implements [Store].
+func (s *store) ListUserSubjects(
+	ctx context.Context,
+	space habitat_syntax.SpaceURI,
+) ([]syntax.DID, error) {
+	dids, _, err := s.ListSubjects(ctx, space)
+	return dids, err
+}
+
+// ListObjects implements [Store]. It returns the spaces did directly holds
+// at least SpaceRoleReader on (reader is implied by every other role, so
+// this covers manager/writer/owner too). Owner/org-member implications
+// aren't expanded here, since that would require checking every space in
+// every org did could be a member of.
+func (s *store) ListObjects(ctx context.Context, did syntax.DID) ([]habitat_syntax.SpaceURI, error) {
+	keys, err := s.fga.ListObjects(
+		ctx,
+		fgastore.MemberUserString(did),
+		fgaRelationFromRole[SpaceRoleReader],
+		fgastore.TypeSpace,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	spaceURIs := make([]habitat_syntax.SpaceURI, 0, len(keys))
+	for _, key := range keys {
+		uri, err := fgastore.ParseSpaceObjectKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("perms: list objects: %w", err)
+		}
+		spaceURIs = append(spaceURIs, uri)
+	}
+	return spaceURIs, nil
+}
+
+// parseSubjectUser decodes a raw FGA user string (as returned by fga.Read)
+// into either a DID (an individual grantee) or a SpaceRoleSubject (a space
+// userset grantee, e.g. "space:<uri>#reader").
+func parseSubjectUser(
+	user string,
+) (did syntax.DID, spaceSubject SpaceRoleSubject, isUser bool, err error) {
+	if strings.HasPrefix(user, "user:") {
+		did, err = fgastore.MemberUserToDID(user)
+		return did, SpaceRoleSubject{}, true, err
+	}
+
+	objectKey, relation, ok := strings.Cut(user, "#")
+	if !ok {
+		return "", SpaceRoleSubject{}, false, fmt.Errorf("unrecognized fga user string: %s", user)
+	}
+	space, err := fgastore.ParseSpaceObjectKey(objectKey)
+	if err != nil {
+		return "", SpaceRoleSubject{}, false, err
+	}
+	role, ok := roleFromFGARelation[relation]
+	if !ok {
+		return "", SpaceRoleSubject{}, false, fmt.Errorf("unrecognized fga relation: %s", relation)
+	}
+	return "", SpaceRoleSubject{Space: space, Role: role}, false, nil
+}

--- a/internal/perms/store.go
+++ b/internal/perms/store.go
@@ -45,21 +45,60 @@ type SpaceRoleSubject struct {
 
 type Store interface {
 	// Additions
-	AddUserRelation(ctx context.Context, did syntax.DID, space habitat_syntax.SpaceURI, role SpaceRole) error
-	AddSpaceRoleRelation(ctx context.Context, subject habitat_syntax.SpaceURI, subjectRole SpaceRole, object habitat_syntax.SpaceURI, objectRole SpaceRole) error
+	AddUserRelation(
+		ctx context.Context,
+		did syntax.DID,
+		space habitat_syntax.SpaceURI,
+		role SpaceRole,
+	) error
+	AddSpaceRoleRelation(
+		ctx context.Context,
+		subject habitat_syntax.SpaceURI,
+		subjectRole SpaceRole,
+		object habitat_syntax.SpaceURI,
+		objectRole SpaceRole,
+	) error
 
 	// Revocations
-	RevokeUserRelation(ctx context.Context, did syntax.DID, space habitat_syntax.SpaceURI, role SpaceRole) error
-	RevokeSpaceRoleRelation(ctx context.Context, subjectSpace habitat_syntax.SpaceURI, subjectRole SpaceRole, objectSpace habitat_syntax.SpaceURI, objectRole SpaceRole) error
+	RevokeUserRelation(
+		ctx context.Context,
+		did syntax.DID,
+		space habitat_syntax.SpaceURI,
+		role SpaceRole,
+	) error
+	RevokeSpaceRoleRelation(
+		ctx context.Context,
+		subjectSpace habitat_syntax.SpaceURI,
+		subjectRole SpaceRole,
+		objectSpace habitat_syntax.SpaceURI,
+		objectRole SpaceRole,
+	) error
 	UnsafeRevokeAllSpaceRoles(ctx context.Context, space habitat_syntax.SpaceURI) error
 
 	// Permission checks
-	CheckUserHasSpaceRole(ctx context.Context, did syntax.DID, space habitat_syntax.SpaceURI, role SpaceRole) (bool, error)
-	CheckSpaceRelationHasSpaceRole(ctx context.Context, subjectSpace habitat_syntax.SpaceURI, subjectRole SpaceRole, objectSpace habitat_syntax.SpaceURI, objectRole SpaceRole) (bool, error)
+	CheckUserHasSpaceRole(
+		ctx context.Context,
+		did syntax.DID,
+		space habitat_syntax.SpaceURI,
+		role SpaceRole,
+	) (bool, error)
+	CheckSpaceRelationHasSpaceRole(
+		ctx context.Context,
+		subjectSpace habitat_syntax.SpaceURI,
+		subjectRole SpaceRole,
+		objectSpace habitat_syntax.SpaceURI,
+		objectRole SpaceRole,
+	) (bool, error)
 
 	// List various things using relations
-	ListSubjects(ctx context.Context, space habitat_syntax.SpaceURI) ([]syntax.DID, []SpaceRoleSubject, error)
-	ListSpaceRoleSubjects(ctx context.Context, space habitat_syntax.SpaceURI) ([]SpaceRoleSubject, error)
+	ListSubjects(
+		ctx context.Context,
+		space habitat_syntax.SpaceURI,
+	) ([]syntax.DID, []SpaceRoleSubject, error)
+	ListSpaceRoleSubjects(
+		ctx context.Context,
+		space habitat_syntax.SpaceURI,
+	) ([]SpaceRoleSubject, error)
 	ListUserSubjects(ctx context.Context, space habitat_syntax.SpaceURI) ([]syntax.DID, error)
 	ListObjects(ctx context.Context, did syntax.DID) ([]habitat_syntax.SpaceURI, error)
 }
@@ -168,7 +207,10 @@ func (s *store) RevokeSpaceRoleRelation(
 //
 // This is only meant to be used upon space deletion--if this is called on a space that is
 // still used, it will be in a broken state.
-func (s *store) UnsafeRevokeAllSpaceRoles(ctx context.Context, space habitat_syntax.SpaceURI) error {
+func (s *store) UnsafeRevokeAllSpaceRoles(
+	ctx context.Context,
+	space habitat_syntax.SpaceURI,
+) error {
 	tuples, err := s.fga.Read(ctx, fgastore.Tuple{Object: fgastore.SpaceObjectKey(space)})
 	if err != nil {
 		return err
@@ -179,7 +221,9 @@ func (s *store) UnsafeRevokeAllSpaceRoles(ctx context.Context, space habitat_syn
 
 	deletes := make([]*openfgav1.TupleKeyWithoutCondition, len(tuples))
 	for i, t := range tuples {
-		deletes[i] = tuple.TupleKeyToTupleKeyWithoutCondition(tuple.NewTupleKey(t.Object, t.Relation, t.User))
+		deletes[i] = tuple.TupleKeyToTupleKeyWithoutCondition(
+			tuple.NewTupleKey(t.Object, t.Relation, t.User),
+		)
 	}
 	return s.fga.WriteRaw(ctx, &openfgav1.WriteRequest{
 		Deletes: &openfgav1.WriteRequestDeletes{
@@ -279,7 +323,10 @@ func (s *store) ListUserSubjects(
 // this covers manager/writer/owner too). Owner/org-member implications
 // aren't expanded here, since that would require checking every space in
 // every org did could be a member of.
-func (s *store) ListObjects(ctx context.Context, did syntax.DID) ([]habitat_syntax.SpaceURI, error) {
+func (s *store) ListObjects(
+	ctx context.Context,
+	did syntax.DID,
+) ([]habitat_syntax.SpaceURI, error) {
 	keys, err := s.fga.ListObjects(
 		ctx,
 		fgastore.MemberUserString(did),

--- a/internal/perms/store_test.go
+++ b/internal/perms/store_test.go
@@ -1,0 +1,256 @@
+package perms
+
+import (
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/stretchr/testify/require"
+
+	"github.com/habitat-network/habitat/internal/fgastore"
+	habitat_syntax "github.com/habitat-network/habitat/internal/syntax"
+)
+
+var (
+	org   = syntax.DID("did:plc:org")
+	alice = syntax.DID("did:plc:alice")
+	bob   = syntax.DID("did:plc:bob")
+
+	docsType  = syntax.NSID("network.habitat.docs")
+	groupType = syntax.NSID("network.habitat.group")
+)
+
+func newTestStore(t *testing.T) *store {
+	t.Helper()
+	fga, err := fgastore.NewMemory(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fga.Close() })
+	return NewStore(fga)
+}
+
+// newSpace returns a space URI owned by org, without creating any backing
+// records — perms only cares about the URI as an FGA object key.
+func newSpace(spaceType syntax.NSID, skey string) habitat_syntax.SpaceURI {
+	return habitat_syntax.ConstructSpaceURI(org, spaceType, habitat_syntax.SpaceKey(skey))
+}
+
+func TestStoreAddUserRelationAndCheckUserHasSpaceRole(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	space := newSpace(docsType, "doc1")
+
+	t.Run("no relation is denied", func(t *testing.T) {
+		ok, err := s.CheckUserHasSpaceRole(ctx, alice, space, SpaceRoleReader)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("granted role is allowed", func(t *testing.T) {
+		require.NoError(t, s.AddUserRelation(ctx, alice, space, SpaceRoleReader))
+		ok, err := s.CheckUserHasSpaceRole(ctx, alice, space, SpaceRoleReader)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("granting is idempotent", func(t *testing.T) {
+		require.NoError(t, s.AddUserRelation(ctx, alice, space, SpaceRoleReader))
+	})
+
+	t.Run("a role does not imply a higher role", func(t *testing.T) {
+		ok, err := s.CheckUserHasSpaceRole(ctx, alice, space, SpaceRoleWriter)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("a higher role implies a lower role", func(t *testing.T) {
+		require.NoError(t, s.AddUserRelation(ctx, bob, space, SpaceRoleWriter))
+		ok, err := s.CheckUserHasSpaceRole(ctx, bob, space, SpaceRoleReader)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("unrelated user is denied", func(t *testing.T) {
+		ok, err := s.CheckUserHasSpaceRole(ctx, "did:plc:stranger", space, SpaceRoleReader)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+}
+
+func TestStoreCheckUserHasSpaceRoleImplicitAccess(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	space := newSpace(docsType, "doc1")
+
+	t.Run("space owner is an implicit owner without a stored tuple", func(t *testing.T) {
+		ok, err := s.CheckUserHasSpaceRole(ctx, space.SpaceOwner(), space, SpaceRoleOwner)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("space owner is an implicit reader too", func(t *testing.T) {
+		ok, err := s.CheckUserHasSpaceRole(ctx, space.SpaceOwner(), space, SpaceRoleReader)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+}
+
+func TestStoreRevokeUserRelation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	space := newSpace(docsType, "doc1")
+
+	require.NoError(t, s.AddUserRelation(ctx, alice, space, SpaceRoleReader))
+	ok, err := s.CheckUserHasSpaceRole(ctx, alice, space, SpaceRoleReader)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, s.RevokeUserRelation(ctx, alice, space, SpaceRoleReader))
+	ok, err = s.CheckUserHasSpaceRole(ctx, alice, space, SpaceRoleReader)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	t.Run("revoking a relation that doesn't exist is a no-op", func(t *testing.T) {
+		require.NoError(t, s.RevokeUserRelation(ctx, alice, space, SpaceRoleReader))
+	})
+}
+
+func TestStoreSpaceRoleRelation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	group := newSpace(groupType, "team")
+	doc := newSpace(docsType, "doc1")
+
+	t.Run("subject without the subject role is denied", func(t *testing.T) {
+		require.NoError(
+			t,
+			s.AddSpaceRoleRelation(ctx, group, SpaceRoleReader, doc, SpaceRoleReader),
+		)
+		ok, err := s.CheckUserHasSpaceRole(ctx, alice, doc, SpaceRoleReader)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("granting the space-role relation propagates to its subjects", func(t *testing.T) {
+		require.NoError(t, s.AddUserRelation(ctx, alice, group, SpaceRoleReader))
+		ok, err := s.CheckUserHasSpaceRole(ctx, alice, doc, SpaceRoleReader)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("CheckSpaceRelationHasSpaceRole reports the userset relation directly", func(t *testing.T) {
+		ok, err := s.CheckSpaceRelationHasSpaceRole(
+			ctx,
+			group,
+			SpaceRoleReader,
+			doc,
+			SpaceRoleReader,
+		)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		ok, err = s.CheckSpaceRelationHasSpaceRole(ctx, group, SpaceRoleReader, doc, SpaceRoleWriter)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("revoking the space-role relation removes access", func(t *testing.T) {
+		require.NoError(
+			t,
+			s.RevokeSpaceRoleRelation(ctx, group, SpaceRoleReader, doc, SpaceRoleReader),
+		)
+		ok, err := s.CheckUserHasSpaceRole(ctx, alice, doc, SpaceRoleReader)
+		require.NoError(t, err)
+		require.False(t, ok)
+
+		t.Run("revoking again is a no-op", func(t *testing.T) {
+			require.NoError(
+				t,
+				s.RevokeSpaceRoleRelation(ctx, group, SpaceRoleReader, doc, SpaceRoleReader),
+			)
+		})
+	})
+}
+
+func TestStoreUnsafeRevokeAllSpaceRoles(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	space := newSpace(docsType, "doc1")
+	group := newSpace(groupType, "team")
+
+	require.NoError(t, s.AddUserRelation(ctx, alice, space, SpaceRoleReader))
+	require.NoError(t, s.AddUserRelation(ctx, bob, space, SpaceRoleWriter))
+	require.NoError(t, s.AddSpaceRoleRelation(ctx, group, SpaceRoleReader, space, SpaceRoleReader))
+
+	require.NoError(t, s.UnsafeRevokeAllSpaceRoles(ctx, space))
+
+	for _, did := range []syntax.DID{alice, bob} {
+		ok, err := s.CheckUserHasSpaceRole(ctx, did, space, SpaceRoleReader)
+		require.NoError(t, err)
+		require.False(t, ok)
+	}
+
+	dids, subjects, err := s.ListSubjects(ctx, space)
+	require.NoError(t, err)
+	require.Empty(t, dids)
+	require.Empty(t, subjects)
+
+	t.Run("no-op on a space with nothing stored", func(t *testing.T) {
+		require.NoError(t, s.UnsafeRevokeAllSpaceRoles(ctx, newSpace(docsType, "doc2")))
+	})
+}
+
+func TestStoreListSubjects(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	space := newSpace(docsType, "doc1")
+	group := newSpace(groupType, "team")
+
+	require.NoError(t, s.AddUserRelation(ctx, alice, space, SpaceRoleReader))
+	require.NoError(t, s.AddUserRelation(ctx, bob, space, SpaceRoleWriter))
+	require.NoError(t, s.AddSpaceRoleRelation(ctx, group, SpaceRoleReader, space, SpaceRoleReader))
+
+	dids, subjects, err := s.ListSubjects(ctx, space)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []syntax.DID{alice, bob}, dids)
+	require.ElementsMatch(t, []SpaceRoleSubject{{Space: group, Role: SpaceRoleReader}}, subjects)
+
+	t.Run("ListUserSubjects returns only the DIDs", func(t *testing.T) {
+		got, err := s.ListUserSubjects(ctx, space)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []syntax.DID{alice, bob}, got)
+	})
+
+	t.Run("ListSpaceRoleSubjects returns only the space-userset grantees", func(t *testing.T) {
+		got, err := s.ListSpaceRoleSubjects(ctx, space)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []SpaceRoleSubject{{Space: group, Role: SpaceRoleReader}}, got)
+	})
+
+	t.Run("empty when nothing is stored", func(t *testing.T) {
+		dids, subjects, err := s.ListSubjects(ctx, newSpace(docsType, "doc2"))
+		require.NoError(t, err)
+		require.Empty(t, dids)
+		require.Empty(t, subjects)
+	})
+}
+
+func TestStoreListObjects(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	doc1 := newSpace(docsType, "doc1")
+	doc2 := newSpace(docsType, "doc2")
+	doc3 := newSpace(docsType, "doc3")
+
+	require.NoError(t, s.AddUserRelation(ctx, alice, doc1, SpaceRoleReader))
+	require.NoError(t, s.AddUserRelation(ctx, alice, doc2, SpaceRoleWriter))
+	require.NoError(t, s.AddUserRelation(ctx, bob, doc3, SpaceRoleReader))
+
+	got, err := s.ListObjects(ctx, alice)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []habitat_syntax.SpaceURI{doc1, doc2}, got)
+
+	t.Run("empty for a did with no relations", func(t *testing.T) {
+		got, err := s.ListObjects(ctx, "did:plc:stranger")
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}

--- a/internal/perms/store_test.go
+++ b/internal/perms/store_test.go
@@ -136,21 +136,30 @@ func TestStoreSpaceRoleRelation(t *testing.T) {
 		require.True(t, ok)
 	})
 
-	t.Run("CheckSpaceRelationHasSpaceRole reports the userset relation directly", func(t *testing.T) {
-		ok, err := s.CheckSpaceRelationHasSpaceRole(
-			ctx,
-			group,
-			SpaceRoleReader,
-			doc,
-			SpaceRoleReader,
-		)
-		require.NoError(t, err)
-		require.True(t, ok)
+	t.Run(
+		"CheckSpaceRelationHasSpaceRole reports the userset relation directly",
+		func(t *testing.T) {
+			ok, err := s.CheckSpaceRelationHasSpaceRole(
+				ctx,
+				group,
+				SpaceRoleReader,
+				doc,
+				SpaceRoleReader,
+			)
+			require.NoError(t, err)
+			require.True(t, ok)
 
-		ok, err = s.CheckSpaceRelationHasSpaceRole(ctx, group, SpaceRoleReader, doc, SpaceRoleWriter)
-		require.NoError(t, err)
-		require.False(t, ok)
-	})
+			ok, err = s.CheckSpaceRelationHasSpaceRole(
+				ctx,
+				group,
+				SpaceRoleReader,
+				doc,
+				SpaceRoleWriter,
+			)
+			require.NoError(t, err)
+			require.False(t, ok)
+		},
+	)
 
 	t.Run("revoking the space-role relation removes access", func(t *testing.T) {
 		require.NoError(

--- a/internal/relationship/server.go
+++ b/internal/relationship/server.go
@@ -50,7 +50,7 @@ func (s *Server) authorize(
 		fgastore.MemberUserString(caller.Subject),
 		relation,
 		fgastore.SpaceObjectKey(space),
-		ownerContextualTuple(space),
+		fgastore.OwnerContextualTuple(space),
 		fgastore.OrgMemberContextualTuple(caller.Org.DID()),
 	)
 }

--- a/internal/relationship/store.go
+++ b/internal/relationship/store.go
@@ -49,16 +49,6 @@ func NewStore(database *gorm.DB, spacesStore spaces.Store, fga fgastore.Store) *
 	return &Store{db: database, spaces: spacesStore, fga: fga}
 }
 
-// ownerContextualTuple makes the space owner (the org) a recognized owner of
-// the space without storing the tuple in FGA, mirroring internal/spaces.
-func ownerContextualTuple(uri habitat_syntax.SpaceURI) fgastore.Tuple {
-	return fgastore.Tuple{
-		User:     fgastore.MemberUserString(uri.SpaceOwner()),
-		Relation: fgastore.RelationSpaceOwner,
-		Object:   fgastore.SpaceObjectKey(uri),
-	}
-}
-
 // WriteTuple writes a relationship tuple, creating it if it does not already
 // exist. The tuple record is stored org-owned (repo = space owner) within the
 // object space, and the relationship is mirrored into FGA. The object space is
@@ -271,7 +261,7 @@ func (s *Store) Check(
 		user,
 		fgaRelation,
 		fgastore.SpaceObjectKey(space),
-		ownerContextualTuple(space),
+		fgastore.OwnerContextualTuple(space),
 		fgastore.OrgMemberContextualTuple(org),
 	)
 }
@@ -292,7 +282,7 @@ func (s *Store) ListSubjects(
 		ctx,
 		fgastore.SpaceObjectKey(space),
 		fgaRelation,
-		ownerContextualTuple(space),
+		fgastore.OwnerContextualTuple(space),
 		fgastore.OrgMemberContextualTuple(org),
 	)
 	if err != nil {

--- a/internal/spaces/server.go
+++ b/internal/spaces/server.go
@@ -261,7 +261,7 @@ func (s *Server) ListMembers(w http.ResponseWriter, r *http.Request) {
 		ctx,
 		fgastore.SpaceObjectKey(spaceURI),
 		fgastore.RelationSpaceReader,
-		ownerContextualTuple(spaceURI),
+		fgastore.OwnerContextualTuple(spaceURI),
 		fgastore.OrgMemberContextualTuple(credInfo.Org.DID()),
 	)
 	if err != nil {

--- a/internal/spaces/store.go
+++ b/internal/spaces/store.go
@@ -267,17 +267,6 @@ func (s *store) WithTx(tx *gorm.DB) Store {
 	}
 }
 
-// ownerContextualTuple returns a Tuple representing the owner relationship,
-// for use as a contextual tuple in FGA queries.  This is how we make the
-// owner a recognized member of the space without storing the owner in FGA.
-func ownerContextualTuple(uri habitat_syntax.SpaceURI) fgastore.Tuple {
-	return fgastore.Tuple{
-		User:     fgastore.MemberUserString(uri.SpaceOwner()),
-		Relation: fgastore.RelationSpaceOwner,
-		Object:   fgastore.SpaceObjectKey(uri),
-	}
-}
-
 func (s *store) CreateSpace(
 	ctx context.Context,
 	org syntax.DID,
@@ -464,7 +453,7 @@ func (s *store) IsMember(
 		fgastore.MemberUserString(did),
 		fgastore.RelationSpaceReader,
 		fgastore.SpaceObjectKey(uri),
-		ownerContextualTuple(uri),
+		fgastore.OwnerContextualTuple(uri),
 		fgastore.OrgMemberContextualTuple(org),
 	)
 }


### PR DESCRIPTION
There's a bit of duplication between the FGA store role definitions and the permission store, will take care of that in a follow up.

Next plan is to start using reference to this instead of fgastore everywhere it's a clean swap in, then migrate the org member / admin relations to spaces instead of its own thing.