### PR TITLE
Track blob references in records for authorization

### DIFF
--- a/internal/spaces/server/server.go
+++ b/internal/spaces/server/server.go
@@ -348,6 +348,14 @@ func (s *Server) GetBlob(w http.ResponseWriter, r *http.Request) {
 		httpx.WriteInvalidRequest(ctx, w, "failed to parse cid", err)
 		return
 	}
+	referenced, err := s.store.BlobReferenced(ctx, spaceURI, c)
+	if err != nil {
+		httpx.WriteServerError(ctx, w, fmt.Errorf("check blob reference: %w", err))
+		return
+	} else if !referenced {
+		httpx.WriteError(ctx, w, "BlobNotFound", "blob not found", http.StatusNotFound)
+		return
+	}
 	mimeType, data, err := s.blobs.GetBlob(ctx, c)
 	if errors.Is(err, spaces.ErrBlobNotFound) {
 		httpx.WriteError(ctx, w, "BlobNotFound", "blob not found", http.StatusNotFound)

--- a/internal/spaces/server/server_test.go
+++ b/internal/spaces/server/server_test.go
@@ -110,6 +110,19 @@ func TestServer_UploadAndGetBlob(t *testing.T) {
 	require.NoError(t, json.NewDecoder(upW.Body).Decode(&out))
 	require.NotEmpty(t, out.Cid)
 
+	// GetBlob authorizes by checking the requested cid is referenced by some
+	// record in the space, so put one that references the uploaded blob.
+	_, _, err = store.PutRecord(t.Context(), uri, owner, groupType, "", map[string]any{
+		"$type": groupType.String(),
+		"image": map[string]any{
+			"$type":    "blob",
+			"ref":      map[string]any{"$link": out.Cid},
+			"mimeType": "text/plain",
+			"size":     float64(len("hello blobs")),
+		},
+	})
+	require.NoError(t, err)
+
 	// Get it back through the space.
 	getW := httptest.NewRecorder()
 	s.GetBlob(

--- a/internal/spaces/store.go
+++ b/internal/spaces/store.go
@@ -2,6 +2,7 @@ package spaces
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/habitat-network/habitat/internal/db"
 	"github.com/habitat-network/habitat/internal/spacecommit"
@@ -44,6 +46,19 @@ type spaceRecord struct {
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 	DeletedAt  gorm.DeletedAt
+}
+
+// blobRef tracks which record within a space references a blob CID.
+// getBlob uses it to authorize a request: a cid is readable if it is
+// referenced by some record in the space the caller can already read.
+// PutRecord keeps it in sync by clearing a record's prior refs and
+// re-inserting the ones extracted from its new value on every write.
+type blobRef struct {
+	Cid        string                  `gorm:"primaryKey"`
+	Space      habitat_syntax.SpaceURI `gorm:"primaryKey"`
+	Repo       syntax.DID              `gorm:"primaryKey"`
+	Collection syntax.NSID             `gorm:"primaryKey"`
+	Rkey       syntax.RecordKey        `gorm:"primaryKey"`
 }
 
 // spaceRepo caches a permissioned repo's LtHash so reads (listRepos,
@@ -148,6 +163,15 @@ type Store interface {
 		rkey string,
 	) error
 
+	// BlobReferenced reports whether cid is referenced by some record within
+	// space, so getBlob can authorize a request without exposing which
+	// record does the referencing.
+	BlobReferenced(
+		ctx context.Context,
+		space habitat_syntax.SpaceURI,
+		c cid.Cid,
+	) (bool, error)
+
 	// Oplog operations
 	//
 	// ListRepoOps returns a repo's operations within a space after a given
@@ -235,7 +259,7 @@ func NewStore(
 	notifier Notifier,
 	commit *spacecommit.Authority,
 ) (*store, error) {
-	if err := db.AutoMigrate(&space{}, &spaceRecord{}, &spaceRepo{}); err != nil {
+	if err := db.AutoMigrate(&space{}, &spaceRecord{}, &spaceRepo{}, &blobRef{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate spaces tables: %w", err)
 	}
 	return &store{
@@ -454,13 +478,22 @@ func (s *store) PutRecord(
 	} else if !ok {
 		return "", nil, ErrSpaceNotFound
 	}
-	if err := atdata.Validate(value); err != nil {
-		return "", nil, fmt.Errorf("%w: %w", ErrInvalidRecord, err)
-	}
-	bytes, err := atdata.MarshalCBOR(value)
+	// UnmarshalJSON both validates against the atproto data model and parses
+	// blob/link/bytes fields into their structured atdata types, so the same
+	// parsed value can be used to extract blob references below.
+	marshalled, err := json.Marshal(value)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to marshal record: %w", err)
 	}
+	parsed, err := atdata.UnmarshalJSON(marshalled)
+	if err != nil {
+		return "", nil, fmt.Errorf("%w: %w", ErrInvalidRecord, err)
+	}
+	bytes, err := atdata.MarshalCBOR(parsed)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to marshal record: %w", err)
+	}
+	blobs := atdata.ExtractBlobs(parsed)
 	span.SetAttributes(attribute.Int("cbor_bytes", len(bytes)))
 	if len(bytes) > atdata.MAX_CBOR_RECORD_SIZE {
 		return "", nil, ErrRecordTooLarge
@@ -515,6 +548,33 @@ func (s *store) PutRecord(
 			return fmt.Errorf("failed to save repo hash: %w", err)
 		}
 		repoHash = h.Sum()
+
+		// Clear this record's prior blob references and set them to exactly
+		// what its new value references.
+		if err := tx.
+			Where("space = ? AND repo = ? AND collection = ? AND rkey = ?",
+				spaceURI, repo, collection, rkey).
+			Delete(&blobRef{}).Error; err != nil {
+			return fmt.Errorf("failed to clear blob refs: %w", err)
+		}
+		if len(blobs) > 0 {
+			refs := make([]blobRef, len(blobs))
+			for i, b := range blobs {
+				refs[i] = blobRef{
+					Cid:        b.Ref.CID().String(),
+					Space:      spaceURI,
+					Repo:       repo,
+					Collection: collection,
+					Rkey:       rkey,
+				}
+			}
+			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).
+				Create(&refs).
+				Error; err != nil {
+				return fmt.Errorf("failed to save blob refs: %w", err)
+			}
+		}
+
 		return tx.Save(&spaceRecord{
 			Repo:       repo,
 			Space:      spaceURI,
@@ -866,6 +926,13 @@ func (s *store) DeleteRecord(
 			}).Error; err != nil {
 			return fmt.Errorf("delete record: %w", err)
 		}
+		// A deleted record no longer authorizes reads of the blobs it referenced.
+		if err := tx.
+			Where("space = ? AND repo = ? AND collection = ? AND rkey = ?",
+				uri, repo, collection, rkey).
+			Delete(&blobRef{}).Error; err != nil {
+			return fmt.Errorf("clear blob refs: %w", err)
+		}
 		// Fold the deleted records out of the cached LtHash.
 		h, _, _, err := loadRepoHash(tx, uri, repo)
 		if err != nil {
@@ -886,4 +953,22 @@ func (s *store) DeleteRecord(
 		}
 		return saveRepoHash(tx, uri, repo, h, rev)
 	})
+}
+
+// BlobReferenced implements [Store].
+func (s *store) BlobReferenced(
+	ctx context.Context,
+	space habitat_syntax.SpaceURI,
+	c cid.Cid,
+) (bool, error) {
+	var ref blobRef
+	err := s.db.WithContext(ctx).
+		Where("space = ? AND cid = ?", space, c.String()).
+		First(&ref).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("check blob reference: %w", err)
+	}
+	return true, nil
 }

--- a/internal/spaces/store_test.go
+++ b/internal/spaces/store_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/ipfs/go-cid"
+
 	notify_testutil "github.com/habitat-network/habitat/internal/notify/testutil"
 	"github.com/habitat-network/habitat/internal/spacecommit"
 	"github.com/habitat-network/habitat/internal/spaces"
@@ -340,6 +342,101 @@ func TestPutRecord_UpdateExisting(t *testing.T) {
 	rec, err := s.GetRecord(t.Context(), uri, owner, coll, "rkey")
 	require.NoError(t, err)
 	require.Equal(t, int64(2), rec.Value["v"])
+}
+
+// blobValue returns a record value with a single atproto blob field
+// referencing cidStr, in the raw JSON shape ExtractBlobs recognizes.
+func blobValue(cidStr string) map[string]any {
+	return map[string]any{
+		"$type": "network.habitat.note",
+		"image": map[string]any{
+			"$type":    "blob",
+			"ref":      map[string]any{"$link": cidStr},
+			"mimeType": "image/png",
+			"size":     float64(42),
+		},
+	}
+}
+
+func TestPutRecord_TracksBlobReferences(t *testing.T) {
+	s := spaces_testutil.NewTestStore(t)
+
+	uri, err := s.CreateSpace(t.Context(), orgID, groupType, "test")
+	require.NoError(t, err)
+
+	coll := syntax.NSID("network.habitat.note")
+	blobCID := "bafkreihdwdcefgh4dqkjv67uzcmw37nwqfknnagwmjb44agkh4lphqzgxq"
+
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", blobValue(blobCID))
+	require.NoError(t, err)
+
+	c, err := cid.Decode(blobCID)
+	require.NoError(t, err)
+	referenced, err := s.BlobReferenced(t.Context(), uri, c)
+	require.NoError(t, err)
+	require.True(t, referenced)
+}
+
+// TestPutRecord_ClearsStaleBlobReferences pins that overwriting a record
+// drops its prior blob references rather than accumulating them: a blob
+// referenced by an old value must not stay authorized once the record no
+// longer references it.
+func TestPutRecord_ClearsStaleBlobReferences(t *testing.T) {
+	s := spaces_testutil.NewTestStore(t)
+
+	uri, err := s.CreateSpace(t.Context(), orgID, groupType, "test")
+	require.NoError(t, err)
+
+	coll := syntax.NSID("network.habitat.note")
+	blobCID := "bafkreihdwdcefgh4dqkjv67uzcmw37nwqfknnagwmjb44agkh4lphqzgxq"
+
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", blobValue(blobCID))
+	require.NoError(t, err)
+
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", map[string]any{"text": "no blob"})
+	require.NoError(t, err)
+
+	c, err := cid.Decode(blobCID)
+	require.NoError(t, err)
+	referenced, err := s.BlobReferenced(t.Context(), uri, c)
+	require.NoError(t, err)
+	require.False(t, referenced)
+}
+
+// TestDeleteRecord_ClearsBlobReferences pins that deleting the only record
+// referencing a blob revokes read access to that blob within the space.
+func TestDeleteRecord_ClearsBlobReferences(t *testing.T) {
+	s := spaces_testutil.NewTestStore(t)
+
+	uri, err := s.CreateSpace(t.Context(), orgID, groupType, "test")
+	require.NoError(t, err)
+
+	coll := syntax.NSID("network.habitat.note")
+	blobCID := "bafkreihdwdcefgh4dqkjv67uzcmw37nwqfknnagwmjb44agkh4lphqzgxq"
+
+	_, _, err = s.PutRecord(t.Context(), uri, owner, coll, "rkey", blobValue(blobCID))
+	require.NoError(t, err)
+
+	require.NoError(t, s.DeleteRecord(t.Context(), uri, owner, coll, "rkey"))
+
+	c, err := cid.Decode(blobCID)
+	require.NoError(t, err)
+	referenced, err := s.BlobReferenced(t.Context(), uri, c)
+	require.NoError(t, err)
+	require.False(t, referenced)
+}
+
+func TestBlobReferenced_UnreferencedCidIsFalse(t *testing.T) {
+	s := spaces_testutil.NewTestStore(t)
+
+	uri, err := s.CreateSpace(t.Context(), orgID, groupType, "test")
+	require.NoError(t, err)
+
+	c, err := cid.Decode("bafkreihdwdcefgh4dqkjv67uzcmw37nwqfknnagwmjb44agkh4lphqzgxq")
+	require.NoError(t, err)
+	referenced, err := s.BlobReferenced(t.Context(), uri, c)
+	require.NoError(t, err)
+	require.False(t, referenced)
 }
 
 func TestGetRecord_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary
Adds blob reference tracking to the spaces store to enable authorization of blob reads based on whether they are referenced by records within a space. This prevents unauthorized access to blobs while maintaining the ability to read blobs that are legitimately referenced by accessible records.

## Changes
- **New `blobRef` table**: Tracks which records reference which blob CIDs, with composite primary key on (Cid, Space, Repo, Collection, Rkey)
- **`PutRecord` blob tracking**: Extracts blobs from record values using `atdata.ExtractBlobs()`, clears prior blob references for the record, and inserts new references on every write
- **`DeleteRecord` cleanup**: Removes blob references when a record is deleted, revoking read access to blobs no longer referenced by any record
- **`BlobReferenced()` method**: New Store interface method to check if a CID is referenced by any record in a space
- **`GetBlob` authorization**: Updated to call `BlobReferenced()` before serving blob data, returning 404 if the blob is not referenced by any record in the space
- **Comprehensive tests**: Added test cases covering blob reference tracking on put, clearing stale references on update, clearing references on delete, and querying unreferenced blobs

## Implementation Details
- Blob references are extracted from CBOR-encoded record values by decoding them back to structured atdata types
- The `blobRef` table uses `OnConflict{DoNothing: true}` to handle duplicate references gracefully (same blob referenced by multiple records)
- Authorization is space-scoped: a blob is only readable if referenced by a record in the specific space being accessed
- The implementation maintains referential integrity by clearing references whenever records are modified or deleted

https://claude.ai/code/session_01DC4Rurf8UZADBAshPxpr3V