### PR TITLE
Cut pear releases weekly on Tuesdays

### DIFF
--- a/.github/workflows/release-pear.yml
+++ b/.github/workflows/release-pear.yml
@@ -1,23 +1,24 @@
 name: Release Pear
 
-# Every commit pushed to main whose CI run passes becomes a GitHub release
-# tagged vYYYY.M.D-<short sha> (CalVer, UTC date). The release publishes a
-# multi-arch image to ghcr.io/habitat-network/pear under that version and
+# Every Tuesday, the newest commit on main whose CI run passed becomes a GitHub
+# release tagged vYYYY.M.D-<short sha> (CalVer, UTC date). The release publishes
+# a multi-arch image to ghcr.io/habitat-network/pear under that version and
 # `latest`, and attaches a docker-compose.yml pinned to that version, so
-# `releases/latest/download/docker-compose.yml` always resolves.
+# `releases/latest/download/docker-compose.yml` always resolves. If that commit
+# is already released, the run does nothing.
 #
-# Manually dispatching this workflow on a branch publishes a test image tagged
+# Manually dispatching this workflow on main cuts a release immediately, the
+# same way. Dispatching it on any other branch publishes a test image tagged
 # with the branch name and does not cut a release.
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
+  schedule:
+    # Tuesdays at 16:00 UTC (9:00 PT). GitHub may start scheduled runs late.
+    - cron: "0 16 * * 2"
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -28,16 +29,12 @@ env:
 
 jobs:
   meta:
-    # workflow_run's branch filter matches on branch name only, so also require
-    # a push to this repository (not a fork PR whose branch is named main).
-    if: >-
-      github.event_name == 'workflow_dispatch' || (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      )
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     outputs:
+      skip: ${{ steps.meta.outputs.skip }}
       sha: ${{ steps.meta.outputs.sha }}
       version: ${{ steps.meta.outputs.version }}
       image_tags: ${{ steps.meta.outputs.image_tags }}
@@ -45,14 +42,29 @@ jobs:
     steps:
       - id: meta
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            sha="$RUN_SHA"
+          # Scheduled runs always run on the default branch.
+          if [ "$REF_NAME" = "main" ]; then
+            # Release the newest main commit whose CI passed rather than HEAD,
+            # so a red (or cancelled) HEAD on Tuesday doesn't skip a week.
+            sha="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow ci.yml \
+              --branch main --event push --status success --limit 1 \
+              --json headSha --jq '.[0].headSha')"
+            if [ -z "$sha" ]; then
+              echo "::error::No passing CI run found on main"
+              exit 1
+            fi
+            if gh release list --repo "$GITHUB_REPOSITORY" --limit 50 \
+              --json tagName --jq '.[].tagName' | grep -q -- "-${sha::7}\$"; then
+              echo "::notice::${sha::7} is already released; nothing to do"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             version="v$(date -u +%Y.%-m.%-d)-${sha::7}"
             {
+              echo "skip=false"
               echo "sha=$sha"
               echo "version=$version"
               echo "image_tags=latest ${version#v}"
@@ -62,6 +74,7 @@ jobs:
             # Docker tags only allow [A-Za-z0-9_.-]
             tag="$(printf '%s' "$REF_NAME" | tr -c 'A-Za-z0-9_.-' '-')"
             {
+              echo "skip=false"
               echo "sha=$GITHUB_SHA"
               echo "version=$tag"
               echo "image_tags=$tag"
@@ -73,6 +86,7 @@ jobs:
   # push by digest; the merge job stitches the digests into one tagged image.
   build:
     needs: meta
+    if: needs.meta.outputs.skip != 'true'
     strategy:
       matrix:
         include:

--- a/api-docs/docs/guides/self-hosting.mdx
+++ b/api-docs/docs/guides/self-hosting.mdx
@@ -7,13 +7,13 @@ sidebar_position: 3
 
 # Self-hosting guide
 
-⚠️ Habitat is under active development. Releases are cut from `main` continuously. ⚠️
+⚠️ Habitat is under active development. Releases are cut from `main` every week. ⚠️
 
 Habitat's Organizational Data Server, Pear, ships as a Docker image (`ghcr.io/habitat-network/pear`, for `linux/amd64` and `linux/arm64`).
 
 ## Releases
 
-Every commit to `main` that passes CI is published as a [GitHub release](https://github.com/habitat-network/habitat/releases) named `vYYYY.M.D-<short sha>`. Each release has a matching image tag (without the `v`) and a `docker-compose.yml` pinned to that image. The `latest` image tag points at the newest release.
+Every Tuesday, the newest commit on `main` that passed CI is published as a [GitHub release](https://github.com/habitat-network/habitat/releases) named `vYYYY.M.D-<short sha>`. Each release has a matching image tag (without the `v`) and a `docker-compose.yml` pinned to that image. The `latest` image tag points at the newest release.
 
 Older `v0.0.x-testing-N` tags are from a previous architecture and do not work with this guide.
 

--- a/build/debian/frontend/README.md
+++ b/build/debian/frontend/README.md
@@ -16,7 +16,7 @@
 git clone https://github.com/habitat-network/habitat
 cd habitat
 # Check out the same release your pear server runs, e.g.
-git checkout v2026.9.11-e3551da
+git checkout v2026.9.11-5d3b3ba
 ```
 
 Releases are listed at https://github.com/habitat-network/habitat/releases.

--- a/build/debian/pear/README.md
+++ b/build/debian/pear/README.md
@@ -4,9 +4,9 @@ Pear is Habitat's Organizational Data Server. It ships as a single Docker image,
 
 ## Releases
 
-Every commit to `main` that passes CI is released automatically as `vYYYY.M.D-<short sha>` (for example `v2026.9.11-e3551da`). Each [GitHub release](https://github.com/habitat-network/habitat/releases) has:
+Releases are cut automatically every Tuesday from the newest commit on `main` that passed CI, and are named `vYYYY.M.D-<short sha>` (for example `v2026.9.11-5d3b3ba`). If nothing has changed since the last release, that week is skipped. Maintainers can also cut one early by running the [Release Pear](https://github.com/habitat-network/habitat/actions/workflows/release-pear.yml) workflow on `main`. Each [GitHub release](https://github.com/habitat-network/habitat/releases) has:
 
-- a matching image tag without the `v`, e.g. `ghcr.io/habitat-network/pear:2026.9.11-e3551da`
+- a matching image tag without the `v`, e.g. `ghcr.io/habitat-network/pear:2026.9.11-5d3b3ba`
 - a `docker-compose.yml` asset whose image tag is pinned to that release
 
 The `latest` image tag always points at the newest release.
@@ -28,7 +28,7 @@ mkdir pear && cd pear
 curl -LO https://github.com/habitat-network/habitat/releases/latest/download/docker-compose.yml
 ```
 
-To install a specific release instead, replace `latest/download` with `download/<version>`, e.g. `download/v2026.9.11-e3551da`.
+To install a specific release instead, replace `latest/download` with `download/<version>`, e.g. `download/v2026.9.11-5d3b3ba`.
 
 **2. Create a `.env` file in the same directory**
 
@@ -63,7 +63,7 @@ curl -LO https://github.com/habitat-network/habitat/releases/latest/download/doc
 docker compose pull && docker compose up -d
 ```
 
-Alternatively, set `PEAR_TAG` in `.env` to pick an image tag without re-downloading. For example, `PEAR_TAG=latest` tracks `main`, and `PEAR_TAG=2026.9.11-e3551da` pins a release. Database migrations run automatically on startup.
+Alternatively, set `PEAR_TAG` in `.env` to pick an image tag without re-downloading. For example, `PEAR_TAG=latest` tracks the newest weekly release, and `PEAR_TAG=2026.9.11-5d3b3ba` pins a release. Database migrations run automatically on startup.
 
 ## Configuration
 
@@ -147,7 +147,7 @@ Build from a release tag rather than an arbitrary commit, so the source matches 
 
 ```bash
 git clone https://github.com/habitat-network/habitat && cd habitat
-git checkout v2026.9.11-e3551da
+git checkout v2026.9.11-5d3b3ba
 docker build -f build/debian/pear/Dockerfile -t ghcr.io/habitat-network/pear:local .
 ```
 


### PR DESCRIPTION
Switches `release-pear.yml` from releasing on every CI pass on `main` to a weekly schedule.

- **Trigger:** `schedule` every Tuesday at 16:00 UTC (9:00 PT), replacing `workflow_run`.
- **What gets released:** the newest `main` commit with a successful CI push run, not necessarily HEAD, so a red or cancelled HEAD doesn't skip the week.
- **No-op weeks:** if that commit already has a release, the run exits with a notice and builds nothing.
- **Manual dispatch on `main`:** cuts a release immediately using the same logic (for out-of-cycle releases). Dispatch on other branches still only pushes a `<branch>` test image.
- **Docs:** the pear README and self-hosting docs page describe the weekly cadence; example versions now reference the real `v2026.9.11-5d3b3ba` release.

## Testing
- `actionlint` passes
- Dry-ran the commit-selection and already-released check locally with `gh` against this repo: it picks `5d3b3ba` and correctly skips it as already released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWhx6fe5j5QSRecGnQNKKc
