### PR TITLE
Update Habitat Portal link to home.habitat.network

### DIFF
--- a/typescript/internal/src/components/AppLayout.tsx
+++ b/typescript/internal/src/components/AppLayout.tsx
@@ -61,7 +61,7 @@ export const AppLayout = ({
                     <DropdownMenuItem
                       render={
                         <a
-                          href="https://habitat.network/habitat"
+                          href="https://home.habitat.network"
                           target="_blank"
                         />
                       }


### PR DESCRIPTION
## Summary
- Point the "Habitat Portal" dropdown link in the shared `AppLayout` (used by chalk and docs) to `https://home.habitat.network` instead of `https://habitat.network/habitat`.

## Test Plan
- [ ] Chalk app: open user dropdown in sidebar footer, click "Habitat Portal", confirm it opens home.habitat.network