### PR TITLE
Add optional basic auth protection for sap internal routes

### DIFF
--- a/cmd/sap/flags.go
+++ b/cmd/sap/flags.go
@@ -3,12 +3,13 @@ package main
 import "github.com/urfave/cli/v3"
 
 var (
-	fDB           = "db"
-	fPort         = "port"
-	fInternalPort = "internal-port"
-	fDomain       = "domain"
-	fLogLevel     = "log-level"
-	fSecret       = "secret"
+	fDB                 = "db"
+	fPort               = "port"
+	fInternalPort       = "internal-port"
+	fDomain             = "domain"
+	fLogLevel           = "log-level"
+	fSecret             = "secret"
+	fInternalAuthSecret = "internal-auth-secret"
 )
 
 func getFlags() []cli.Flag {
@@ -27,9 +28,14 @@ func getFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:    fInternalPort,
-			Usage:   "Internal HTTP port serving the org and channel endpoints",
+			Usage:   "Internal HTTP port serving the org and channel endpoints. If set to the same value as -port, the internal routes are served on the same listener as the public ones.",
 			Value:   "2581",
 			Sources: cli.EnvVars("SAP_INTERNAL_PORT"),
+		},
+		&cli.StringFlag{
+			Name:    fInternalAuthSecret,
+			Usage:   "If set, require HTTP basic auth (any username, this value as the password) on the internal routes",
+			Sources: cli.EnvVars("SAP_INTERNAL_AUTH_SECRET"),
 		},
 		&cli.StringFlag{
 			Name:    fDomain,

--- a/cmd/sap/main.go
+++ b/cmd/sap/main.go
@@ -123,10 +123,18 @@ func runSap(ctx context.Context, cmd *cli.Command) error {
 	internalMux.HandleFunc("/channel", server.handleOutboxChannel)
 	internalMux.HandleFunc("/proxy/", server.handleProxy)
 
+	var internalHandler http.Handler = internalMux
+	if internalAuthSecret := cmd.String(fInternalAuthSecret); internalAuthSecret != "" {
+		internalHandler = basicAuthMiddleware(internalAuthSecret, internalMux)
+	}
+
+	port := cmd.String(fPort)
+	internalPort := cmd.String(fInternalPort)
+
 	slog.InfoContext(
 		ctx, "listening",
-		"oauth_port", cmd.String(fPort),
-		"internal_port", cmd.String(fInternalPort),
+		"oauth_port", port,
+		"internal_port", internalPort,
 	)
 
 	eg, ctx := errgroup.WithContext(ctx)
@@ -135,12 +143,27 @@ func runSap(ctx context.Context, cmd *cli.Command) error {
 		slog.ErrorContext(ctx, "stopped", "error", err)
 		return err
 	})
-	eg.Go(func() error {
-		return serve(ctx, fmt.Sprintf(":%s", cmd.String(fPort)), oauthMux)
-	})
-	eg.Go(func() error {
-		return serve(ctx, fmt.Sprintf(":%s", cmd.String(fInternalPort)), internalMux)
-	})
+
+	if port == internalPort {
+		// Same port configured for both: share a single listener, with the
+		// public OAuth routes taking precedence over the internal ones on
+		// any overlapping pattern.
+		combinedMux := http.NewServeMux()
+		combinedMux.Handle("/", internalHandler)
+		combinedMux.HandleFunc("/oauth-callback", server.handleOAuthCallback)
+		combinedMux.HandleFunc("/client-metadata.json", server.handleClientMetadata)
+		combinedMux.HandleFunc("/xrpc/network.habitat.space.notifyWrite", server.handleNotifyWrite)
+		eg.Go(func() error {
+			return serve(ctx, fmt.Sprintf(":%s", port), combinedMux)
+		})
+	} else {
+		eg.Go(func() error {
+			return serve(ctx, fmt.Sprintf(":%s", port), oauthMux)
+		})
+		eg.Go(func() error {
+			return serve(ctx, fmt.Sprintf(":%s", internalPort), internalHandler)
+		})
+	}
 
 	err = eg.Wait()
 	return err

--- a/cmd/sap/server.go
+++ b/cmd/sap/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -364,6 +365,21 @@ func (s *server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		slog.ErrorContext(r.Context(), "proxy: copy response body", "err", err)
 	}
+}
+
+// basicAuthMiddleware requires an HTTP basic auth password matching secret
+// on every request (the username is ignored). It's used to protect sap's
+// internal routes when a secret is configured.
+func basicAuthMiddleware(secret string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, password, ok := r.BasicAuth()
+		if !ok || subtle.ConstantTimeCompare([]byte(password), []byte(secret)) != 1 {
+			w.Header().Set("WWW-Authenticate", `Basic realm="sap-internal"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *server) handleClientMetadata(w http.ResponseWriter, r *http.Request) {

--- a/cmd/sap/server_test.go
+++ b/cmd/sap/server_test.go
@@ -258,6 +258,41 @@ func TestHandleNotifyWriteRejectsMissingOrInvalidAuth(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
+func TestBasicAuthMiddlewareRejectsMissingOrWrongPassword(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := basicAuthMiddleware("s3cret", next)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	req = httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.SetBasicAuth("anyone", "wrong")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestBasicAuthMiddlewareAllowsAnyUsernameWithCorrectPassword(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := basicAuthMiddleware("s3cret", next)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.SetBasicAuth("whoever", "s3cret")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestHandleTrackSpaceRejectsUnparsableSpace(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Adds optional HTTP basic authentication to protect sap's internal routes, and supports running both public OAuth and internal routes on the same port when configured identically.

## Key Changes
- **Basic auth middleware**: New `basicAuthMiddleware` function that requires HTTP basic auth (any username, configured password) on protected routes. Uses constant-time comparison to prevent timing attacks.
- **Internal auth secret flag**: New `--internal-auth-secret` / `SAP_INTERNAL_AUTH_SECRET` environment variable to enable basic auth on internal routes when set.
- **Shared port support**: When `--port` and `--internal-port` are configured to the same value, both public OAuth and internal routes are served on a single listener with public routes taking precedence on overlapping patterns.
- **Code cleanup**: Extract port values to variables for reuse and improved logging clarity.
- **Test coverage**: Added tests for basic auth middleware behavior (rejecting missing/wrong credentials, allowing correct password with any username).

## Implementation Details
- The basic auth middleware wraps the internal mux only when a secret is configured, avoiding unnecessary overhead when auth is disabled.
- When ports are identical, a combined mux is created with public OAuth routes registered first (taking precedence) followed by the internal handler.
- The middleware uses `crypto/subtle.ConstantTimeCompare` to prevent timing-based password attacks.

https://claude.ai/code/session_01CzERzTLbVz2oHnuFLk2NV1