### PR TITLE
[Frontend] Fix opensocial back button label

### DIFF
--- a/frontend/src/routes/_requireAuth/opensocial/$org.tsx
+++ b/frontend/src/routes/_requireAuth/opensocial/$org.tsx
@@ -62,7 +62,7 @@ function OrgDetail() {
           to="/opensocial"
           className="text-sm text-muted-foreground hover:text-foreground"
         >
-          ← All communities
+          ← All organizations
         </Link>
         <div className="flex items-center justify-between gap-3 mt-2">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
The back button on the opensocial org detail page said "All communities", but the opensocial index page and the rest of the UI use "organizations". Renamed the label to "All organizations" for consistency.