### PR TITLE
[Opensocial] Write community.opensocial.space record into members space

### DIFF
--- a/internal/opensocial/store.go
+++ b/internal/opensocial/store.go
@@ -206,7 +206,9 @@ func (s *Store) CreateSpace(
 			return fmt.Errorf("marshal space record: %w", err)
 		}
 		if _, _, err = spacesStoreTx.PutRecord(
-			ctx, spaceURI, orgDID, "community.opensocial.space", "",
+			ctx,
+			habitat_syntax.ConstructSpaceURI(orgDID, MembersSpaceType, "self"),
+			orgDID, "community.opensocial.space", "",
 			recordBytes,
 		); err != nil {
 			return fmt.Errorf("put space record: %w", err)

--- a/internal/opensocial/store_test.go
+++ b/internal/opensocial/store_test.go
@@ -99,6 +99,24 @@ func TestStore(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, []any{opensocial.MemberRoleRkey}, record.Value["roles"])
+
+		// The space record indexing the new space lives in the members space.
+		membersSpace := habitat_syntax.ConstructSpaceURI(org, opensocial.MembersSpaceType, "self")
+		spaceColl := syntax.NSID("community.opensocial.space")
+		spaceRecords, err := s.SpaceStore.ListRecords(t.Context(), membersSpace, org, &spaceColl)
+		require.NoError(t, err)
+		var indexedURIs []string
+		for _, rec := range spaceRecords {
+			uri, ok := rec.Value["uri"].(string)
+			require.True(t, ok)
+			indexedURIs = append(indexedURIs, uri)
+		}
+		require.Contains(t, indexedURIs, spaceURI.String())
+
+		// ... and is not written into the new space itself.
+		newSpaceRecords, err := s.SpaceStore.ListRecords(t.Context(), spaceURI, org, &spaceColl)
+		require.NoError(t, err)
+		require.Empty(t, newSpaceRecords)
 	})
 
 	t.Run("UploadImage", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `community.opensocial.createSpace` now writes the `community.opensocial.space` index record into the org's members space instead of the newly created space, matching the lexicon.
- Updated the `CreateSpace` test to assert the index record lands in the members space and is absent from the new space.

## Test Plan
- [x] `go test ./internal/opensocial/`
- [x] `go test ./internal/pearserver/`
- [x] `golangci-lint run ./internal/opensocial/...` (0 issues)