### PR TITLE
Require callers to marshal records before PutRecord

### DIFF
--- a/cmd/sap/server_test.go
+++ b/cmd/sap/server_test.go
@@ -110,7 +110,7 @@ func TestRedirectToReturnToRedirectsAndClearsPending(t *testing.T) {
 	srv.pendingReturnTo[testDID] = "https://app.example.com/callback"
 	srv.mu.Unlock()
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth-callback", nil)
+	req := httptest.NewRequest(http.MethodGet, "/oauth-callback", http.NoBody)
 	w := httptest.NewRecorder()
 
 	handled := srv.redirectToReturnTo(w, req, testDID)
@@ -136,7 +136,7 @@ func TestHandleListSessions(t *testing.T) {
 	const testSessionID = "session-abc"
 	require.NoError(t, srv.sap.AddSession(t.Context(), testDID, testSessionID))
 
-	req := httptest.NewRequest(http.MethodGet, "/session/list", nil)
+	req := httptest.NewRequest(http.MethodGet, "/session/list", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.handleListSessions(w, req)
@@ -155,7 +155,7 @@ func TestRedirectToReturnToNoPendingFallsBackToFalse(t *testing.T) {
 
 	srv := newTestServer(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth-callback", nil)
+	req := httptest.NewRequest(http.MethodGet, "/oauth-callback", http.NoBody)
 	w := httptest.NewRecorder()
 
 	handled := srv.redirectToReturnTo(w, req, "did:plc:unknown")
@@ -173,7 +173,7 @@ func TestHandleClientMetadataIncludesJWKSForConfidentialClient(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, srv.oauthClient.Config.SetClientSecret(priv, "sap"))
 
-	req := httptest.NewRequest(http.MethodGet, "/client-metadata.json", nil)
+	req := httptest.NewRequest(http.MethodGet, "/client-metadata.json", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.handleClientMetadata(w, req)
@@ -231,7 +231,7 @@ func TestHandleRecrawlRequiresDIDHeader(t *testing.T) {
 
 	srv := newTestServer(t)
 
-	req := httptest.NewRequest(http.MethodPost, "/session/recrawl", nil)
+	req := httptest.NewRequest(http.MethodPost, "/session/recrawl", http.NoBody)
 	w := httptest.NewRecorder()
 	srv.handleRecrawl(w, req)
 	require.Equal(t, http.StatusBadRequest, w.Code)
@@ -246,7 +246,7 @@ func TestHandleRecrawlAllowsMissingSessionHeader(t *testing.T) {
 
 	srv := newTestServer(t)
 
-	req := httptest.NewRequest(http.MethodPost, "/session/recrawl", nil)
+	req := httptest.NewRequest(http.MethodPost, "/session/recrawl", http.NoBody)
 	req.Header.Set(habitatDIDHeader, "did:plc:member")
 	w := httptest.NewRecorder()
 	srv.handleRecrawl(w, req)
@@ -261,7 +261,7 @@ func TestHandleRecrawlSchedulesAndReturnsAccepted(t *testing.T) {
 
 	srv := newTestServer(t)
 
-	req := httptest.NewRequest(http.MethodPost, "/session/recrawl", nil)
+	req := httptest.NewRequest(http.MethodPost, "/session/recrawl", http.NoBody)
 	req.Header.Set(habitatDIDHeader, "did:plc:member")
 	req.Header.Set(habitatSessionHeader, "session-abc")
 	w := httptest.NewRecorder()
@@ -309,12 +309,12 @@ func TestBasicAuthMiddlewareRejectsMissingOrWrongPassword(t *testing.T) {
 	})
 	handler := basicAuthMiddleware("s3cret", next)
 
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	require.Equal(t, http.StatusUnauthorized, w.Code)
 
-	req = httptest.NewRequest(http.MethodGet, "/health", nil)
+	req = httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
 	req.SetBasicAuth("anyone", "wrong")
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
@@ -329,7 +329,7 @@ func TestBasicAuthMiddlewareAllowsAnyUsernameWithCorrectPassword(t *testing.T) {
 	})
 	handler := basicAuthMiddleware("s3cret", next)
 
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
 	req.SetBasicAuth("whoever", "s3cret")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)

--- a/internal/perms/store.go
+++ b/internal/perms/store.go
@@ -125,14 +125,17 @@ func (s *store) SetUserRelation(
 ) (habitat_syntax.SpaceRecordURI, error) {
 	var uri habitat_syntax.SpaceRecordURI
 	err := s.db.Transaction(func(tx *gorm.DB) error {
-		var err error
+		recordBytes, err := spaces.MarshalRecord(habitat.NetworkHabitatRelationshipUserRelation{
+			Subject:   did.String(),
+			Relation:  string(role),
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		})
+		if err != nil {
+			return fmt.Errorf("err marshaling relationship record: %w", err)
+		}
 		uri, _, err = s.spaces.WithTx(tx).
 			PutRecord(ctx, space, space.SpaceOwner(), habitat_syntax.UserRelationCollection, userRelationRkey(did),
-				habitat.NetworkHabitatRelationshipUserRelation{
-					Subject:   did.String(),
-					Relation:  string(role),
-					CreatedAt: time.Now().UTC().Format(time.RFC3339),
-				})
+				recordBytes)
 		if err != nil {
 			return fmt.Errorf("err putting relationship record: %w", err)
 		}
@@ -190,15 +193,18 @@ func (s *store) SetSpaceRoleRelation(
 ) (habitat_syntax.SpaceRecordURI, error) {
 	var uri habitat_syntax.SpaceRecordURI
 	err := s.db.Transaction(func(tx *gorm.DB) error {
-		var err error
+		recordBytes, err := spaces.MarshalRecord(habitat.NetworkHabitatRelationshipSpaceRelation{
+			Subject:     subject.String(),
+			SubjectRole: string(subjectRole),
+			Relation:    string(objectRole),
+			CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		})
+		if err != nil {
+			return fmt.Errorf("err marshaling relationship record: %w", err)
+		}
 		uri, _, err = s.spaces.WithTx(tx).
 			PutRecord(ctx, object, object.SpaceOwner(), habitat_syntax.SpaceRelationCollection, spaceRelationRkey(subject, subjectRole),
-				habitat.NetworkHabitatRelationshipSpaceRelation{
-					Subject:     subject.String(),
-					SubjectRole: string(subjectRole),
-					Relation:    string(objectRole),
-					CreatedAt:   time.Now().UTC().Format(time.RFC3339),
-				})
+				recordBytes)
 		if err != nil {
 			return fmt.Errorf("err putting relationship record: %w", err)
 		}

--- a/internal/simplespace/server_test.go
+++ b/internal/simplespace/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/habitat-network/habitat/internal/authn"
 	authntest "github.com/habitat-network/habitat/internal/authn/testutil"
 	"github.com/habitat-network/habitat/internal/spaces"
+	spaces_testutil "github.com/habitat-network/habitat/internal/spaces/testutil"
 	habitat_syntax "github.com/habitat-network/habitat/internal/syntax"
 )
 
@@ -307,7 +308,7 @@ func TestServer_SpaceLifecycle(t *testing.T) {
 		owner,
 		coll,
 		"k1",
-		mustMarshalRecord(t, map[string]any{"x": 1}),
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
 	)
 	require.NoError(t, err)
 
@@ -334,7 +335,7 @@ func TestServer_SpaceLifecycle(t *testing.T) {
 		alice,
 		coll,
 		"k1",
-		mustMarshalRecord(t, map[string]any{"x": 2}),
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
 	)
 	require.NoError(t, err)
 

--- a/internal/simplespace/server_test.go
+++ b/internal/simplespace/server_test.go
@@ -307,7 +307,7 @@ func TestServer_SpaceLifecycle(t *testing.T) {
 		owner,
 		coll,
 		"k1",
-		map[string]any{"x": 1},
+		mustMarshalRecord(t, map[string]any{"x": 1}),
 	)
 	require.NoError(t, err)
 
@@ -334,7 +334,7 @@ func TestServer_SpaceLifecycle(t *testing.T) {
 		alice,
 		coll,
 		"k1",
-		map[string]any{"x": 2},
+		mustMarshalRecord(t, map[string]any{"x": 2}),
 	)
 	require.NoError(t, err)
 

--- a/internal/simplespace/store_test.go
+++ b/internal/simplespace/store_test.go
@@ -214,9 +214,23 @@ func TestDeleteSpace(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.spaces.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"r1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.spaces.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"r2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
 	require.NoError(t, s.AddMember(t.Context(), uri, alice))
 

--- a/internal/simplespace/store_test.go
+++ b/internal/simplespace/store_test.go
@@ -22,6 +22,15 @@ var (
 	groupType = syntax.NSID("network.habitat.group")
 )
 
+// mustMarshalRecord validates and CBOR-encodes value the way a real
+// PutRecord caller must before calling the store's PutRecord.
+func mustMarshalRecord(t *testing.T, value any) []byte {
+	t.Helper()
+	bytes, err := spaces.MarshalRecord(value)
+	require.NoError(t, err)
+	return bytes
+}
+
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 
@@ -214,9 +223,9 @@ func TestDeleteSpace(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r1", map[string]any{"x": 1})
+	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r2", map[string]any{"x": 2})
+	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r2", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 	require.NoError(t, s.AddMember(t.Context(), uri, alice))
 

--- a/internal/simplespace/store_test.go
+++ b/internal/simplespace/store_test.go
@@ -22,15 +22,6 @@ var (
 	groupType = syntax.NSID("network.habitat.group")
 )
 
-// mustMarshalRecord validates and CBOR-encodes value the way a real
-// PutRecord caller must before calling the store's PutRecord.
-func mustMarshalRecord(t *testing.T, value any) []byte {
-	t.Helper()
-	bytes, err := spaces.MarshalRecord(value)
-	require.NoError(t, err)
-	return bytes
-}
-
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 
@@ -223,9 +214,9 @@ func TestDeleteSpace(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r2", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.spaces.PutRecord(t.Context(), uri, owner, coll, "r2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 	require.NoError(t, s.AddMember(t.Context(), uri, alice))
 

--- a/internal/spaces/server/server.go
+++ b/internal/spaces/server/server.go
@@ -206,19 +206,24 @@ func (s *Server) PutRecord(w http.ResponseWriter, r *http.Request) {
 		httpx.WriteInvalidRequest(ctx, w, "record must be a JSON object", nil)
 		return
 	}
+	recordBytes, err := spaces.MarshalRecord(value)
+	if errors.Is(err, spaces.ErrInvalidRecord) {
+		httpx.WriteInvalidRequest(ctx, w, fmt.Sprintf("invalid record: %v", err), err)
+		return
+	} else if err != nil {
+		httpx.WriteServerError(ctx, w, fmt.Errorf("marshal record: %w", err))
+		return
+	}
 	recordURI, cid, err := s.store.PutRecord(
 		ctx,
 		spaceURI,
 		repo,
 		collection,
 		rkey,
-		value,
+		recordBytes,
 	)
 	if errors.Is(err, spaces.ErrSpaceNotFound) {
 		httpx.WriteSpaceNotFound(ctx, w, err)
-		return
-	} else if errors.Is(err, spaces.ErrInvalidRecord) {
-		httpx.WriteInvalidRequest(ctx, w, fmt.Sprintf("invalid record: %v", err), err)
 		return
 	} else if err != nil {
 		httpx.WriteServerError(ctx, w, fmt.Errorf("put record: %w", err))

--- a/internal/spaces/server/server_test.go
+++ b/internal/spaces/server/server_test.go
@@ -57,15 +57,6 @@ func newTestStore(t *testing.T) (atcrypto.PrivateKey, spaces.Store) {
 	return key, spaces_testutil.NewTestStore(t, spaces_testutil.WithHostKey(key))
 }
 
-// mustMarshalRecord validates and CBOR-encodes value the way a real
-// PutRecord caller must before calling the store's PutRecord.
-func mustMarshalRecord(t *testing.T, value any) []byte {
-	t.Helper()
-	bytes, err := spaces.MarshalRecord(value)
-	require.NoError(t, err)
-	return bytes
-}
-
 func newTestServerWithOpts(
 	t *testing.T,
 	key atcrypto.PrivateKey,
@@ -168,7 +159,7 @@ func TestServer_ListSpaces(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -200,7 +191,7 @@ func TestServer_ListRepos(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -281,7 +272,7 @@ func TestServer_DeleteRecord(t *testing.T) {
 		owner,
 		syntax.NSID("network.habitat.note"),
 		"del-me",
-		mustMarshalRecord(t, map[string]any{"x": 1}),
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
 	)
 	require.NoError(t, err)
 
@@ -317,9 +308,9 @@ func TestServer_ListRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -356,7 +347,7 @@ func TestServer_GetRepo(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -529,7 +520,7 @@ func TestServer_DeleteRecord_Unauthorized(t *testing.T) {
 		owner,
 		syntax.NSID("network.habitat.note"),
 		"test",
-		mustMarshalRecord(t, map[string]any{"x": 1}),
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
 	)
 	require.NoError(t, err)
 
@@ -557,9 +548,9 @@ func TestServer_ListRepoOps(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -599,7 +590,7 @@ func TestServer_ListRepoOps_IncludesSignedCommit(t *testing.T) {
 
 	uri, err := store.CreateSpace(t.Context(), orgID, groupType, "test")
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -647,7 +638,7 @@ func TestServer_GetLatestCommit(t *testing.T) {
 
 	uri, err := store.CreateSpace(t.Context(), orgID, groupType, "test")
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -714,9 +705,9 @@ func TestServer_ListRepoOps_Since(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -763,7 +754,7 @@ func TestServer_ListRepoOps_IncludesValue(t *testing.T) {
 		owner,
 		coll,
 		"k1",
-		mustMarshalRecord(t, map[string]any{"text": "hello"}),
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"text": "hello"}),
 	)
 	require.NoError(t, err)
 
@@ -804,7 +795,7 @@ func TestServer_ListRepoOps_ExcludeValues(t *testing.T) {
 		owner,
 		coll,
 		"k1",
-		mustMarshalRecord(t, map[string]any{"text": "hello"}),
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"text": "hello"}),
 	)
 	require.NoError(t, err)
 
@@ -840,7 +831,7 @@ func TestServer_ListRepoOpsSinceAheadRejects(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 
 	// A TID-like string that sorts after any real TID (base32 is a-z + 2-7).

--- a/internal/spaces/server/server_test.go
+++ b/internal/spaces/server/server_test.go
@@ -159,7 +159,14 @@ func TestServer_ListSpaces(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -191,7 +198,14 @@ func TestServer_ListRepos(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -308,9 +322,23 @@ func TestServer_ListRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -347,7 +375,14 @@ func TestServer_GetRepo(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -548,9 +583,23 @@ func TestServer_ListRepoOps(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -590,7 +639,14 @@ func TestServer_ListRepoOps_IncludesSignedCommit(t *testing.T) {
 
 	uri, err := store.CreateSpace(t.Context(), orgID, groupType, "test")
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		groupType,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -638,7 +694,14 @@ func TestServer_GetLatestCommit(t *testing.T) {
 
 	uri, err := store.CreateSpace(t.Context(), orgID, groupType, "test")
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		groupType,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -705,9 +768,23 @@ func TestServer_ListRepoOps_Since(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -831,7 +908,14 @@ func TestServer_ListRepoOpsSinceAheadRejects(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
+	_, _, err = store.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}),
+	)
 	require.NoError(t, err)
 
 	// A TID-like string that sorts after any real TID (base32 is a-z + 2-7).

--- a/internal/spaces/server/server_test.go
+++ b/internal/spaces/server/server_test.go
@@ -57,6 +57,15 @@ func newTestStore(t *testing.T) (atcrypto.PrivateKey, spaces.Store) {
 	return key, spaces_testutil.NewTestStore(t, spaces_testutil.WithHostKey(key))
 }
 
+// mustMarshalRecord validates and CBOR-encodes value the way a real
+// PutRecord caller must before calling the store's PutRecord.
+func mustMarshalRecord(t *testing.T, value any) []byte {
+	t.Helper()
+	bytes, err := spaces.MarshalRecord(value)
+	require.NoError(t, err)
+	return bytes
+}
+
 func newTestServerWithOpts(
 	t *testing.T,
 	key atcrypto.PrivateKey,
@@ -159,7 +168,7 @@ func TestServer_ListSpaces(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -191,7 +200,7 @@ func TestServer_ListRepos(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -272,7 +281,7 @@ func TestServer_DeleteRecord(t *testing.T) {
 		owner,
 		syntax.NSID("network.habitat.note"),
 		"del-me",
-		map[string]any{"x": 1},
+		mustMarshalRecord(t, map[string]any{"x": 1}),
 	)
 	require.NoError(t, err)
 
@@ -308,9 +317,9 @@ func TestServer_ListRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", map[string]any{"x": 2})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -347,7 +356,7 @@ func TestServer_GetRepo(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -520,7 +529,7 @@ func TestServer_DeleteRecord_Unauthorized(t *testing.T) {
 		owner,
 		syntax.NSID("network.habitat.note"),
 		"test",
-		map[string]any{"x": 1},
+		mustMarshalRecord(t, map[string]any{"x": 1}),
 	)
 	require.NoError(t, err)
 
@@ -548,9 +557,9 @@ func TestServer_ListRepoOps(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", map[string]any{"x": 2})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -590,7 +599,7 @@ func TestServer_ListRepoOps_IncludesSignedCommit(t *testing.T) {
 
 	uri, err := store.CreateSpace(t.Context(), orgID, groupType, "test")
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", map[string]any{"x": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -638,7 +647,7 @@ func TestServer_GetLatestCommit(t *testing.T) {
 
 	uri, err := store.CreateSpace(t.Context(), orgID, groupType, "test")
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", map[string]any{"x": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -705,9 +714,9 @@ func TestServer_ListRepoOps_Since(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", map[string]any{"x": 2})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(
@@ -754,7 +763,7 @@ func TestServer_ListRepoOps_IncludesValue(t *testing.T) {
 		owner,
 		coll,
 		"k1",
-		map[string]any{"text": "hello"},
+		mustMarshalRecord(t, map[string]any{"text": "hello"}),
 	)
 	require.NoError(t, err)
 
@@ -795,7 +804,7 @@ func TestServer_ListRepoOps_ExcludeValues(t *testing.T) {
 		owner,
 		coll,
 		"k1",
-		map[string]any{"text": "hello"},
+		mustMarshalRecord(t, map[string]any{"text": "hello"}),
 	)
 	require.NoError(t, err)
 
@@ -831,7 +840,7 @@ func TestServer_ListRepoOpsSinceAheadRejects(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 1})
+	_, _, err = store.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 
 	// A TID-like string that sorts after any real TID (base32 is a-z + 2-7).

--- a/internal/spaces/store.go
+++ b/internal/spaces/store.go
@@ -109,16 +109,16 @@ type Store interface {
 
 	// Record operations
 	//
-	// PutRecord takes the record value as already-validated CBOR bytes
-	// (see [MarshalRecord]) — it is the caller's responsibility to validate
-	// and marshal user input before calling PutRecord.
+	// PutRecord takes the record value as a [MarshaledRecord] — callers must
+	// validate and marshal user input via [MarshalRecord] before calling
+	// PutRecord.
 	PutRecord(
 		ctx context.Context,
 		space habitat_syntax.SpaceURI,
 		owner syntax.DID,
 		collection syntax.NSID,
 		rkey syntax.RecordKey,
-		value []byte,
+		value MarshaledRecord,
 	) (habitat_syntax.SpaceRecordURI, *cid.Cid, error)
 	GetRecord(
 		ctx context.Context,
@@ -444,7 +444,7 @@ func (s *store) PutRecord(
 	repo syntax.DID,
 	collection syntax.NSID,
 	rkey syntax.RecordKey,
-	value []byte,
+	value MarshaledRecord,
 ) (habitat_syntax.SpaceRecordURI, *cid.Cid, error) {
 	ctx, span := tracer.Start(ctx, "PutRecord", trace.WithAttributes(
 		attribute.String("space", spaceURI.String()),

--- a/internal/spaces/store.go
+++ b/internal/spaces/store.go
@@ -109,13 +109,17 @@ type Store interface {
 	) ([]RepoInfo, error)
 
 	// Record operations
+	//
+	// PutRecord takes the record value as already-validated CBOR bytes
+	// (see [MarshalRecord]) — it is the caller's responsibility to validate
+	// and marshal user input before calling PutRecord.
 	PutRecord(
 		ctx context.Context,
 		space habitat_syntax.SpaceURI,
 		owner syntax.DID,
 		collection syntax.NSID,
 		rkey syntax.RecordKey,
-		value any,
+		value []byte,
 	) (habitat_syntax.SpaceRecordURI, *cid.Cid, error)
 	GetRecord(
 		ctx context.Context,
@@ -435,13 +439,37 @@ func (s *store) ListRepos(
 
 // ---- Record operations ----
 
+// MarshalRecord validates value against the atproto data model and encodes
+// it as the CBOR bytes PutRecord expects. Callers must run their input
+// through this (or otherwise produce equivalent, validated CBOR) before
+// calling PutRecord.
+func MarshalRecord(value any) ([]byte, error) {
+	jsonBytes, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal value: %w", err)
+	}
+	// validates against atproto data model
+	recordMap, err := atdata.UnmarshalJSON(jsonBytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRecord, err)
+	}
+	bytes, err := atdata.MarshalCBOR(recordMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal record: %w", err)
+	}
+	if len(bytes) > atdata.MAX_CBOR_RECORD_SIZE {
+		return nil, ErrRecordTooLarge
+	}
+	return bytes, nil
+}
+
 func (s *store) PutRecord(
 	ctx context.Context,
 	spaceURI habitat_syntax.SpaceURI,
 	repo syntax.DID,
 	collection syntax.NSID,
 	rkey syntax.RecordKey,
-	value any,
+	value []byte,
 ) (habitat_syntax.SpaceRecordURI, *cid.Cid, error) {
 	ctx, span := tracer.Start(ctx, "PutRecord", trace.WithAttributes(
 		attribute.String("space", spaceURI.String()),
@@ -455,25 +483,12 @@ func (s *store) PutRecord(
 	} else if !ok {
 		return "", nil, ErrSpaceNotFound
 	}
-	jsonBytes, err := json.Marshal(value)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to marshal value: %w", err)
-	}
-	// validates against atproto data model
-	recordMap, err := atdata.UnmarshalJSON(jsonBytes)
-	if err != nil {
-		return "", nil, fmt.Errorf("%w: %w", ErrInvalidRecord, err)
-	}
-	bytes, err := atdata.MarshalCBOR(recordMap)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to marshal record: %w", err)
-	}
-	span.SetAttributes(attribute.Int("cbor_bytes", len(bytes)))
-	if len(bytes) > atdata.MAX_CBOR_RECORD_SIZE {
+	span.SetAttributes(attribute.Int("cbor_bytes", len(value)))
+	if len(value) > atdata.MAX_CBOR_RECORD_SIZE {
 		return "", nil, ErrRecordTooLarge
 	}
 
-	newCid, err := cid.NewPrefixV1(cid.DagCBOR, multihash.SHA2_256).Sum(bytes)
+	newCid, err := cid.NewPrefixV1(cid.DagCBOR, multihash.SHA2_256).Sum(value)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to compute cid: %w", err)
 	}
@@ -527,7 +542,7 @@ func (s *store) PutRecord(
 			Space:      spaceURI,
 			Collection: collection,
 			Rkey:       rkey,
-			Value:      bytes,
+			Value:      value,
 			Rev:        tid,
 			PrevCid:    existing.Cid,
 			Cid:        newCidStr,

--- a/internal/spaces/store.go
+++ b/internal/spaces/store.go
@@ -459,9 +459,6 @@ func (s *store) PutRecord(
 		return "", nil, ErrSpaceNotFound
 	}
 	span.SetAttributes(attribute.Int("cbor_bytes", len(value)))
-	if len(value) > atdata.MAX_CBOR_RECORD_SIZE {
-		return "", nil, ErrRecordTooLarge
-	}
 
 	newCid, err := cid.NewPrefixV1(cid.DagCBOR, multihash.SHA2_256).Sum(value)
 	if err != nil {

--- a/internal/spaces/store.go
+++ b/internal/spaces/store.go
@@ -2,7 +2,6 @@ package spaces
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -438,30 +437,6 @@ func (s *store) ListRepos(
 }
 
 // ---- Record operations ----
-
-// MarshalRecord validates value against the atproto data model and encodes
-// it as the CBOR bytes PutRecord expects. Callers must run their input
-// through this (or otherwise produce equivalent, validated CBOR) before
-// calling PutRecord.
-func MarshalRecord(value any) ([]byte, error) {
-	jsonBytes, err := json.Marshal(value)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal value: %w", err)
-	}
-	// validates against atproto data model
-	recordMap, err := atdata.UnmarshalJSON(jsonBytes)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidRecord, err)
-	}
-	bytes, err := atdata.MarshalCBOR(recordMap)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal record: %w", err)
-	}
-	if len(bytes) > atdata.MAX_CBOR_RECORD_SIZE {
-		return nil, ErrRecordTooLarge
-	}
-	return bytes, nil
-}
 
 func (s *store) PutRecord(
 	ctx context.Context,

--- a/internal/spaces/store_test.go
+++ b/internal/spaces/store_test.go
@@ -21,6 +21,15 @@ var (
 	groupType = syntax.NSID("network.habitat.group")
 )
 
+// mustMarshalRecord validates and CBOR-encodes value the way a real
+// PutRecord caller must before calling the store's PutRecord.
+func mustMarshalRecord(t *testing.T, value any) []byte {
+	t.Helper()
+	bytes, err := spaces.MarshalRecord(value)
+	require.NoError(t, err)
+	return bytes
+}
+
 func TestCreateSpace(t *testing.T) {
 	s := spaces_testutil.NewTestStore(t)
 
@@ -61,9 +70,9 @@ func TestListSpaces(t *testing.T) {
 	// permissioned repo in — the ones it has written to — and consults no
 	// access store.
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), space1, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), space1, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), space2, alice, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), space2, alice, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	// Owner sees the space it wrote to, not the one it was merely granted read
@@ -97,7 +106,7 @@ func TestListSpaces_OwningASpaceIsNotWritingToIt(t *testing.T) {
 	// A write on the org's behalf — how relationship tuples land in a space —
 	// puts that one space, and only that one, on its listing.
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), space1, orgID, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), space1, orgID, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	spaces, err = s.ListSpaces(t.Context(), orgID, nil, nil)
@@ -112,7 +121,7 @@ func TestListSpaces_LeavesListingAfterSpaceIsDeleted(t *testing.T) {
 	uri, err := s.CreateSpace(t.Context(), orgID, groupType, "space1")
 	require.NoError(t, err)
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	// Deleting the space drops its permissioned repos, so it leaves the
@@ -131,7 +140,7 @@ func TestListSpaces_LeavesListingAfterDeletingAllRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, nil, nil)
@@ -158,9 +167,9 @@ func TestListSpaces_FilterByType(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), group1, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), group1, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), personal1, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), personal1, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, nil, &groupType)
@@ -185,9 +194,9 @@ func TestListSpaces_FilterByOwnerWithWildcardInDID(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), wanted, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), wanted, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), other, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), other, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, &orgWithPort, nil)
@@ -208,9 +217,9 @@ func TestListSpaces_NilOwnerFilterSpansAllOrgs(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), spaceA, member, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), spaceA, member, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), spaceB, member, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), spaceB, member, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	// With no owner filter, the member sees spaces across every org they
@@ -244,9 +253,9 @@ func TestListRepos_WithRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, alice, coll, "k2", map[string]any{"x": 2})
+	_, _, err = s.PutRecord(t.Context(), uri, alice, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	repos, err := s.ListRepos(t.Context(), uri)
@@ -270,9 +279,9 @@ func TestListRepos_HashMatchesLtHash(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", map[string]any{"x": 2})
+	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	repos, err := s.ListRepos(t.Context(), uri)
@@ -302,7 +311,7 @@ func TestPutAndGetRecord(t *testing.T) {
 	coll := syntax.NSID("network.habitat.note")
 	val := map[string]any{"text": "hello world"}
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "my-rkey", val)
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "my-rkey", mustMarshalRecord(t, val))
 	require.NoError(t, err)
 
 	rec, err := s.GetRecord(t.Context(), uri, owner, coll, "my-rkey")
@@ -319,7 +328,7 @@ func TestPutRecord_SpaceNotFound(t *testing.T) {
 
 	uri := habitat_syntax.ConstructSpaceURI(owner, groupType, "nonexistent")
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.ErrorIs(t, err, spaces.ErrSpaceNotFound)
 }
 
@@ -331,10 +340,10 @@ func TestPutRecord_UpdateExisting(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", map[string]any{"v": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", mustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", map[string]any{"v": 2})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", mustMarshalRecord(t, map[string]any{"v": 2}))
 	require.NoError(t, err)
 
 	rec, err := s.GetRecord(t.Context(), uri, owner, coll, "rkey")
@@ -361,11 +370,11 @@ func TestListRecords(t *testing.T) {
 
 	collA := syntax.NSID("network.habitat.alpha")
 	collB := syntax.NSID("network.habitat.beta")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k2", map[string]any{"x": 2})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collB, "k1", map[string]any{"x": 3})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, collB, "k1", mustMarshalRecord(t, map[string]any{"x": 3}))
 	require.NoError(t, err)
 
 	// All records
@@ -382,18 +391,12 @@ func TestListRecords(t *testing.T) {
 	}
 }
 
-func TestPutRecord_RejectsNonIntegerFloat(t *testing.T) {
-	s := spaces_testutil.NewTestStore(t)
-
-	uri, err := s.CreateSpace(t.Context(), orgID, groupType, "test")
-	require.NoError(t, err)
-
-	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 0.15})
+// TestMarshalRecord_RejectsNonIntegerFloat pins that MarshalRecord — which
+// callers must run over user input before calling PutRecord — rejects values
+// that don't conform to the atproto data model.
+func TestMarshalRecord_RejectsNonIntegerFloat(t *testing.T) {
+	_, err := spaces.MarshalRecord(map[string]any{"x": 0.15})
 	require.ErrorIs(t, err, spaces.ErrInvalidRecord)
-
-	_, err = s.GetRecord(t.Context(), uri, owner, coll, "k1")
-	require.ErrorIs(t, err, spaces.ErrRecordNotFound)
 }
 
 func TestDeleteRecord(t *testing.T) {
@@ -403,7 +406,7 @@ func TestDeleteRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	err = s.DeleteRecord(t.Context(), uri, owner, coll, "rkey")
@@ -427,7 +430,7 @@ func TestRepoHash_IncrementalOnUpdateAndDelete(t *testing.T) {
 	require.NoError(t, err)
 	coll := syntax.NSID("network.habitat.note")
 
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 1})
+	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 	var want1 spacecommit.LtHash
 	want1.Add(spacecommit.RecordElement(coll, "k1", cid1.String()))
@@ -437,7 +440,7 @@ func TestRepoHash_IncrementalOnUpdateAndDelete(t *testing.T) {
 	require.Equal(t, want1.Sum(), hash)
 
 	// Update the same rkey: the old element must be folded out and the new in.
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 2})
+	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 2}))
 	require.NoError(t, err)
 	require.NotEqual(t, cid1.String(), cid2.String())
 	var want2 spacecommit.LtHash
@@ -514,9 +517,9 @@ func TestDeleteSpace(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r2", map[string]any{"x": 2})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r2", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	err = s.DeleteSpace(t.Context(), uri)
@@ -554,11 +557,11 @@ func TestListRepoOps(t *testing.T) {
 		require.Len(t, records, 0)
 	})
 	t.Run("multiple", func(t *testing.T) {
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", map[string]any{"x": 1})
+		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 		require.NoError(t, err)
-		_, _, err = s.PutRecord(ctx, uri, alice, coll, "k2", map[string]any{"x": 2})
+		_, _, err = s.PutRecord(ctx, uri, alice, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
 		require.NoError(t, err)
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k3", map[string]any{"x": 3})
+		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k3", mustMarshalRecord(t, map[string]any{"x": 3}))
 		require.NoError(t, err)
 
 		records, _, err := s.ListRepoOps(ctx, uri, owner, "", 1)
@@ -598,7 +601,7 @@ func TestListRepoOps(t *testing.T) {
 
 	t.Run("includes value", func(t *testing.T) {
 		owner := syntax.DID("did:web:bob")
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", map[string]any{"text": "hello"})
+		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"text": "hello"}))
 		require.NoError(t, err)
 
 		records, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
@@ -617,7 +620,7 @@ func TestPutRecordTriggersNotify(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	require.Len(t, notifier.Writes, 1)
@@ -634,17 +637,17 @@ func TestPutRecordSkipsNotifyWhenCidUnchanged(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 1)
 
 	// Writing the exact same value again produces the same CID.
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 1, "no-op write should not trigger another notify")
 
 	// A write that actually changes the content still notifies.
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"x": 2})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 2)
 }
@@ -669,9 +672,9 @@ func TestListRepoOpsPrev(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 1})
+	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 2})
+	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 2}))
 	require.NoError(t, err)
 
 	// An update overwrites in place: one op whose prev is the old cid.
@@ -701,7 +704,7 @@ func TestListRepoOpsPrevCreateIsEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 
 	ops, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
@@ -721,9 +724,9 @@ func TestPutRecordNotifiesRepoHash(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 1})
+	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", map[string]any{"v": 2})
+	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"v": 2}))
 	require.NoError(t, err)
 
 	require.Len(t, notifier.Writes, 2)
@@ -745,7 +748,7 @@ func TestListRepoOps_RevTooFar(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", map[string]any{"v": 1})
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 
 	// A TID-like string that sorts after any real TID (base32 is a-z + 2-7).

--- a/internal/spaces/store_test.go
+++ b/internal/spaces/store_test.go
@@ -61,9 +61,23 @@ func TestListSpaces(t *testing.T) {
 	// permissioned repo in — the ones it has written to — and consults no
 	// access store.
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), space1, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		space1,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), space2, alice, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		space2,
+		alice,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	// Owner sees the space it wrote to, not the one it was merely granted read
@@ -97,7 +111,14 @@ func TestListSpaces_OwningASpaceIsNotWritingToIt(t *testing.T) {
 	// A write on the org's behalf — how relationship tuples land in a space —
 	// puts that one space, and only that one, on its listing.
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), space1, orgID, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		space1,
+		orgID,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	spaces, err = s.ListSpaces(t.Context(), orgID, nil, nil)
@@ -112,7 +133,14 @@ func TestListSpaces_LeavesListingAfterSpaceIsDeleted(t *testing.T) {
 	uri, err := s.CreateSpace(t.Context(), orgID, groupType, "space1")
 	require.NoError(t, err)
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	// Deleting the space drops its permissioned repos, so it leaves the
@@ -131,7 +159,14 @@ func TestListSpaces_LeavesListingAfterDeletingAllRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, nil, nil)
@@ -158,9 +193,23 @@ func TestListSpaces_FilterByType(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), group1, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		group1,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), personal1, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		personal1,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, nil, &groupType)
@@ -185,9 +234,23 @@ func TestListSpaces_FilterByOwnerWithWildcardInDID(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), wanted, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		wanted,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), other, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		other,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, &orgWithPort, nil)
@@ -208,9 +271,23 @@ func TestListSpaces_NilOwnerFilterSpansAllOrgs(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), spaceA, member, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		spaceA,
+		member,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), spaceB, member, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		spaceB,
+		member,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	// With no owner filter, the member sees spaces across every org they
@@ -244,9 +321,23 @@ func TestListRepos_WithRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, alice, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		alice,
+		coll,
+		"k2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
 
 	repos, err := s.ListRepos(t.Context(), uri)
@@ -270,9 +361,23 @@ func TestListRepos_HashMatchesLtHash(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, cid1, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, cid2, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
 
 	repos, err := s.ListRepos(t.Context(), uri)
@@ -302,7 +407,14 @@ func TestPutAndGetRecord(t *testing.T) {
 	coll := syntax.NSID("network.habitat.note")
 	val := map[string]any{"text": "hello world"}
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "my-rkey", spaces_testutil.MustMarshalRecord(t, val))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"my-rkey",
+		spaces_testutil.MustMarshalRecord(t, val),
+	)
 	require.NoError(t, err)
 
 	rec, err := s.GetRecord(t.Context(), uri, owner, coll, "my-rkey")
@@ -319,7 +431,14 @@ func TestPutRecord_SpaceNotFound(t *testing.T) {
 
 	uri := habitat_syntax.ConstructSpaceURI(owner, groupType, "nonexistent")
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.ErrorIs(t, err, spaces.ErrSpaceNotFound)
 }
 
@@ -331,10 +450,24 @@ func TestPutRecord_UpdateExisting(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"rkey",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}),
+	)
 	require.NoError(t, err)
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"rkey",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}),
+	)
 	require.NoError(t, err)
 
 	rec, err := s.GetRecord(t.Context(), uri, owner, coll, "rkey")
@@ -361,11 +494,32 @@ func TestListRecords(t *testing.T) {
 
 	collA := syntax.NSID("network.habitat.alpha")
 	collB := syntax.NSID("network.habitat.beta")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		collA,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		collA,
+		"k2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collB, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 3}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		collB,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 3}),
+	)
 	require.NoError(t, err)
 
 	// All records
@@ -389,7 +543,14 @@ func TestDeleteRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"rkey",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	err = s.DeleteRecord(t.Context(), uri, owner, coll, "rkey")
@@ -413,7 +574,14 @@ func TestRepoHash_IncrementalOnUpdateAndDelete(t *testing.T) {
 	require.NoError(t, err)
 	coll := syntax.NSID("network.habitat.note")
 
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
+	_, cid1, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}),
+	)
 	require.NoError(t, err)
 	var want1 spacecommit.LtHash
 	want1.Add(spacecommit.RecordElement(coll, "k1", cid1.String()))
@@ -423,7 +591,14 @@ func TestRepoHash_IncrementalOnUpdateAndDelete(t *testing.T) {
 	require.Equal(t, want1.Sum(), hash)
 
 	// Update the same rkey: the old element must be folded out and the new in.
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}))
+	_, cid2, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}),
+	)
 	require.NoError(t, err)
 	require.NotEqual(t, cid1.String(), cid2.String())
 	var want2 spacecommit.LtHash
@@ -500,9 +675,23 @@ func TestDeleteSpace(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"r1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"r2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
 
 	err = s.DeleteSpace(t.Context(), uri)
@@ -540,11 +729,32 @@ func TestListRepoOps(t *testing.T) {
 		require.Len(t, records, 0)
 	})
 	t.Run("multiple", func(t *testing.T) {
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+		_, _, err = s.PutRecord(
+			ctx,
+			uri,
+			owner,
+			coll,
+			"k1",
+			spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+		)
 		require.NoError(t, err)
-		_, _, err = s.PutRecord(ctx, uri, alice, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+		_, _, err = s.PutRecord(
+			ctx,
+			uri,
+			alice,
+			coll,
+			"k2",
+			spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+		)
 		require.NoError(t, err)
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k3", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 3}))
+		_, _, err = s.PutRecord(
+			ctx,
+			uri,
+			owner,
+			coll,
+			"k3",
+			spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 3}),
+		)
 		require.NoError(t, err)
 
 		records, _, err := s.ListRepoOps(ctx, uri, owner, "", 1)
@@ -584,7 +794,14 @@ func TestListRepoOps(t *testing.T) {
 
 	t.Run("includes value", func(t *testing.T) {
 		owner := syntax.DID("did:web:bob")
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"text": "hello"}))
+		_, _, err = s.PutRecord(
+			ctx,
+			uri,
+			owner,
+			coll,
+			"k1",
+			spaces_testutil.MustMarshalRecord(t, map[string]any{"text": "hello"}),
+		)
 		require.NoError(t, err)
 
 		records, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
@@ -603,7 +820,14 @@ func TestPutRecordTriggersNotify(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 
 	require.Len(t, notifier.Writes, 1)
@@ -620,17 +844,38 @@ func TestPutRecordSkipsNotifyWhenCidUnchanged(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 1)
 
 	// Writing the exact same value again produces the same CID.
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}),
+	)
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 1, "no-op write should not trigger another notify")
 
 	// A write that actually changes the content still notifies.
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}),
+	)
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 2)
 }
@@ -655,9 +900,23 @@ func TestListRepoOpsPrev(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
+	_, cid1, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}),
+	)
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}))
+	_, cid2, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}),
+	)
 	require.NoError(t, err)
 
 	// An update overwrites in place: one op whose prev is the old cid.
@@ -687,7 +946,14 @@ func TestListRepoOpsPrevCreateIsEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}),
+	)
 	require.NoError(t, err)
 
 	ops, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
@@ -707,9 +973,23 @@ func TestPutRecordNotifiesRepoHash(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
+	_, cid1, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}),
+	)
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}))
+	_, cid2, err := s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k2",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}),
+	)
 	require.NoError(t, err)
 
 	require.Len(t, notifier.Writes, 2)
@@ -731,7 +1011,14 @@ func TestListRepoOps_RevTooFar(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
+	_, _, err = s.PutRecord(
+		t.Context(),
+		uri,
+		owner,
+		coll,
+		"k1",
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}),
+	)
 	require.NoError(t, err)
 
 	// A TID-like string that sorts after any real TID (base32 is a-z + 2-7).

--- a/internal/spaces/store_test.go
+++ b/internal/spaces/store_test.go
@@ -21,15 +21,6 @@ var (
 	groupType = syntax.NSID("network.habitat.group")
 )
 
-// mustMarshalRecord validates and CBOR-encodes value the way a real
-// PutRecord caller must before calling the store's PutRecord.
-func mustMarshalRecord(t *testing.T, value any) []byte {
-	t.Helper()
-	bytes, err := spaces.MarshalRecord(value)
-	require.NoError(t, err)
-	return bytes
-}
-
 func TestCreateSpace(t *testing.T) {
 	s := spaces_testutil.NewTestStore(t)
 
@@ -70,9 +61,9 @@ func TestListSpaces(t *testing.T) {
 	// permissioned repo in — the ones it has written to — and consults no
 	// access store.
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), space1, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), space1, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), space2, alice, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), space2, alice, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	// Owner sees the space it wrote to, not the one it was merely granted read
@@ -106,7 +97,7 @@ func TestListSpaces_OwningASpaceIsNotWritingToIt(t *testing.T) {
 	// A write on the org's behalf — how relationship tuples land in a space —
 	// puts that one space, and only that one, on its listing.
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), space1, orgID, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), space1, orgID, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	spaces, err = s.ListSpaces(t.Context(), orgID, nil, nil)
@@ -121,7 +112,7 @@ func TestListSpaces_LeavesListingAfterSpaceIsDeleted(t *testing.T) {
 	uri, err := s.CreateSpace(t.Context(), orgID, groupType, "space1")
 	require.NoError(t, err)
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	// Deleting the space drops its permissioned repos, so it leaves the
@@ -140,7 +131,7 @@ func TestListSpaces_LeavesListingAfterDeletingAllRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, nil, nil)
@@ -167,9 +158,9 @@ func TestListSpaces_FilterByType(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), group1, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), group1, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), personal1, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), personal1, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, nil, &groupType)
@@ -194,9 +185,9 @@ func TestListSpaces_FilterByOwnerWithWildcardInDID(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), wanted, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), wanted, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), other, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), other, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	spaces, err := s.ListSpaces(t.Context(), owner, &orgWithPort, nil)
@@ -217,9 +208,9 @@ func TestListSpaces_NilOwnerFilterSpansAllOrgs(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), spaceA, member, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), spaceA, member, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), spaceB, member, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), spaceB, member, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	// With no owner filter, the member sees spaces across every org they
@@ -253,9 +244,9 @@ func TestListRepos_WithRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, alice, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.PutRecord(t.Context(), uri, alice, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	repos, err := s.ListRepos(t.Context(), uri)
@@ -279,9 +270,9 @@ func TestListRepos_HashMatchesLtHash(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	repos, err := s.ListRepos(t.Context(), uri)
@@ -311,7 +302,7 @@ func TestPutAndGetRecord(t *testing.T) {
 	coll := syntax.NSID("network.habitat.note")
 	val := map[string]any{"text": "hello world"}
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "my-rkey", mustMarshalRecord(t, val))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "my-rkey", spaces_testutil.MustMarshalRecord(t, val))
 	require.NoError(t, err)
 
 	rec, err := s.GetRecord(t.Context(), uri, owner, coll, "my-rkey")
@@ -328,7 +319,7 @@ func TestPutRecord_SpaceNotFound(t *testing.T) {
 
 	uri := habitat_syntax.ConstructSpaceURI(owner, groupType, "nonexistent")
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.ErrorIs(t, err, spaces.ErrSpaceNotFound)
 }
 
@@ -340,10 +331,10 @@ func TestPutRecord_UpdateExisting(t *testing.T) {
 
 	coll := syntax.NSID("network.habitat.note")
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", mustMarshalRecord(t, map[string]any{"v": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", mustMarshalRecord(t, map[string]any{"v": 2}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}))
 	require.NoError(t, err)
 
 	rec, err := s.GetRecord(t.Context(), uri, owner, coll, "rkey")
@@ -370,11 +361,11 @@ func TestListRecords(t *testing.T) {
 
 	collA := syntax.NSID("network.habitat.alpha")
 	collB := syntax.NSID("network.habitat.beta")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, collA, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, collB, "k1", mustMarshalRecord(t, map[string]any{"x": 3}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, collB, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 3}))
 	require.NoError(t, err)
 
 	// All records
@@ -406,7 +397,7 @@ func TestDeleteRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	err = s.DeleteRecord(t.Context(), uri, owner, coll, "rkey")
@@ -430,7 +421,7 @@ func TestRepoHash_IncrementalOnUpdateAndDelete(t *testing.T) {
 	require.NoError(t, err)
 	coll := syntax.NSID("network.habitat.note")
 
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
+	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 	var want1 spacecommit.LtHash
 	want1.Add(spacecommit.RecordElement(coll, "k1", cid1.String()))
@@ -440,7 +431,7 @@ func TestRepoHash_IncrementalOnUpdateAndDelete(t *testing.T) {
 	require.Equal(t, want1.Sum(), hash)
 
 	// Update the same rkey: the old element must be folded out and the new in.
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 2}))
+	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}))
 	require.NoError(t, err)
 	require.NotEqual(t, cid1.String(), cid2.String())
 	var want2 spacecommit.LtHash
@@ -517,9 +508,9 @@ func TestDeleteSpace(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r2", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "r2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 
 	err = s.DeleteSpace(t.Context(), uri)
@@ -557,11 +548,11 @@ func TestListRepoOps(t *testing.T) {
 		require.Len(t, records, 0)
 	})
 	t.Run("multiple", func(t *testing.T) {
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 		require.NoError(t, err)
-		_, _, err = s.PutRecord(ctx, uri, alice, coll, "k2", mustMarshalRecord(t, map[string]any{"x": 2}))
+		_, _, err = s.PutRecord(ctx, uri, alice, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 		require.NoError(t, err)
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k3", mustMarshalRecord(t, map[string]any{"x": 3}))
+		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k3", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 3}))
 		require.NoError(t, err)
 
 		records, _, err := s.ListRepoOps(ctx, uri, owner, "", 1)
@@ -601,7 +592,7 @@ func TestListRepoOps(t *testing.T) {
 
 	t.Run("includes value", func(t *testing.T) {
 		owner := syntax.DID("did:web:bob")
-		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"text": "hello"}))
+		_, _, err = s.PutRecord(ctx, uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"text": "hello"}))
 		require.NoError(t, err)
 
 		records, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
@@ -620,7 +611,7 @@ func TestPutRecordTriggersNotify(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 
 	require.Len(t, notifier.Writes, 1)
@@ -637,17 +628,17 @@ func TestPutRecordSkipsNotifyWhenCidUnchanged(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 1)
 
 	// Writing the exact same value again produces the same CID.
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 1}))
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 1, "no-op write should not trigger another notify")
 
 	// A write that actually changes the content still notifies.
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"x": 2}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"x": 2}))
 	require.NoError(t, err)
 	require.Len(t, notifier.Writes, 2)
 }
@@ -672,9 +663,9 @@ func TestListRepoOpsPrev(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
+	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 2}))
+	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}))
 	require.NoError(t, err)
 
 	// An update overwrites in place: one op whose prev is the old cid.
@@ -704,7 +695,7 @@ func TestListRepoOpsPrevCreateIsEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 
 	ops, _, err := s.ListRepoOps(t.Context(), uri, owner, "", 100)
@@ -724,9 +715,9 @@ func TestPutRecordNotifiesRepoHash(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
+	_, cid1, err := s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
-	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", mustMarshalRecord(t, map[string]any{"v": 2}))
+	_, cid2, err := s.PutRecord(t.Context(), uri, owner, coll, "k2", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 2}))
 	require.NoError(t, err)
 
 	require.Len(t, notifier.Writes, 2)
@@ -748,7 +739,7 @@ func TestListRepoOps_RevTooFar(t *testing.T) {
 	require.NoError(t, err)
 
 	coll := syntax.NSID("network.habitat.note")
-	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", mustMarshalRecord(t, map[string]any{"v": 1}))
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "k1", spaces_testutil.MustMarshalRecord(t, map[string]any{"v": 1}))
 	require.NoError(t, err)
 
 	// A TID-like string that sorts after any real TID (base32 is a-z + 2-7).

--- a/internal/spaces/store_test.go
+++ b/internal/spaces/store_test.go
@@ -382,14 +382,6 @@ func TestListRecords(t *testing.T) {
 	}
 }
 
-// TestMarshalRecord_RejectsNonIntegerFloat pins that MarshalRecord — which
-// callers must run over user input before calling PutRecord — rejects values
-// that don't conform to the atproto data model.
-func TestMarshalRecord_RejectsNonIntegerFloat(t *testing.T) {
-	_, err := spaces.MarshalRecord(map[string]any{"x": 0.15})
-	require.ErrorIs(t, err, spaces.ErrInvalidRecord)
-}
-
 func TestDeleteRecord(t *testing.T) {
 	s := spaces_testutil.NewTestStore(t)
 

--- a/internal/spaces/testutil/store.go
+++ b/internal/spaces/testutil/store.go
@@ -87,6 +87,15 @@ func NewTestStore(t *testing.T, opts ...Option) spaces.Store {
 	return s
 }
 
+// MustMarshalRecord validates and CBOR-encodes value the way a real
+// PutRecord caller must before calling the store's PutRecord.
+func MustMarshalRecord(t *testing.T, value any) []byte {
+	t.Helper()
+	bytes, err := spaces.MarshalRecord(value)
+	require.NoError(t, err)
+	return bytes
+}
+
 // noMemberSigner never resolves a habitat-managed signer, so Authority.Build
 // always falls back to the host key.
 type noMemberSigner struct{}

--- a/internal/spaces/testutil/store.go
+++ b/internal/spaces/testutil/store.go
@@ -89,11 +89,11 @@ func NewTestStore(t *testing.T, opts ...Option) spaces.Store {
 
 // MustMarshalRecord validates and CBOR-encodes value the way a real
 // PutRecord caller must before calling the store's PutRecord.
-func MustMarshalRecord(t *testing.T, value any) []byte {
+func MustMarshalRecord(t *testing.T, value any) spaces.MarshaledRecord {
 	t.Helper()
-	bytes, err := spaces.MarshalRecord(value)
+	record, err := spaces.MarshalRecord(value)
 	require.NoError(t, err)
-	return bytes
+	return record
 }
 
 // noMemberSigner never resolves a habitat-managed signer, so Authority.Build

--- a/internal/spaces/util.go
+++ b/internal/spaces/util.go
@@ -7,11 +7,16 @@ import (
 	"github.com/bluesky-social/indigo/atproto/atdata"
 )
 
+// MarshaledRecord is a record value that has been validated against the
+// atproto data model and CBOR-encoded by [MarshalRecord]. PutRecord only
+// accepts this type so callers can't pass unvalidated bytes by mistake.
+type MarshaledRecord []byte
+
 // MarshalRecord validates value against the atproto data model and encodes
 // it as the CBOR bytes PutRecord expects. Callers must run their input
 // through this (or otherwise produce equivalent, validated CBOR) before
 // calling PutRecord.
-func MarshalRecord(value any) ([]byte, error) {
+func MarshalRecord(value any) (MarshaledRecord, error) {
 	jsonBytes, err := json.Marshal(value)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal value: %w", err)
@@ -28,5 +33,5 @@ func MarshalRecord(value any) ([]byte, error) {
 	if len(bytes) > atdata.MAX_CBOR_RECORD_SIZE {
 		return nil, ErrRecordTooLarge
 	}
-	return bytes, nil
+	return MarshaledRecord(bytes), nil
 }

--- a/internal/spaces/util.go
+++ b/internal/spaces/util.go
@@ -1,0 +1,32 @@
+package spaces
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/atproto/atdata"
+)
+
+// MarshalRecord validates value against the atproto data model and encodes
+// it as the CBOR bytes PutRecord expects. Callers must run their input
+// through this (or otherwise produce equivalent, validated CBOR) before
+// calling PutRecord.
+func MarshalRecord(value any) ([]byte, error) {
+	jsonBytes, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal value: %w", err)
+	}
+	// validates against atproto data model
+	recordMap, err := atdata.UnmarshalJSON(jsonBytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRecord, err)
+	}
+	bytes, err := atdata.MarshalCBOR(recordMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal record: %w", err)
+	}
+	if len(bytes) > atdata.MAX_CBOR_RECORD_SIZE {
+		return nil, ErrRecordTooLarge
+	}
+	return bytes, nil
+}

--- a/internal/spaces/util_test.go
+++ b/internal/spaces/util_test.go
@@ -1,0 +1,16 @@
+package spaces_test
+
+import (
+	"testing"
+
+	"github.com/habitat-network/habitat/internal/spaces"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarshalRecord_RejectsNonIntegerFloat pins that MarshalRecord — which
+// callers must run over user input before calling PutRecord — rejects values
+// that don't conform to the atproto data model.
+func TestMarshalRecord_RejectsNonIntegerFloat(t *testing.T) {
+	_, err := spaces.MarshalRecord(map[string]any{"x": 0.15})
+	require.ErrorIs(t, err, spaces.ErrInvalidRecord)
+}

--- a/pkg/sap/sap_test.go
+++ b/pkg/sap/sap_test.go
@@ -70,8 +70,14 @@ func TestSap(t *testing.T) {
 	}
 	putRecord := func(space habitat_syntax.SpaceURI, rkey string, data string) {
 		recURI, _, err := pear.store.PutRecord(
-			t.Context(), space, author, collection,
-			syntax.RecordKey(rkey), spaces_testutil.MustMarshalRecord(t, map[string]any{"data": data}),
+			t.Context(),
+			space,
+			author,
+			collection,
+			syntax.RecordKey(
+				rkey,
+			),
+			spaces_testutil.MustMarshalRecord(t, map[string]any{"data": data}),
 		)
 		require.NoError(t, err)
 		createdURIs[recURI.String()] = true
@@ -283,8 +289,14 @@ func TestSapTrackSpace(t *testing.T) {
 	)
 	require.NoError(t, err)
 	recURI, _, err := pear.store.PutRecord(
-		t.Context(), space, author, collection,
-		syntax.RecordKey("rkey-0"), spaces_testutil.MustMarshalRecord(t, map[string]any{"data": "tracked"}),
+		t.Context(),
+		space,
+		author,
+		collection,
+		syntax.RecordKey(
+			"rkey-0",
+		),
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"data": "tracked"}),
 	)
 	require.NoError(t, err)
 
@@ -372,8 +384,14 @@ func TestSapRecrawl(t *testing.T) {
 	)
 	require.NoError(t, err)
 	recURI, _, err := pear.store.PutRecord(
-		t.Context(), space, author, collection,
-		syntax.RecordKey("rkey-0"), spaces_testutil.MustMarshalRecord(t, map[string]any{"data": "recrawled"}),
+		t.Context(),
+		space,
+		author,
+		collection,
+		syntax.RecordKey(
+			"rkey-0",
+		),
+		spaces_testutil.MustMarshalRecord(t, map[string]any{"data": "recrawled"}),
 	)
 	require.NoError(t, err)
 

--- a/pkg/sap/sap_test.go
+++ b/pkg/sap/sap_test.go
@@ -71,7 +71,7 @@ func TestSap(t *testing.T) {
 	putRecord := func(space habitat_syntax.SpaceURI, rkey string, data string) {
 		recURI, _, err := pear.store.PutRecord(
 			t.Context(), space, author, collection,
-			syntax.RecordKey(rkey), mustMarshalRecord(t, map[string]any{"data": data}),
+			syntax.RecordKey(rkey), spaces_testutil.MustMarshalRecord(t, map[string]any{"data": data}),
 		)
 		require.NoError(t, err)
 		createdURIs[recURI.String()] = true
@@ -284,7 +284,7 @@ func TestSapTrackSpace(t *testing.T) {
 	require.NoError(t, err)
 	recURI, _, err := pear.store.PutRecord(
 		t.Context(), space, author, collection,
-		syntax.RecordKey("rkey-0"), mustMarshalRecord(t, map[string]any{"data": "tracked"}),
+		syntax.RecordKey("rkey-0"), spaces_testutil.MustMarshalRecord(t, map[string]any{"data": "tracked"}),
 	)
 	require.NoError(t, err)
 
@@ -373,7 +373,7 @@ func TestSapRecrawl(t *testing.T) {
 	require.NoError(t, err)
 	recURI, _, err := pear.store.PutRecord(
 		t.Context(), space, author, collection,
-		syntax.RecordKey("rkey-0"), mustMarshalRecord(t, map[string]any{"data": "recrawled"}),
+		syntax.RecordKey("rkey-0"), spaces_testutil.MustMarshalRecord(t, map[string]any{"data": "recrawled"}),
 	)
 	require.NoError(t, err)
 
@@ -446,15 +446,6 @@ func TestSapRecrawl(t *testing.T) {
 		return cr.State == "complete"
 	}, 5*time.Second, 50*time.Millisecond, "crawl never completed")
 	require.Empty(t, cr.Cursor)
-}
-
-// mustMarshalRecord validates and CBOR-encodes value the way a real
-// PutRecord caller must before calling the store's PutRecord.
-func mustMarshalRecord(t *testing.T, value any) []byte {
-	t.Helper()
-	bytes, err := spaces.MarshalRecord(value)
-	require.NoError(t, err)
-	return bytes
 }
 
 // pearHost bundles the host-side pieces the test drives.

--- a/pkg/sap/sap_test.go
+++ b/pkg/sap/sap_test.go
@@ -71,7 +71,7 @@ func TestSap(t *testing.T) {
 	putRecord := func(space habitat_syntax.SpaceURI, rkey string, data string) {
 		recURI, _, err := pear.store.PutRecord(
 			t.Context(), space, author, collection,
-			syntax.RecordKey(rkey), map[string]any{"data": data},
+			syntax.RecordKey(rkey), mustMarshalRecord(t, map[string]any{"data": data}),
 		)
 		require.NoError(t, err)
 		createdURIs[recURI.String()] = true
@@ -284,7 +284,7 @@ func TestSapTrackSpace(t *testing.T) {
 	require.NoError(t, err)
 	recURI, _, err := pear.store.PutRecord(
 		t.Context(), space, author, collection,
-		syntax.RecordKey("rkey-0"), map[string]any{"data": "tracked"},
+		syntax.RecordKey("rkey-0"), mustMarshalRecord(t, map[string]any{"data": "tracked"}),
 	)
 	require.NoError(t, err)
 
@@ -373,7 +373,7 @@ func TestSapRecrawl(t *testing.T) {
 	require.NoError(t, err)
 	recURI, _, err := pear.store.PutRecord(
 		t.Context(), space, author, collection,
-		syntax.RecordKey("rkey-0"), map[string]any{"data": "recrawled"},
+		syntax.RecordKey("rkey-0"), mustMarshalRecord(t, map[string]any{"data": "recrawled"}),
 	)
 	require.NoError(t, err)
 
@@ -446,6 +446,15 @@ func TestSapRecrawl(t *testing.T) {
 		return cr.State == "complete"
 	}, 5*time.Second, 50*time.Millisecond, "crawl never completed")
 	require.Empty(t, cr.Cursor)
+}
+
+// mustMarshalRecord validates and CBOR-encodes value the way a real
+// PutRecord caller must before calling the store's PutRecord.
+func mustMarshalRecord(t *testing.T, value any) []byte {
+	t.Helper()
+	bytes, err := spaces.MarshalRecord(value)
+	require.NoError(t, err)
+	return bytes
 }
 
 // pearHost bundles the host-side pieces the test drives.


### PR DESCRIPTION
## Summary

This change moves record validation and CBOR marshaling out of `PutRecord` and into a new `MarshalRecord` function that callers must invoke before calling the store. This enforces a clearer separation of concerns: validation happens at the API boundary (where user input enters), while `PutRecord` focuses solely on persistence.

## Key Changes

- **New `MarshalRecord` function** (`internal/spaces/util.go`): Validates values against the atproto data model and encodes them as CBOR bytes. Callers must invoke this before calling `PutRecord`.

- **Updated `PutRecord` signature**: Changed the `value` parameter from `any` to `[]byte`, removing all validation and marshaling logic from the store method.

- **API server validation** (`internal/spaces/server/server.go`): Moved `MarshalRecord` call to the HTTP handler, validating user input at the request boundary before passing to the store.

- **Permissions store** (`internal/perms/store.go`): Updated `SetUserRelation` and `SetSpaceRoleRelation` to call `MarshalRecord` before `PutRecord`.

- **Test utilities** (`internal/spaces/testutil/store.go`): Added `MustMarshalRecord` helper for test code to marshal values consistently.

- **Test updates**: Updated all test files to use `spaces_testutil.MustMarshalRecord` when calling `PutRecord`, and refactored `TestPutRecord_RejectsNonIntegerFloat` to test `MarshalRecord` directly rather than the store.

## Implementation Details

- The validation logic (atproto data model conformance, size limits) remains identical; it's just relocated to `MarshalRecord`.
- This pattern ensures validation happens once at the API boundary, not repeatedly in the store.
- Callers in `internal/perms` now explicitly marshal relationship records before persistence, making the data flow clearer.

https://claude.ai/code/session_01HYME4TjHBFWYhGfCLdd48U

<!-- branch-stack-start -->

<!-- branch-stack-end -->
