### PR TITLE
Remove description from OrgItem

### DIFF
--- a/frontend/src/components/OrgItem.tsx
+++ b/frontend/src/components/OrgItem.tsx
@@ -9,7 +9,6 @@ import {
   ItemMedia,
   ItemContent,
   ItemTitle,
-  ItemDescription,
 } from "internal/components/ui";
 
 export function OrgItem({
@@ -42,9 +41,7 @@ export function OrgItem({
             <DidHoverCard did={org.did}>{org.did}</DidHoverCard>
           )}
         </ItemTitle>
-        {profile?.description && (
-          <ItemDescription>{profile.description}</ItemDescription>
-        )}
+
         <span className="font-mono text-xs text-muted-foreground break-all">
           {org.did}
         </span>


### PR DESCRIPTION
## Summary
- Remove the profile description line from OrgItem so all org items render uniformly with just an avatar, title, and DID.